### PR TITLE
lxd/instances: Don't start instances when evacuated (from Incus)

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1700,9 +1700,7 @@ func (d *Daemon) init() error {
 	d.tasks.Start(d.shutdownCtx)
 
 	// Restore instances
-	if !d.db.Cluster.LocalNodeIsEvacuated() {
-		instancesStart(d.State(), instances)
-	}
+	instancesStart(d.State(), instances)
 
 	// Re-balance in case things changed while LXD was down
 	deviceTaskBalance(d.State())

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -262,11 +262,19 @@ func instanceShouldAutoStart(inst instance.Instance) bool {
 }
 
 func instancesStart(s *state.State, instances []instance.Instance) {
+	// Check if the cluster is currently evacuated.
+	if s.DB.Cluster.LocalNodeIsEvacuated() {
+		return
+	}
+
+	// Acquire startup lock.
 	instancesStartMu.Lock()
 	defer instancesStartMu.Unlock()
 
+	// Sort based on instance boot priority.
 	sort.Sort(instanceAutostartList(instances))
 
+	// Let's make up to 3 attempts to start instances.
 	maxAttempts := 3
 
 	// Start the instances


### PR DESCRIPTION
I (Stephane) noticed a few cases where an offline network or storage coming back online on an evacuated host would cause instances coming back online.

As all code paths to instancesStart come from locations attempting auto-start on daemon startup, lets just move the evacuation check to the function itself.

(cherry picked from commit 6b3a2bf770de3db734d172cc4e827a4f1c009f34)

License: Apache-2.0