### PR TITLE
Use shorter virtiofsd and swtpm socket paths

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -465,7 +465,7 @@ func DiskVMVirtiofsdStart(execPath string, inst instance.Instance, socketPath st
 		return nil, nil, UnsupportedError{"SEV unsupported"}
 	}
 
-	// Trickery to handle paths > 107 chars.
+	// Trickery to handle paths > 108 chars.
 	socketFileDir, err := os.Open(filepath.Dir(socketPath))
 	if err != nil {
 		return nil, nil, err

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -30,7 +30,7 @@ const RBDFormatPrefix = "rbd"
 const RBDFormatSeparator = " "
 
 // DiskParseRBDFormat parses an rbd formatted string, and returns the pool name, volume name, and list of options.
-func DiskParseRBDFormat(rbd string) (string, string, []string, error) {
+func DiskParseRBDFormat(rbd string) (poolName string, volumeName string, options []string, err error) {
 	if !strings.HasPrefix(rbd, fmt.Sprintf("%s%s", RBDFormatPrefix, RBDFormatSeparator)) {
 		return "", "", nil, fmt.Errorf("Invalid rbd format, missing prefix")
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3343,6 +3343,11 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 	// where 9p isn't available in the VM guest OS.
 	configSockPath, _ := d.configVirtiofsdPaths()
 	if shared.PathExists(configSockPath) {
+		shortPath, err := util.ShortenedFilePath(configSockPath, fdFiles)
+		if err != nil {
+			return "", nil, err
+		}
+
 		devBus, devAddr, multi = bus.allocate(busFunctionGroup9p)
 		driveConfigVirtioOpts := qemuDriveConfigOpts{
 			dev: qemuDevOpts{
@@ -3352,7 +3357,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 				multifunction: multi,
 			},
 			protocol: "virtio-fs",
-			path:     configSockPath,
+			path:     shortPath,
 		}
 
 		cfg = append(cfg, qemuDriveConfig(&driveConfigVirtioOpts)...)
@@ -3746,6 +3751,11 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 
 		devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
 
+		shortPath, err := util.ShortenedFilePath(virtiofsdSockPath, fdFiles)
+		if err != nil {
+			return err
+		}
+
 		// Add virtio-fs device as this will be preferred over 9p.
 		driveDirVirtioOpts := qemuDriveDirOpts{
 			dev: qemuDevOpts{
@@ -3756,7 +3766,7 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 			},
 			devName:  driveConf.DevName,
 			mountTag: mountTag,
-			path:     virtiofsdSockPath,
+			path:     shortPath,
 			protocol: "virtio-fs",
 		}
 		*cfg = append(*cfg, qemuDriveDir(&driveDirVirtioOpts)...)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3506,7 +3506,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 
 		// Add TPM device.
 		if len(runConf.TPMDevice) > 0 {
-			err = d.addTPMDeviceConfig(&cfg, runConf.TPMDevice)
+			err = d.addTPMDeviceConfig(&cfg, runConf.TPMDevice, fdFiles)
 			if err != nil {
 				return "", nil, err
 			}
@@ -4697,7 +4697,7 @@ func (d *qemu) addUSBDeviceConfig(usbDev deviceConfig.USBDeviceItem) (monitorHoo
 	return monHook, nil
 }
 
-func (d *qemu) addTPMDeviceConfig(cfg *[]cfgSection, tpmConfig []deviceConfig.RunConfigItem) error {
+func (d *qemu) addTPMDeviceConfig(cfg *[]cfgSection, tpmConfig []deviceConfig.RunConfigItem, fdFiles *[]*os.File) error {
 	var devName, socketPath string
 
 	for _, tpmItem := range tpmConfig {
@@ -4708,9 +4708,14 @@ func (d *qemu) addTPMDeviceConfig(cfg *[]cfgSection, tpmConfig []deviceConfig.Ru
 		}
 	}
 
+	shortPath, err := util.ShortenedFilePath(socketPath, fdFiles)
+	if err != nil {
+		return err
+	}
+
 	tpmOpts := qemuTPMOpts{
 		devName: devName,
-		path:    socketPath,
+		path:    shortPath,
 	}
 	*cfg = append(*cfg, qemuTPM(&tpmOpts)...)
 

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -102,3 +102,11 @@ func GetQemuFwPaths() ([]string, error) {
 
 	return qemuFwPaths, nil
 }
+
+// AddFileDescriptor adds a file path to the list of files to open and pass file descriptor to other processes.
+// Returns the file descriptor number that the other process will receive.
+func AddFileDescriptor(fdFiles *[]*os.File, file *os.File) int {
+	// Append the tap device file path to the list of files to be opened and passed to qemu.
+	*fdFiles = append(*fdFiles, file)
+	return 2 + len(*fdFiles) // Use 2+fdFiles count, as first user file descriptor is 3.
+}

--- a/test/suites/container_devices_tpm.sh
+++ b/test/suites/container_devices_tpm.sh
@@ -10,7 +10,7 @@ test_container_devices_tpm() {
   lxc launch testimage "${ctName}"
 
   # Check adding a device with no path
-  ! lxc config device add "${ctName}" test-dev-invalid
+  ! lxc config device add "${ctName}" test-dev-invalid tpm
 
   # Add device
   lxc config device add "${ctName}" test-dev1 tpm path=/dev/tpm0 pathrm=/dev/tpmrm0


### PR DESCRIPTION
Fixes #12539.
These changes generally include getting the file descriptor of the directory of a socket's file to use an alternative shorter path to the same socket. This same fix is applied during VM start (with disk virtiofsd sockets, qemu config virtiofsd sockets and the swtpm sockets), and when hotplugging a disk on a VM (with disk virtiofsd sockets)