### PR TITLE
Enable renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays"
+  ]
+}


### PR DESCRIPTION
The renovate bot was first tested on the `lxd-pkg-snap.git` repo and we liked it.