### PR TITLE
Release LXD 5.21.1

### DIFF
--- a/shared/version/flex.go
+++ b/shared/version/flex.go
@@ -1,7 +1,7 @@
 package version
 
 // Version contains the LXD version number.
-var Version = "5.21.0"
+var Version = "5.21.1"
 
 // IsLTSVersion indicates this is an LTS version of LXD.
 var IsLTSVersion = true


### PR DESCRIPTION
I noticed this commit wasn't in the main branch - which means edge builds were still showing LXD 5.21.0 as the version.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit 0e7f2b5bf4d2bc4eb3abc54b2b5e12c3be663820)