### PR TITLE
lxc: Make `lxc init` and `lxd launch` manpages more consistent

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -42,9 +42,13 @@ func (c *cmdInit) Command() *cobra.Command {
 	cmd.Short = i18n.G("Create instances from images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Create instances from images`))
 	cmd.Example = cli.FormatSection("", i18n.G(`lxc init ubuntu:22.04 u1
+    Create a container (but do not start it)
 
 lxc init ubuntu:22.04 u1 < config.yaml
-    Create the instance with configuration from config.yaml`))
+    Create a container with configuration from config.yaml
+
+lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB
+    Create a virtual machine with 4 cpus and 4GiB of RAM`))
 
 	cmd.RunE = c.Run
 	cmd.Flags().StringArrayVarP(&c.flagConfig, "config", "c", nil, i18n.G("Config key/value to apply to the new instance")+"``")

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -23,8 +23,8 @@ func (c *cmdLaunch) Command() *cobra.Command {
 	cmd.Short = i18n.G("Create and start instances from images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create and start instances from images`))
-	cmd.Example = cli.FormatSection("", i18n.G(
-		`lxc launch ubuntu:22.04 u1
+	cmd.Example = cli.FormatSection("", i18n.G(`lxc launch ubuntu:22.04 u1
+    Create and start a container
 
 lxc launch ubuntu:22.04 u1 < config.yaml
     Create and start a container with configuration from config.yaml

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -867,7 +867,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1125,7 +1125,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1191,7 +1191,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1479,7 +1479,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1488,12 +1488,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1827,7 +1827,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2032,7 +2032,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2181,12 +2181,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2201,12 +2201,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2236,7 +2236,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2251,7 +2251,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2261,12 +2261,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2305,7 +2305,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2320,7 +2320,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2642,22 +2642,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2847,11 +2847,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2860,7 +2860,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2883,7 +2883,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2921,7 +2921,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3868,7 +3868,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3910,7 +3910,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4161,7 +4161,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4444,7 +4444,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4609,7 +4609,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4919,7 +4919,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4968,12 +4968,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5049,7 +5049,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5311,7 +5311,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5705,11 +5705,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5759,7 +5759,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5920,11 +5920,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6067,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6083,7 +6083,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6663,7 +6663,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7167,7 +7167,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7213,14 +7213,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7406,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -682,12 +682,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -726,7 +726,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1429,7 +1429,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1691,7 +1691,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1700,7 +1700,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1810,7 +1810,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1820,12 +1820,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2011,7 +2011,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2167,7 +2167,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2407,7 +2407,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Flüchtiger Container"
@@ -2570,12 +2570,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2590,12 +2590,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2625,7 +2625,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2640,7 +2640,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2650,12 +2650,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2694,7 +2694,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2709,7 +2709,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3057,22 +3057,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3268,12 +3268,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3282,7 +3282,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3291,7 +3291,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3305,7 +3305,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3344,7 +3344,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -4392,7 +4392,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -4436,7 +4436,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4641,7 +4641,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4694,7 +4694,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4902,7 +4902,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4985,7 +4985,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5148,7 +5148,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5498,7 +5498,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5550,12 +5550,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -5635,7 +5635,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5917,7 +5917,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6263,7 +6263,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -6343,12 +6343,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6402,7 +6402,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6568,11 +6568,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6717,7 +6717,7 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6733,7 +6733,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7610,7 +7610,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8479,7 +8479,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8525,14 +8525,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -8722,16 +8727,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -873,7 +873,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1132,7 +1132,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1386,7 +1386,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1394,7 +1394,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1498,12 +1498,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1682,7 +1682,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1843,7 +1843,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2057,7 +2057,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2206,12 +2206,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2226,12 +2226,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2261,7 +2261,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2286,12 +2286,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2330,7 +2330,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2680,22 +2680,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2885,11 +2885,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2898,7 +2898,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2921,7 +2921,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2959,7 +2959,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3933,7 +3933,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3975,7 +3975,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4175,7 +4175,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network load balancer %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4228,7 +4228,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4430,7 +4430,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4512,7 +4512,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4668,7 +4668,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4677,7 +4677,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4992,7 +4992,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5042,12 +5042,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5124,7 +5124,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5398,7 +5398,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5727,7 +5727,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5803,11 +5803,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5857,7 +5857,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6018,11 +6018,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6165,7 +6165,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6181,7 +6181,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6778,7 +6778,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7328,14 +7328,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7521,16 +7526,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -670,12 +670,12 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -713,7 +713,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1383,7 +1383,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1449,7 +1449,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiando la imagen: %s"
@@ -1650,7 +1650,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Creando el contenedor"
@@ -1748,7 +1748,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1757,12 +1757,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
@@ -1943,7 +1943,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2093,7 +2093,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2105,7 +2105,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2471,12 +2471,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2491,12 +2491,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2526,7 +2526,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2551,12 +2551,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2595,7 +2595,7 @@ msgstr "Acepta certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2610,7 +2610,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2948,22 +2948,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3157,11 +3157,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3171,7 +3171,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3181,7 +3181,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3233,7 +3233,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -4228,7 +4228,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4473,7 +4473,7 @@ msgstr "Perfil %s creado"
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4524,7 +4524,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4726,7 +4726,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -4968,7 +4968,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4977,7 +4977,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5299,7 +5299,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5351,12 +5351,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5434,7 +5434,7 @@ msgstr "Aliases:"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5708,7 +5708,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6039,7 +6039,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -6115,11 +6115,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6171,7 +6171,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6333,11 +6333,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6482,7 +6482,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6498,7 +6498,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7155,7 +7155,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7745,7 +7745,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7791,14 +7791,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7984,16 +7989,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -679,12 +679,12 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -721,7 +721,7 @@ msgstr "--console ne peut être utilisé avec --all"
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1423,7 +1423,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1497,7 +1497,7 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1694,7 +1694,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copie de l'image : %s"
@@ -1703,7 +1703,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Création du conteneur"
@@ -1829,7 +1829,7 @@ msgstr "Créé : %s"
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1839,12 +1839,12 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
@@ -2035,7 +2035,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2186,7 +2186,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -2199,7 +2199,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2427,7 +2427,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
@@ -2601,12 +2601,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2621,12 +2621,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2656,7 +2656,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2671,7 +2671,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2681,12 +2681,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2726,7 +2726,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2741,7 +2741,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3092,22 +3092,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3311,12 +3311,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3326,7 +3326,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3336,7 +3336,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3350,7 +3350,7 @@ msgstr "Conteneur publié avec l'empreinte : %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3388,7 +3388,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -4476,7 +4476,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4523,7 +4523,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4729,7 +4729,7 @@ msgstr "Le réseau %s a été créé"
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr "Nom du réseau"
 
@@ -4783,7 +4783,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -5002,7 +5002,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5086,7 +5086,7 @@ msgstr "Profil %s ajouté à %s"
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -5248,7 +5248,7 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -5258,7 +5258,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5618,7 +5618,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5670,12 +5670,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -5758,7 +5758,7 @@ msgstr "Création du conteneur"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6042,7 +6042,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6396,7 +6396,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -6478,11 +6478,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6538,7 +6538,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -6704,12 +6704,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -6857,7 +6857,7 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6873,7 +6873,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7805,7 +7805,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8735,7 +8735,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8791,14 +8791,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -8997,16 +9002,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1129,7 +1129,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1391,7 +1391,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2036,7 +2036,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2265,12 +2265,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2309,7 +2309,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2324,7 +2324,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2646,22 +2646,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2851,11 +2851,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2887,7 +2887,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3872,7 +3872,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4114,7 +4114,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4604,7 +4604,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4613,7 +4613,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4972,12 +4972,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5053,7 +5053,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5633,7 +5633,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5709,11 +5709,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5763,7 +5763,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5924,11 +5924,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6071,7 +6071,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6087,7 +6087,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6667,7 +6667,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7171,7 +7171,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7217,14 +7217,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7410,16 +7415,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -675,12 +675,12 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -717,7 +717,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1381,7 +1381,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1447,7 +1447,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1635,7 +1635,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Creazione del container in corso"
@@ -1644,7 +1644,7 @@ msgstr "Creazione del container in corso"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Creazione del container in corso"
@@ -1744,7 +1744,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1753,12 +1753,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
@@ -1938,7 +1938,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2100,7 +2100,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2315,7 +2315,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2467,12 +2467,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2487,12 +2487,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2522,7 +2522,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2547,12 +2547,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2591,7 +2591,7 @@ msgstr "Accetta certificato"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2606,7 +2606,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2942,22 +2942,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3150,11 +3150,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3163,7 +3163,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3173,7 +3173,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3187,7 +3187,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3225,7 +3225,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -4227,7 +4227,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -4270,7 +4270,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4471,7 +4471,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4522,7 +4522,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4726,7 +4726,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4966,7 +4966,7 @@ msgstr "Creazione del container in corso"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4976,7 +4976,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5299,7 +5299,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5351,12 +5351,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5434,7 +5434,7 @@ msgstr "Creazione del container in corso"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6036,7 +6036,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -6114,11 +6114,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6168,7 +6168,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6331,11 +6331,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6480,7 +6480,7 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6496,7 +6496,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7152,7 +7152,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7742,7 +7742,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7788,14 +7788,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7982,16 +7987,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -667,12 +667,12 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -708,7 +708,7 @@ msgstr "--console と --all は同時に指定できません"
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1397,7 +1397,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1467,7 +1467,7 @@ msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `n
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない場合は none)"
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
@@ -1670,7 +1670,7 @@ msgstr "一致するエントリを見つけられませんでした"
 msgid "Create a cluster group"
 msgstr "クラスターグループを作成します"
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr "仮想マシンを作成します"
 
@@ -1678,7 +1678,7 @@ msgstr "仮想マシンを作成します"
 msgid "Create aliases for existing images"
 msgstr "既存のイメージに対するエイリアスを作成します"
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr "空のインスタンスを作成"
 
@@ -1776,7 +1776,7 @@ msgstr "プロジェクトを作成します"
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
@@ -1785,12 +1785,12 @@ msgstr "プロファイルを適用しないインスタンスを作成します
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
@@ -1966,7 +1966,7 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2118,7 +2118,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
@@ -2132,7 +2132,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2354,7 +2354,7 @@ msgstr "TTLを指定します"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
@@ -2518,12 +2518,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2538,12 +2538,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2573,7 +2573,7 @@ msgstr "クライアント %q のチャンネルの受け入れに失敗しま�
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2588,7 +2588,7 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2598,12 +2598,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2642,7 +2642,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2657,7 +2657,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -3006,22 +3006,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3223,11 +3223,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3236,7 +3236,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3246,7 +3246,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3260,7 +3260,7 @@ msgstr "インスタンスは以下のフィンガープリントで publish さ
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
@@ -3299,7 +3299,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -4425,7 +4425,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4472,7 +4472,7 @@ msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4685,7 +4685,7 @@ msgstr "ネットワークロードバランサー %s を作成しました"
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr "ネットワーク名:"
 
@@ -4738,7 +4738,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -4940,7 +4940,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -5024,7 +5024,7 @@ msgstr "プロファイル名 %s を %s に変更しました"
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
@@ -5183,7 +5183,7 @@ msgstr "インスタンスの出力中: %s"
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
@@ -5192,7 +5192,7 @@ msgstr "ファイル %s を %s から取得します: %%s"
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5516,7 +5516,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -5566,12 +5566,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -5649,7 +5649,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5977,7 +5977,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -6298,7 +6298,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -6374,11 +6374,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6431,7 +6431,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -6606,13 +6606,13 @@ msgstr "インスタンスがクリーンにシャットダウンするまで待
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -6763,7 +6763,7 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
@@ -6779,7 +6779,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -7390,7 +7390,7 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -7959,7 +7959,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8024,21 +8024,30 @@ msgstr ""
 "    LXD サーバの情報を表示します。"
 
 #: lxc/init.go:44
+#, fuzzy
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
-"lxc init ubuntu:22.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    config.yaml の設定を使ってインスタンスを作成します"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
+"    config.yaml の設定を使ってインスタンスを作成し、起動します\n"
+"\n"
+"lxc launch ubuntu:20.04 v1 --vm\n"
+"    仮想マシンを作成し、起動します"
 
 #: lxc/launch.go:26
 #, fuzzy
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -8305,16 +8314,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
@@ -8340,6 +8349,17 @@ msgstr "y"
 #: lxc/image.go:1127
 msgid "yes"
 msgstr "yes"
+
+#~ msgid ""
+#~ "lxc init ubuntu:22.04 u1\n"
+#~ "\n"
+#~ "lxc init ubuntu:22.04 u1 < config.yaml\n"
+#~ "    Create the instance with configuration from config.yaml"
+#~ msgstr ""
+#~ "lxc init ubuntu:22.04 u1\n"
+#~ "\n"
+#~ "lxc init ubuntu:22.04 u1 < config.yaml\n"
+#~ "    config.yaml の設定を使ってインスタンスを作成します"
 
 #, c-format
 #~ msgid ""
@@ -8455,23 +8475,6 @@ msgstr "yes"
 #~ "\n"
 #~ "lxc init ubuntu:20.04 u1 < config.yaml\n"
 #~ "    config.yaml の設定を使ってインスタンスを作成します"
-
-#~ msgid ""
-#~ "lxc launch ubuntu:20.04 u1\n"
-#~ "\n"
-#~ "lxc launch ubuntu:20.04 u1 < config.yaml\n"
-#~ "    Create and start a container with configuration from config.yaml\n"
-#~ "\n"
-#~ "lxc launch ubuntu:20.04 v1 --vm\n"
-#~ "    Create and start a virtual machine"
-#~ msgstr ""
-#~ "lxc launch ubuntu:20.04 u1\n"
-#~ "\n"
-#~ "lxc launch ubuntu:20.04 u1 < config.yaml\n"
-#~ "    config.yaml の設定を使ってインスタンスを作成し、起動します\n"
-#~ "\n"
-#~ "lxc launch ubuntu:20.04 v1 --vm\n"
-#~ "    仮想マシンを作成し、起動します"
 
 #~ msgid "Invalid key=value configuration: %w"
 #~ msgstr "不適切な キー=値 のペア: %w"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -867,7 +867,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1125,7 +1125,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1191,7 +1191,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1479,7 +1479,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1488,12 +1488,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1827,7 +1827,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2032,7 +2032,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2181,12 +2181,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2201,12 +2201,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2236,7 +2236,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2251,7 +2251,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2261,12 +2261,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2305,7 +2305,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2320,7 +2320,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2642,22 +2642,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2847,11 +2847,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2860,7 +2860,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2883,7 +2883,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2921,7 +2921,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3868,7 +3868,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3910,7 +3910,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4161,7 +4161,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4444,7 +4444,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4609,7 +4609,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4919,7 +4919,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4968,12 +4968,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5049,7 +5049,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5311,7 +5311,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5705,11 +5705,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5759,7 +5759,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5920,11 +5920,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6067,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6083,7 +6083,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6663,7 +6663,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7167,7 +7167,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7213,14 +7213,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7406,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-03-27 11:10-0300\n"
+        "POT-Creation-Date: 2024-04-02 18:01-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -401,12 +401,12 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -442,7 +442,7 @@ msgstr  ""
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -728,7 +728,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -826,7 +826,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -1081,7 +1081,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738 lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:406 lxc/network_forward.go:529 lxc/network_forward.go:671 lxc/network_forward.go:748 lxc/network_forward.go:814 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:530 lxc/network_load_balancer.go:673 lxc/network_load_balancer.go:749 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:914 lxc/network_load_balancer.go:976 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:335 lxc/storage_volume.go:537 lxc/storage_volume.go:616 lxc/storage_volume.go:860 lxc/storage_volume.go:1074 lxc/storage_volume.go:1187 lxc/storage_volume.go:1655 lxc/storage_volume.go:1735 lxc/storage_volume.go:1862 lxc/storage_volume.go:2008 lxc/storage_volume.go:2112 lxc/storage_volume.go:2152 lxc/storage_volume.go:2245 lxc/storage_volume.go:2317 lxc/storage_volume.go:2469
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738 lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:406 lxc/network_forward.go:529 lxc/network_forward.go:671 lxc/network_forward.go:748 lxc/network_forward.go:814 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:530 lxc/network_load_balancer.go:673 lxc/network_load_balancer.go:749 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:914 lxc/network_load_balancer.go:976 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:335 lxc/storage_volume.go:537 lxc/storage_volume.go:616 lxc/storage_volume.go:860 lxc/storage_volume.go:1074 lxc/storage_volume.go:1187 lxc/storage_volume.go:1655 lxc/storage_volume.go:1735 lxc/storage_volume.go:1862 lxc/storage_volume.go:2008 lxc/storage_volume.go:2112 lxc/storage_volume.go:2152 lxc/storage_volume.go:2245 lxc/storage_volume.go:2317 lxc/storage_volume.go:2469
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1120,7 +1120,7 @@ msgstr  ""
 msgid   "Compression algorithm to use (none for uncompressed)"
 msgstr  ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
@@ -1293,7 +1293,7 @@ msgstr  ""
 msgid   "Create a cluster group"
 msgstr  ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid   "Create a virtual machine"
 msgstr  ""
 
@@ -1301,7 +1301,7 @@ msgstr  ""
 msgid   "Create aliases for existing images"
 msgstr  ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid   "Create an empty instance"
 msgstr  ""
 
@@ -1392,7 +1392,7 @@ msgstr  ""
 msgid   "Create storage pools"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
@@ -1401,12 +1401,12 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid   "Creating the instance"
 msgstr  ""
 
@@ -1539,7 +1539,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350 lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821 lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1651 lxc/storage_volume.go:1732 lxc/storage_volume.go:1847 lxc/storage_volume.go:1991 lxc/storage_volume.go:2100 lxc/storage_volume.go:2146 lxc/storage_volume.go:2243 lxc/storage_volume.go:2310 lxc/storage_volume.go:2464 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350 lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821 lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1651 lxc/storage_volume.go:1732 lxc/storage_volume.go:1847 lxc/storage_volume.go:1991 lxc/storage_volume.go:2100 lxc/storage_volume.go:2146 lxc/storage_volume.go:2243 lxc/storage_volume.go:2310 lxc/storage_volume.go:2464 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1609,7 +1609,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
@@ -1621,7 +1621,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1819,7 +1819,7 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid   "Ephemeral instance"
 msgstr  ""
 
@@ -1953,12 +1953,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -1973,12 +1973,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2008,7 +2008,7 @@ msgstr  ""
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2023,7 +2023,7 @@ msgstr  ""
 msgid   "Failed loading profile %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2033,12 +2033,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2077,7 +2077,7 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2092,7 +2092,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2398,22 +2398,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2600,11 +2600,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2613,7 +2613,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -2622,7 +2622,7 @@ msgstr  ""
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2636,7 +2636,7 @@ msgstr  ""
 msgid   "Instance snapshots cannot be rebuilt: %s"
 msgstr  ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid   "Instance type"
 msgstr  ""
 
@@ -2674,7 +2674,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -3537,7 +3537,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3577,7 +3577,7 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3763,7 +3763,7 @@ msgstr  ""
 msgid   "Network load balancer %s deleted"
 msgstr  ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid   "Network name"
 msgstr  ""
 
@@ -3813,7 +3813,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -4014,7 +4014,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
@@ -4087,7 +4087,7 @@ msgstr  ""
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
@@ -4227,7 +4227,7 @@ msgstr  ""
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
@@ -4236,7 +4236,7 @@ msgstr  ""
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4542,7 +4542,7 @@ msgstr  ""
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -4591,12 +4591,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -4671,7 +4671,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4905,7 +4905,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -5217,7 +5217,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -5290,11 +5290,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -5342,7 +5342,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -5497,11 +5497,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -5637,7 +5637,7 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
@@ -5652,7 +5652,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -6208,7 +6208,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6667,7 +6667,7 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
@@ -6705,13 +6705,18 @@ msgstr  ""
 
 #: lxc/init.go:44
 msgid   "lxc init ubuntu:22.04 u1\n"
+        "    Create a container (but do not start it)\n"
         "\n"
         "lxc init ubuntu:22.04 u1 < config.yaml\n"
-        "    Create the instance with configuration from config.yaml"
+        "    Create a container with configuration from config.yaml\n"
+        "\n"
+        "lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+        "    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr  ""
 
 #: lxc/launch.go:26
 msgid   "lxc launch ubuntu:22.04 u1\n"
+        "    Create and start a container\n"
         "\n"
         "lxc launch ubuntu:22.04 u1 < config.yaml\n"
         "    Create and start a container with configuration from config.yaml\n"
@@ -6869,16 +6874,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -657,12 +657,12 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -698,7 +698,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -993,7 +993,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1094,7 +1094,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1418,7 +1418,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1606,7 +1606,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1614,7 +1614,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1706,7 +1706,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1715,12 +1715,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1894,7 +1894,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2042,7 +2042,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2259,7 +2259,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2408,12 +2408,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2428,12 +2428,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2478,7 +2478,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2488,12 +2488,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2532,7 +2532,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2547,7 +2547,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2869,22 +2869,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3074,11 +3074,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3087,7 +3087,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3110,7 +3110,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3148,7 +3148,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -4095,7 +4095,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -4137,7 +4137,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4337,7 +4337,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4388,7 +4388,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4671,7 +4671,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4836,7 +4836,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5146,7 +5146,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5195,12 +5195,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5276,7 +5276,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5538,7 +5538,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5856,7 +5856,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5932,11 +5932,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5986,7 +5986,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6147,11 +6147,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6294,7 +6294,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6310,7 +6310,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6890,7 +6890,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7394,7 +7394,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7440,14 +7440,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7633,16 +7638,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -695,12 +695,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -736,7 +736,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1132,7 +1132,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1390,7 +1390,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1644,7 +1644,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1744,7 +1744,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1753,12 +1753,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1932,7 +1932,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2080,7 +2080,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2297,7 +2297,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2446,12 +2446,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2466,12 +2466,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2501,7 +2501,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2516,7 +2516,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2526,12 +2526,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2585,7 +2585,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2907,22 +2907,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3112,11 +3112,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3125,7 +3125,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3134,7 +3134,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3148,7 +3148,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3186,7 +3186,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -4133,7 +4133,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -4175,7 +4175,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4627,7 +4627,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4709,7 +4709,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5184,7 +5184,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5233,12 +5233,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5576,7 +5576,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5970,11 +5970,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6024,7 +6024,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6185,11 +6185,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6332,7 +6332,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6348,7 +6348,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6928,7 +6928,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7432,7 +7432,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7478,14 +7478,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7671,16 +7676,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -867,7 +867,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1125,7 +1125,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1191,7 +1191,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1479,7 +1479,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1488,12 +1488,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1827,7 +1827,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2032,7 +2032,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2181,12 +2181,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2201,12 +2201,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2236,7 +2236,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2251,7 +2251,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2261,12 +2261,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2305,7 +2305,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2320,7 +2320,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2642,22 +2642,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2847,11 +2847,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2860,7 +2860,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2883,7 +2883,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2921,7 +2921,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3868,7 +3868,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3910,7 +3910,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4161,7 +4161,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4444,7 +4444,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4609,7 +4609,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4919,7 +4919,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4968,12 +4968,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5049,7 +5049,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5311,7 +5311,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5705,11 +5705,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5759,7 +5759,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5920,11 +5920,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6067,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6083,7 +6083,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6663,7 +6663,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7167,7 +7167,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7213,14 +7213,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7406,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -681,12 +681,12 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -725,7 +725,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1146,7 +1146,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1407,7 +1407,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1480,7 +1480,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiar a imagem: %s"
@@ -1681,7 +1681,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1788,7 +1788,7 @@ msgstr "Criar projetos"
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1797,12 +1797,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
@@ -1990,7 +1990,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2142,7 +2142,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2530,12 +2530,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2550,12 +2550,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2585,7 +2585,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2600,7 +2600,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2610,12 +2610,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2654,7 +2654,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2669,7 +2669,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3012,22 +3012,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3219,11 +3219,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3232,7 +3232,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3241,7 +3241,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3293,7 +3293,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -4293,7 +4293,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -4336,7 +4336,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4537,7 +4537,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4588,7 +4588,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4790,7 +4790,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4873,7 +4873,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -5033,7 +5033,7 @@ msgstr "Editar arquivos no container"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -5043,7 +5043,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5377,7 +5377,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5429,12 +5429,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5512,7 +5512,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5792,7 +5792,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -6208,12 +6208,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6266,7 +6266,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6428,11 +6428,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6577,7 +6577,7 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6593,7 +6593,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7228,7 +7228,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7776,7 +7776,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7822,14 +7822,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -8015,16 +8020,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -690,12 +690,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -731,7 +731,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1404,7 +1404,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Копирование образа: %s"
@@ -1669,7 +1669,7 @@ msgstr "Копирование образа: %s"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1786,12 +1786,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1976,7 +1976,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2356,7 +2356,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2514,12 +2514,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2534,12 +2534,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2569,7 +2569,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2584,7 +2584,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2594,12 +2594,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2638,7 +2638,7 @@ msgstr "Принять сертификат"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2653,7 +2653,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2993,22 +2993,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3203,11 +3203,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3217,7 +3217,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3227,7 +3227,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3241,7 +3241,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3279,7 +3279,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -4293,7 +4293,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -4336,7 +4336,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4538,7 +4538,7 @@ msgstr " Использование сети:"
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4591,7 +4591,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4795,7 +4795,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4877,7 +4877,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -5033,7 +5033,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -5042,7 +5042,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5424,12 +5424,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5507,7 +5507,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5783,7 +5783,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6122,7 +6122,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -6199,11 +6199,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6414,11 +6414,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6562,7 +6562,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6578,7 +6578,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7416,7 +7416,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8264,7 +8264,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8310,14 +8310,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -8503,16 +8508,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1129,7 +1129,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1391,7 +1391,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2036,7 +2036,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2265,12 +2265,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2309,7 +2309,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2324,7 +2324,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2646,22 +2646,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2851,11 +2851,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2887,7 +2887,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3872,7 +3872,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4114,7 +4114,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4604,7 +4604,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4613,7 +4613,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4972,12 +4972,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5053,7 +5053,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5633,7 +5633,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5709,11 +5709,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5763,7 +5763,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5924,11 +5924,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6071,7 +6071,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6087,7 +6087,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6667,7 +6667,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7171,7 +7171,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7217,14 +7217,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7410,16 +7415,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1129,7 +1129,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1391,7 +1391,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2036,7 +2036,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2265,12 +2265,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2309,7 +2309,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2324,7 +2324,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2646,22 +2646,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2851,11 +2851,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2887,7 +2887,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3872,7 +3872,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4114,7 +4114,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4604,7 +4604,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4613,7 +4613,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4972,12 +4972,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5053,7 +5053,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5633,7 +5633,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5709,11 +5709,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5763,7 +5763,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5924,11 +5924,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6071,7 +6071,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6087,7 +6087,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6667,7 +6667,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7171,7 +7171,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7217,14 +7217,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7410,16 +7415,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -867,7 +867,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1125,7 +1125,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1191,7 +1191,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1479,7 +1479,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1488,12 +1488,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1827,7 +1827,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2032,7 +2032,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2181,12 +2181,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2201,12 +2201,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2236,7 +2236,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2251,7 +2251,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2261,12 +2261,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2305,7 +2305,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2320,7 +2320,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2642,22 +2642,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2847,11 +2847,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2860,7 +2860,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2883,7 +2883,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2921,7 +2921,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3868,7 +3868,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3910,7 +3910,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4161,7 +4161,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4444,7 +4444,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4609,7 +4609,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4919,7 +4919,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4968,12 +4968,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5049,7 +5049,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5311,7 +5311,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5705,11 +5705,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5759,7 +5759,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5920,11 +5920,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6067,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6083,7 +6083,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6663,7 +6663,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7167,7 +7167,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7213,14 +7213,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7406,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1129,7 +1129,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1383,7 +1383,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1391,7 +1391,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1483,7 +1483,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2036,7 +2036,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2265,12 +2265,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2309,7 +2309,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2324,7 +2324,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2646,22 +2646,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2851,11 +2851,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2887,7 +2887,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3872,7 +3872,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4114,7 +4114,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4604,7 +4604,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4613,7 +4613,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4972,12 +4972,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5053,7 +5053,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5633,7 +5633,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5709,11 +5709,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5763,7 +5763,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5924,11 +5924,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6071,7 +6071,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6087,7 +6087,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6667,7 +6667,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7171,7 +7171,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7217,14 +7217,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7410,16 +7415,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -594,12 +594,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -635,7 +635,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -930,7 +930,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1289,7 +1289,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1543,7 +1543,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1652,12 +1652,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1831,7 +1831,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1979,7 +1979,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1991,7 +1991,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2345,12 +2345,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2365,12 +2365,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2425,12 +2425,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2806,22 +2806,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3011,11 +3011,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3024,7 +3024,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3033,7 +3033,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -4032,7 +4032,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4274,7 +4274,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4325,7 +4325,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4526,7 +4526,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4608,7 +4608,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4764,7 +4764,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5083,7 +5083,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5132,12 +5132,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5213,7 +5213,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5475,7 +5475,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5793,7 +5793,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5869,11 +5869,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5923,7 +5923,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6084,11 +6084,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6827,7 +6827,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7331,7 +7331,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7377,14 +7377,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7570,16 +7575,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-27 11:10-0300\n"
+"POT-Creation-Date: 2024-04-02 18:01-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:917
+#: lxc/file.go:924
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:814
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:126 lxc/rebuild.go:64
+#: lxc/init.go:130 lxc/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:317 lxc/rebuild.go:131
+#: lxc/init.go:321 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:217 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:221 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:57
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:61
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:50
+#: lxc/copy.go:53 lxc/init.go:54
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Create a cluster group"
 msgstr ""
 
-#: lxc/init.go:60
+#: lxc/init.go:64
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:59
+#: lxc/init.go:63
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/init.go:58
+#: lxc/copy.go:63 lxc/init.go:62
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1491,12 +1491,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:163
+#: lxc/init.go:167
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:161
+#: lxc/init.go:165
 msgid "Creating the instance"
 msgstr ""
 
@@ -1670,7 +1670,7 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
 #: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
 #: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:377
+#: lxc/init.go:381
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:983
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:53
+#: lxc/copy.go:56 lxc/init.go:57
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2184,12 +2184,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1249
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1276
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1061
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1175
+#: lxc/file.go:1182
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1180
+#: lxc/file.go:1187
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1080
+#: lxc/file.go:1087
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1207
+#: lxc/file.go:1214
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1192
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:802
+#: lxc/file.go:809
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2645,22 +2645,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1292
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1281
+#: lxc/file.go:1288
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1104
+#: lxc/file.go:1111
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1114
+#: lxc/file.go:1121
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1106
+#: lxc/file.go:1113
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1283
+#: lxc/file.go:1290
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:388
+#: lxc/init.go:392
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1033
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: lxc/init.go:56
+#: lxc/init.go:60
 msgid "Instance type"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1028
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:590
 msgid "Missing target directory"
 msgstr ""
 
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:967 lxc/file.go:968
+#: lxc/file.go:974 lxc/file.go:975
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: lxc/init.go:54
+#: lxc/init.go:58
 msgid "Network name"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:52 lxc/move.go:59
+#: lxc/copy.go:54 lxc/import.go:37 lxc/init.go:56 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1084
+#: lxc/file.go:1091
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4447,7 +4447,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/init.go:51
+#: lxc/copy.go:55 lxc/init.go:55
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:749
+#: lxc/file.go:408 lxc/file.go:756
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:683 lxc/file.go:849
+#: lxc/file.go:690 lxc/file.go:856
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:335
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1219
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1213
+#: lxc/file.go:1220
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:984
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:982
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:55 lxc/move.go:65
+#: lxc/copy.go:60 lxc/import.go:36 lxc/init.go:59 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5708,11 +5708,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1014
+#: lxc/file.go:1021
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1008
+#: lxc/file.go:1015
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5762,7 +5762,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:409
+#: lxc/init.go:413
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5923,11 +5923,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:411
+#: lxc/init.go:415
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:410
+#: lxc/init.go:414
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1242
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6086,7 +6086,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:789
+#: lxc/file.go:796
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6666,7 +6666,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:966
+#: lxc/file.go:973
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:970
+#: lxc/file.go:977
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7216,14 +7216,19 @@ msgstr ""
 #: lxc/init.go:44
 msgid ""
 "lxc init ubuntu:22.04 u1\n"
+"    Create a container (but do not start it)\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
-"    Create the instance with configuration from config.yaml"
+"    Create a container with configuration from config.yaml\n"
+"\n"
+"lxc init ubuntu:22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"    Create a virtual machine with 4 cpus and 4GiB of RAM"
 msgstr ""
 
 #: lxc/launch.go:26
 msgid ""
 "lxc launch ubuntu:22.04 u1\n"
+"    Create and start a container\n"
 "\n"
 "lxc launch ubuntu:22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
@@ -7409,16 +7414,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1131
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1090
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1036
+#: lxc/file.go:1043
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 


### PR DESCRIPTION
I prefer the specificity of container/vm here rather than the generic "instance", as the commands are specific to one or the other.

Resolves #13243