### PR TITLE
Network: Block external req to `bridge` managed dns service

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -46,15 +46,23 @@ chain in{{.chainSeparator}}{{.networkName}} {
 
 	iifname "{{.networkName}}" tcp dport 53 accept
 	iifname "{{.networkName}}" udp dport 53 accept
+	iifname "lo" tcp dport 53 accept
+	iifname "lo" udp dport 53 accept
 
-	{{- range .ipFamilies}}
-	{{if eq . "ip" -}}
+	{{if ne .ip4Address "<nil>" -}}
+	ip daddr == "{{.ip4Address}}" tcp dport 53 drop
+	ip daddr == "{{.ip4Address}}" udp dport 53 drop
+
 	iifname "{{$.networkName}}" icmp type {3, 11, 12} accept
 	iifname "{{$.networkName}}" udp dport 67 accept
-	{{else -}}
+	{{- end}}
+
+	{{if ne .ip6Address "<nil>" -}}
+	ip6 daddr == "{{.ip6Address}}" tcp dport 53 drop
+	ip6 daddr == "{{.ip6Address}}" udp dport 53 drop
+
 	iifname "{{$.networkName}}" icmpv6 type {1, 2, 3, 4, 133, 135, 136, 143} accept
 	iifname "{{$.networkName}}" udp dport 547 accept
-	{{- end}}
 	{{- end}}
 }
 

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -719,20 +719,20 @@ func (d Xtables) aclRuleSubjectToACLMatch(direction string, ipVersion uint, subj
 			ip, _, _ = net.ParseCIDR(subjectCriterion)
 		}
 
-		if ip != nil {
-			var subjectIPVersion uint = 4
-			if ip.To4() == nil {
-				subjectIPVersion = 6
-			}
-
-			if ipVersion != subjectIPVersion {
-				continue // Skip subjects that not for the xtables tool we are using.
-			}
-
-			fieldParts = append(fieldParts, subjectCriterion)
-		} else {
+		if ip == nil {
 			return nil, fmt.Errorf("Unsupported xtables subject %q", subjectCriterion)
 		}
+
+		var subjectIPVersion uint = 4
+		if ip.To4() == nil {
+			subjectIPVersion = 6
+		}
+
+		if ipVersion != subjectIPVersion {
+			continue // Skip subjects that not for the xtables tool we are using.
+		}
+
+		fieldParts = append(fieldParts, subjectCriterion)
 	}
 
 	if len(fieldParts) > 0 {
@@ -1107,7 +1107,7 @@ func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv
 func (d Xtables) generateFilterIptablesRules(parentName string, hostName string, hwAddr string, IPv6Nets []*net.IPNet, parentManaged bool) (rules [][]string, err error) {
 	mac, err := net.ParseMAC(hwAddr)
 	if err != nil {
-		return
+		return [][]string{}, err
 	}
 
 	macHex := hex.EncodeToString(mac)
@@ -1162,7 +1162,7 @@ func (d Xtables) generateFilterIptablesRules(parentName string, hostName string,
 		}
 	}
 
-	return
+	return [][]string{}, err
 }
 
 // matchEbtablesRule compares an active rule to a supplied match rule to see if they match.
@@ -1431,7 +1431,7 @@ func (d Xtables) InstanceClearNetPrio(projectName string, instanceName string, d
 }
 
 // iptablesChainExists checks whether a chain exists in a table, and whether it has any rules.
-func (d Xtables) iptablesChainExists(ipVersion uint, table string, chain string) (bool, bool, error) {
+func (d Xtables) iptablesChainExists(ipVersion uint, table string, chain string) (exists, hasRules bool, err error) {
 	var cmd string
 	if ipVersion == 4 {
 		cmd = "iptables"
@@ -1441,7 +1441,7 @@ func (d Xtables) iptablesChainExists(ipVersion uint, table string, chain string)
 		return false, false, fmt.Errorf("Invalid IP version")
 	}
 
-	_, err := exec.LookPath(cmd)
+	_, err = exec.LookPath(cmd)
 	if err != nil {
 		return false, false, fmt.Errorf("Failed checking %q chain %q exists in table %q: %w", cmd, chain, table, err)
 	}

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -11,7 +11,7 @@ type Firewall interface {
 	String() string
 	Compat() (bool, error)
 
-	NetworkSetup(networkName string, opts drivers.Opts) error
+	NetworkSetup(networkName string, ip4Address net.IP, ip6Address net.IP, opts drivers.Opts) error
 	NetworkClear(networkName string, delete bool, ipVersions []uint) error
 	NetworkApplyACLRules(networkName string, rules []drivers.ACLRule) error
 	NetworkApplyForwards(networkName string, rules []drivers.AddressForward) error

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -3,7 +3,7 @@ package firewall
 import (
 	"net"
 
-	drivers "github.com/canonical/lxd/lxd/firewall/drivers"
+	"github.com/canonical/lxd/lxd/firewall/drivers"
 )
 
 // Firewall represents a LXD firewall.


### PR DESCRIPTION
Blocks DNS requests originating outside the managed bridge per #13081.

Still working on tests and evaluating if/how this is relevant to fan bridges.