### PR TITLE
Auth: Add project query parameter to URLs in authorizer

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -219,6 +219,13 @@ func projectUsedBy(ctx context.Context, tx *db.ClusterTx, project *cluster.Proje
 	var usedBy []string
 	for _, entityIDToURL := range entityURLs {
 		for _, u := range entityIDToURL {
+			// Omit the project query parameter if it is the default project.
+			if u.Query().Get("project") == api.ProjectDefaultName {
+				q := u.Query()
+				q.Del("project")
+				u.RawQuery = q.Encode()
+			}
+
 			usedBy = append(usedBy, u.String())
 		}
 	}

--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -65,13 +65,9 @@ func (t *tls) CheckPermission(ctx context.Context, entityURL *api.URL, entitleme
 		return nil
 	}
 
-	entityType, projectName, _, pathArgs, err := entity.ParseURL(entityURL.URL)
+	entityType, projectName, _, _, err := entity.ParseURL(entityURL.URL)
 	if err != nil {
 		return fmt.Errorf("Failed to parse entity URL: %w", err)
-	}
-
-	if entityType == entity.TypeProject {
-		projectName = pathArgs[0]
 	}
 
 	// Check server level object types
@@ -156,7 +152,7 @@ func (t *tls) GetPermissionChecker(ctx context.Context, entitlement auth.Entitle
 
 	// Filter objects by project.
 	return func(entityURL *api.URL) bool {
-		eType, project, _, pathArgs, err := entity.ParseURL(entityURL.URL)
+		eType, project, _, _, err := entity.ParseURL(entityURL.URL)
 		if err != nil {
 			logger.Warn("Permission checker failed to parse entity URL", logger.Ctx{"entity_url": entityURL, "err": err})
 			return false
@@ -166,11 +162,6 @@ func (t *tls) GetPermissionChecker(ctx context.Context, entitlement auth.Entitle
 		if eType != entityType {
 			logger.Warn("Permission checker received URL with unexpected entity type", logger.Ctx{"expected": entityType, "actual": eType, "entity_url": entityURL})
 			return false
-		}
-
-		// If it's a project URL, the project name is in the path, not the query parameter.
-		if eType == entity.TypeProject {
-			project = pathArgs[0]
 		}
 
 		// If an effective project has been set in the request context. We expect all entities to be in that project.

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -233,7 +233,7 @@ var profileEntityByID = fmt.Sprintf(`%s WHERE profiles.id = ?`, profileEntities)
 var profileEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, profileEntities)
 
 // projectEntities returns all entities of type entity.TypeProject.
-var projectEntities = fmt.Sprintf(`SELECT %d, projects.id, '', '', json_array(projects.name) FROM projects`, entityTypeProject)
+var projectEntities = fmt.Sprintf(`SELECT %d, projects.id, projects.name, '', json_array(projects.name) FROM projects`, entityTypeProject)
 
 // projectEntities gets the entity of type entity.TypeProject with a particular ID.
 var projectEntityByID = fmt.Sprintf(`%s WHERE id = ?`, projectEntities)
@@ -779,7 +779,7 @@ WHERE projects.name = ?
 var projectIDFromURL = `
 SELECT ?, projects.id 
 FROM projects 
-WHERE '' = ? 
+WHERE projects.name = ? 
 	AND '' = ? 
 	AND projects.name = ?`
 

--- a/lxd/db/openfga/openfga.go
+++ b/lxd/db/openfga/openfga.go
@@ -407,7 +407,7 @@ func (o *openfgaStore) ReadStartingWithUser(ctx context.Context, store string, f
 		return nil, fmt.Errorf("ReadStartingWithUser: Failed to parse user entity URL %q: %w", userURL, err)
 	}
 
-	_, _, _, userURLPathArguments, err := entity.ParseURL(*u)
+	_, projectName, _, userURLPathArguments, err := entity.ParseURL(*u)
 	if err != nil {
 		return nil, fmt.Errorf("ReadStartingWithUser: Unexpected user entity URL %q: %w", userURL, err)
 	}
@@ -419,13 +419,6 @@ func (o *openfgaStore) ReadStartingWithUser(ctx context.Context, store string, f
 			return nil, fmt.Errorf("ReadStartingWithUser: Cannot list project relations for non-project entities")
 		} else if filter.Relation == "server" && userEntityType != entity.TypeServer {
 			return nil, fmt.Errorf("ReadStartingWithUser: Cannot list server relations for non-server entities")
-		}
-
-		// If the filter is by project, we want to filter entity URLs by the project name.
-		var projectName string
-		if filter.Relation == "project" {
-			// The project name is the first path argument of a project URL.
-			projectName = userURLPathArguments[0]
 		}
 
 		// Get the entity URLs with the given type and project (if set).

--- a/shared/entity/type.go
+++ b/shared/entity/type.go
@@ -216,8 +216,9 @@ func (t Type) URL(projectName string, location string, pathArguments ...string) 
 
 	u := api.NewURL().Path(path...)
 
-	// Always set project parameter if provided (operations and warnings may be project specific but it is not a requirement).
-	if projectName != "" {
+	// Set project parameter if provided and the entity type is not TypeProject (operations and warnings may be project
+	// specific but it is not a requirement).
+	if projectName != "" && t != TypeProject {
 		u = u.WithQuery("project", projectName)
 	}
 

--- a/shared/entity/type.go
+++ b/shared/entity/type.go
@@ -356,6 +356,11 @@ entityTypeLoop:
 		}
 	}
 
+	// If it's a project URL the project name is not a query parameter, it's in the path.
+	if entityType == TypeProject {
+		projectName = pathArguments[0]
+	}
+
 	return entityType, projectName, u.Query().Get("target"), pathArguments, nil
 }
 

--- a/shared/entity/type_test.go
+++ b/shared/entity/type_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -12,158 +13,191 @@ import (
 
 func TestURL(t *testing.T) {
 	tests := []struct {
-		name               string
-		rawURL             string
-		expectedEntityType Type
-		expectedProject    string
-		expectedLocation   string
-		expectedPathArgs   []string
-		expectedErr        error
+		name                  string
+		rawURL                string
+		expectedNormalisedURL string
+		expectedEntityType    Type
+		expectedProject       string
+		expectedLocation      string
+		expectedPathArgs      []string
+		expectedErr           error
 	}{
 		{
-			name:               "containers",
-			rawURL:             "/1.0/containers/my-container?project=my-project",
-			expectedEntityType: TypeContainer,
-			expectedProject:    "my-project",
-			expectedPathArgs:   []string{"my-container"},
-			expectedErr:        nil,
+			name:        "not a LXD URL",
+			rawURL:      "/1.0/not/a/url",
+			expectedErr: fmt.Errorf("Failed to match entity URL %q", "/1.0/not/a/url"),
 		},
 		{
-			name:               "images",
-			rawURL:             "/1.0/images/fwirnoaiwnerfoiawnef",
-			expectedEntityType: TypeImage,
-			expectedProject:    "default",
-			expectedPathArgs:   []string{"fwirnoaiwnerfoiawnef"},
-			expectedErr:        nil,
+			name:                  "containers",
+			rawURL:                "/1.0/containers/my-container?project=my-project",
+			expectedNormalisedURL: "/1.0/containers/my-container?project=my-project",
+			expectedEntityType:    TypeContainer,
+			expectedProject:       "my-project",
+			expectedPathArgs:      []string{"my-container"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "profiles",
-			rawURL:             "/1.0/profiles/my-profile?project=my-project",
-			expectedEntityType: TypeProfile,
-			expectedProject:    "my-project",
-			expectedPathArgs:   []string{"my-profile"},
-			expectedErr:        nil,
+			name:                  "images",
+			rawURL:                "/1.0/images/fwirnoaiwnerfoiawnef",
+			expectedNormalisedURL: "/1.0/images/fwirnoaiwnerfoiawnef?project=default",
+			expectedEntityType:    TypeImage,
+			expectedProject:       api.ProjectDefaultName,
+			expectedPathArgs:      []string{"fwirnoaiwnerfoiawnef"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "projects",
-			rawURL:             "/1.0/projects/my-project",
-			expectedEntityType: TypeProject,
-			expectedProject:    "",
-			expectedPathArgs:   []string{"my-project"},
-			expectedErr:        nil,
+			name:                  "profiles",
+			rawURL:                "/1.0/profiles/my-profile?project=my-project",
+			expectedNormalisedURL: "/1.0/profiles/my-profile?project=my-project",
+			expectedEntityType:    TypeProfile,
+			expectedProject:       "my-project",
+			expectedPathArgs:      []string{"my-profile"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "certificates",
-			rawURL:             "/1.0/certificates/foawienfoawnefkanwelfknsfl",
-			expectedEntityType: TypeCertificate,
-			expectedProject:    "",
-			expectedPathArgs:   []string{"foawienfoawnefkanwelfknsfl"},
-			expectedErr:        nil,
+			name:                  "projects",
+			rawURL:                "/1.0/projects/my-project",
+			expectedNormalisedURL: "/1.0/projects/my-project",
+			expectedEntityType:    TypeProject,
+			expectedProject:       "my-project",
+			expectedPathArgs:      []string{"my-project"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "instances",
-			rawURL:             "/1.0/instances/my-instance",
-			expectedEntityType: TypeInstance,
-			expectedProject:    "default",
-			expectedPathArgs:   []string{"my-instance"},
-			expectedErr:        nil,
+			name:                  "certificates",
+			rawURL:                "/1.0/certificates/foawienfoawnefkanwelfknsfl",
+			expectedNormalisedURL: "/1.0/certificates/foawienfoawnefkanwelfknsfl",
+			expectedEntityType:    TypeCertificate,
+			expectedProject:       "",
+			expectedPathArgs:      []string{"foawienfoawnefkanwelfknsfl"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "instance backup",
-			rawURL:             "/1.0/instances/my-instance/backups/my-backup?project=my-project",
-			expectedEntityType: TypeInstanceBackup,
-			expectedProject:    "my-project",
-			expectedPathArgs:   []string{"my-instance", "my-backup"},
-			expectedErr:        nil,
+			name:                  "instances",
+			rawURL:                "/1.0/instances/my-instance",
+			expectedNormalisedURL: "/1.0/instances/my-instance?project=default",
+			expectedEntityType:    TypeInstance,
+			expectedProject:       api.ProjectDefaultName,
+			expectedPathArgs:      []string{"my-instance"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "instance snapshot",
-			rawURL:             "/1.0/instances/my-instance/snapshots/my-snapshot",
-			expectedEntityType: TypeInstanceSnapshot,
-			expectedProject:    "default",
-			expectedPathArgs:   []string{"my-instance", "my-snapshot"},
-			expectedErr:        nil,
+			name:                  "instance backup",
+			rawURL:                "/1.0/instances/my-instance/backups/my-backup?project=my-project",
+			expectedNormalisedURL: "/1.0/instances/my-instance/backups/my-backup?project=my-project",
+			expectedEntityType:    TypeInstanceBackup,
+			expectedProject:       "my-project",
+			expectedPathArgs:      []string{"my-instance", "my-backup"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "networks",
-			rawURL:             "/1.0/networks/my-network?project=my-project",
-			expectedEntityType: TypeNetwork,
-			expectedProject:    "my-project",
-			expectedPathArgs:   []string{"my-network"},
-			expectedErr:        nil,
+			name:                  "instance snapshot",
+			rawURL:                "/1.0/instances/my-instance/snapshots/my-snapshot",
+			expectedNormalisedURL: "/1.0/instances/my-instance/snapshots/my-snapshot?project=default",
+			expectedEntityType:    TypeInstanceSnapshot,
+			expectedProject:       api.ProjectDefaultName,
+			expectedPathArgs:      []string{"my-instance", "my-snapshot"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "network acls",
-			rawURL:             "/1.0/network-acls/my-network-acl",
-			expectedEntityType: TypeNetworkACL,
-			expectedProject:    "default",
-			expectedPathArgs:   []string{"my-network-acl"},
-			expectedErr:        nil,
+			name:                  "networks",
+			rawURL:                "/1.0/networks/my-network?project=my-project",
+			expectedNormalisedURL: "/1.0/networks/my-network?project=my-project",
+			expectedEntityType:    TypeNetwork,
+			expectedProject:       "my-project",
+			expectedPathArgs:      []string{"my-network"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "cluster members",
-			rawURL:             "/1.0/cluster/members/node01",
-			expectedEntityType: TypeNode,
-			expectedProject:    "",
-			expectedPathArgs:   []string{"node01"},
-			expectedErr:        nil,
+			name:                  "network acls",
+			rawURL:                "/1.0/network-acls/my-network-acl",
+			expectedNormalisedURL: "/1.0/network-acls/my-network-acl?project=default",
+			expectedEntityType:    TypeNetworkACL,
+			expectedProject:       api.ProjectDefaultName,
+			expectedPathArgs:      []string{"my-network-acl"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "operation",
-			rawURL:             "/1.0/operations/3e75d1bf-30ed-45ce-9e02-267fa7338eb4",
-			expectedEntityType: TypeOperation,
-			expectedProject:    "",
-			expectedPathArgs:   []string{"3e75d1bf-30ed-45ce-9e02-267fa7338eb4"},
-			expectedErr:        nil,
+			name:                  "cluster members",
+			rawURL:                "/1.0/cluster/members/node01",
+			expectedNormalisedURL: "/1.0/cluster/members/node01",
+			expectedEntityType:    TypeNode,
+			expectedProject:       "",
+			expectedPathArgs:      []string{"node01"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "storage pools",
-			rawURL:             "/1.0/storage-pools/my-storage-pool",
-			expectedEntityType: TypeStoragePool,
-			expectedProject:    "",
-			expectedPathArgs:   []string{"my-storage-pool"},
-			expectedErr:        nil,
+			name:                  "operation",
+			rawURL:                "/1.0/operations/3e75d1bf-30ed-45ce-9e02-267fa7338eb4",
+			expectedNormalisedURL: "/1.0/operations/3e75d1bf-30ed-45ce-9e02-267fa7338eb4",
+			expectedEntityType:    TypeOperation,
+			expectedProject:       "",
+			expectedPathArgs:      []string{"3e75d1bf-30ed-45ce-9e02-267fa7338eb4"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "storage volumes",
-			rawURL:             "/1.0/storage-pools/my-storage-pool/volumes/custom/my%2Fstorage-volume?project=my-project&target=node01",
-			expectedEntityType: TypeStorageVolume,
-			expectedProject:    "my-project",
-			expectedLocation:   "node01",
-			expectedPathArgs:   []string{"my-storage-pool", "custom", "my/storage-volume"},
-			expectedErr:        nil,
+			name:                  "storage pools",
+			rawURL:                "/1.0/storage-pools/my-storage-pool",
+			expectedNormalisedURL: "/1.0/storage-pools/my-storage-pool",
+			expectedEntityType:    TypeStoragePool,
+			expectedProject:       "",
+			expectedPathArgs:      []string{"my-storage-pool"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "storage volume backups",
-			rawURL:             "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume/backups/my-backup?project=my-project",
-			expectedEntityType: TypeStorageVolumeBackup,
-			expectedProject:    "my-project",
-			expectedPathArgs:   []string{"my-storage-pool", "custom", "my-storage-volume", "my-backup"},
-			expectedErr:        nil,
+			name:                  "storage volumes",
+			rawURL:                "/1.0/storage-pools/my-storage-pool/volumes/custom/my%2Fstorage-volume?project=my-project&target=node01",
+			expectedNormalisedURL: "/1.0/storage-pools/my-storage-pool/volumes/custom/my%2Fstorage-volume?project=my-project&target=node01",
+			expectedEntityType:    TypeStorageVolume,
+			expectedProject:       "my-project",
+			expectedLocation:      "node01",
+			expectedPathArgs:      []string{"my-storage-pool", "custom", "my/storage-volume"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "storage volume snapshots",
-			rawURL:             "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume/snapshots/my-snapshot?project=my-project",
-			expectedEntityType: TypeStorageVolumeSnapshot,
-			expectedProject:    "my-project",
-			expectedPathArgs:   []string{"my-storage-pool", "custom", "my-storage-volume", "my-snapshot"},
-			expectedErr:        nil,
+			name:                  "storage volume backups",
+			rawURL:                "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume/backups/my-backup?project=my-project",
+			expectedNormalisedURL: "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume/backups/my-backup?project=my-project",
+			expectedEntityType:    TypeStorageVolumeBackup,
+			expectedProject:       "my-project",
+			expectedPathArgs:      []string{"my-storage-pool", "custom", "my-storage-volume", "my-backup"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "warnings",
-			rawURL:             "/1.0/warnings/3e75d1bf-30ed-45ce-9e02-267fa7338eb4",
-			expectedEntityType: TypeWarning,
-			expectedProject:    "",
-			expectedPathArgs:   []string{"3e75d1bf-30ed-45ce-9e02-267fa7338eb4"},
-			expectedErr:        nil,
+			name:                  "storage volume snapshots",
+			rawURL:                "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume/snapshots/my-snapshot?project=my-project",
+			expectedNormalisedURL: "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume/snapshots/my-snapshot?project=my-project",
+			expectedEntityType:    TypeStorageVolumeSnapshot,
+			expectedProject:       "my-project",
+			expectedPathArgs:      []string{"my-storage-pool", "custom", "my-storage-volume", "my-snapshot"},
+			expectedErr:           nil,
 		},
 		{
-			name:               "cluster groups",
-			rawURL:             "/1.0/cluster/groups/my-cluster-group",
-			expectedEntityType: TypeClusterGroup,
-			expectedProject:    "",
-			expectedPathArgs:   []string{"my-cluster-group"},
-			expectedErr:        nil,
+			name:                  "storage buckets",
+			rawURL:                "/1.0/storage-pools/my-storage-pool/buckets/my-bucket",
+			expectedNormalisedURL: "/1.0/storage-pools/my-storage-pool/buckets/my-bucket?project=default",
+			expectedEntityType:    TypeStorageBucket,
+			expectedProject:       api.ProjectDefaultName,
+			expectedPathArgs:      []string{"my-storage-pool", "my-bucket"},
+			expectedErr:           nil,
+		},
+		{
+			name:                  "warnings",
+			rawURL:                "/1.0/warnings/3e75d1bf-30ed-45ce-9e02-267fa7338eb4",
+			expectedNormalisedURL: "/1.0/warnings/3e75d1bf-30ed-45ce-9e02-267fa7338eb4",
+			expectedEntityType:    TypeWarning,
+			expectedProject:       "",
+			expectedPathArgs:      []string{"3e75d1bf-30ed-45ce-9e02-267fa7338eb4"},
+			expectedErr:           nil,
+		},
+		{
+			name:                  "cluster groups",
+			rawURL:                "/1.0/cluster/groups/my-cluster-group",
+			expectedNormalisedURL: "/1.0/cluster/groups/my-cluster-group",
+			expectedEntityType:    TypeClusterGroup,
+			expectedProject:       "",
+			expectedPathArgs:      []string{"my-cluster-group"},
+			expectedErr:           nil,
 		},
 	}
 
@@ -181,24 +215,13 @@ func TestURL(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedErr, actualErr)
-
-			requiresProject, err := actualEntityType.RequiresProject()
-			assert.NoError(t, err)
-			if u.Query().Get("project") != "" || !requiresProject {
-				// Assert that we can convert back to the same value.
-				actualURL, err := actualEntityType.URL(actualProject, actualLocation, actualPathArgs...)
-				assert.NoError(t, err)
-				assert.Equal(t, tt.rawURL, actualURL.String())
-			} else {
-				// If the entity type requires a project but one wasn't set, assert that (entity.Type).URL sets the
-				// default project.
-				q := u.Query()
-				q.Set("project", api.ProjectDefaultName)
-				u.RawQuery = q.Encode()
-				actualURL, err := actualEntityType.URL(actualProject, actualLocation, actualPathArgs...)
-				assert.NoError(t, err)
-				assert.Equal(t, u.String(), actualURL.String())
+			if tt.expectedErr != nil {
+				return
 			}
+
+			normalisedURL, err := actualEntityType.URL(actualProject, actualLocation, actualPathArgs...)
+			assert.Equal(t, normalisedURL.String(), tt.expectedNormalisedURL)
+			assert.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
In our implementation of `(github.com/openfga/openfga/pkg/storage).OpenFGADatastore`, entity URLs are expected to include the project query parameter even if it is the default project. However, LXD typically displays URLs without the project query parameter when a resource is in the default project (with the exception of permissions, where we have been explicit).

This PR ensures that the project query parameter is added to URLs inside the Authorizer so that this doesn't need to be done elsewhere in the codebase (such as in `project.FilterUsedBy` which has now been simplified). 

Closes #13072