### PR TITLE
lxd: `GET /1.0/warnings` should use the `can_view_warnings` entitlement.

### DIFF
--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -33,13 +33,13 @@ import (
 var warningsCmd = APIEndpoint{
 	Path: "warnings",
 
-	Get: APIEndpointAction{Handler: warningsGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
+	Get: APIEndpointAction{Handler: warningsGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanViewWarnings)},
 }
 
 var warningCmd = APIEndpoint{
 	Path: "warnings/{id}",
 
-	Get:    APIEndpointAction{Handler: warningGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
+	Get:    APIEndpointAction{Handler: warningGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanViewWarnings)},
 	Patch:  APIEndpointAction{Handler: warningPatch, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 	Put:    APIEndpointAction{Handler: warningPut, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 	Delete: APIEndpointAction{Handler: warningDelete, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},


### PR DESCRIPTION
The OpenFGA model states that the "can_view_warnings" entitlement grants permission to view warnings. However, this is currently incorrect as the handlers are checking for `can_edit` on `server`.

I've added a regression test for this. Also, while working on it I have simplified the `POST /internal/testing/warnings` endpoint because while debugging it was very unclear why the request body was being unmarshaled into a `shared.JMap`.

I found this while working on #13262 