### PR TITLE
Determine delta source file based on delta file type

### DIFF
--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -248,12 +248,19 @@ func (s *Products) ToLXD() ([]api.Image, map[string][][]string) {
 							continue
 						}
 
-						srcFingerprint = item.LXDHashSha256SquashFs
+						// Take correct source image fingerprint based on
+						// delta file type.
+						if delta.FileType == "disk-kvm.img.vcdiff" {
+							srcFingerprint = item.LXDHashSha256DiskKvmImg
+						} else if delta.FileType == "squashfs.vcdiff" {
+							srcFingerprint = item.LXDHashSha256SquashFs
+						}
+
 						break
 					}
 
 					if srcFingerprint == "" {
-						// Couldn't find the image
+						// Couldn't find the source image
 						continue
 					}
 


### PR DESCRIPTION
When delta file is detected in product catalog, its source image fingerprint is always set to the container's rootfs. Instead, we should determine source image fingerprint based on the delta file type.

This issue only happened when a VM image is being pulled while older container image existed because in such case the source image hash for VM delta file would be set to container image.

---

Reproducer prior this fix:

```sh
# Get 1 day old container image using its fingerprint (Alpine 3.18 cloud):
$ lxc image copy images:349cf03fadf87a872caf596b781469719e45d60bec6ec08a83906236f1bfd622 local:
Image copied successfully!  

# Get latest VM image:
$ lxc image copy images:alpine/3.18/cloud local: --vm 
Error: Failed remote image download: Failed to run: xdelta3 -f -d -s /var/snap/lxd/common/lxd/images/349cf03fadf87a872caf596b781469719e45d60bec6ec08a83906236f1bfd622.rootfs /tmp/lxc_image_1829347942 /tmp/lxc_image_4001681385: exit status 1 (xdelta3: source file too short: XD3_INVALID_INPUT
xdelta3: normally this indicates that the source file is incorrect
xdelta3: please verify the source file with sha1sum or equivalent)  

# Get latest container image:
$ lxc image copy images:alpine/3.18/cloud local:
Image copied successfully!
```

With this fix in place (note: cached images must be removed):

```sh
# Get 1 day old container image using its fingerprint (Alpine 3.18 cloud):
$ lxc image copy images:349cf03fadf87a872caf596b781469719e45d60bec6ec08a83906236f1bfd622 local:
Image copied successfully!  

# Get latest VM image 
$ lxc image copy images:alpine/3.18/cloud local: --vm
Image copied successfully!  
```

To verify an older VM image delta is used (note: again cached images must be removed):

```sh
# Get 1 day old container image using its fingerprint (Alpine 3.18 cloud):
lxc image copy images:349cf03fadf87a872caf596b781469719e45d60bec6ec08a83906236f1bfd622 local:
Image copied successfully!  

# Get 1 day old VM image using its fingerprint (Alpine 3.18 cloud): 
$ lxc image copy images:7df3fcb1615d99724d950d2de218f6b533580e99c6b71a2d7363e0f627d92106 local:
Image copied successfully!

# Get latest VM image 
$ lxc image copy images:alpine/3.18/cloud local: --vm
Image copied successfully!  
```

---

Closes #13264