### PR TITLE
lxd: Fix metrics crash due to absent locking

### DIFF
--- a/lxc/config/default.go
+++ b/lxc/config/default.go
@@ -59,6 +59,7 @@ var StaticRemotes = map[string]Remote{
 // DefaultRemotes is the list of default remotes.
 var DefaultRemotes = map[string]Remote{
 	"local":                LocalRemote,
+	"images":               ImagesRemote,
 	"ubuntu":               UbuntuRemote,
 	"ubuntu-daily":         UbuntuDailyRemote,
 	"ubuntu-minimal":       UbuntuMinimalRemote,

--- a/lxd-benchmark/benchmark/benchmark.go
+++ b/lxd-benchmark/benchmark/benchmark.go
@@ -49,7 +49,7 @@ func LaunchContainers(c lxd.ContainerServer, count int, parallel int, image stri
 
 	fingerprint, err := ensureImage(c, image)
 	if err != nil {
-		return duration, err
+		return duration, fmt.Errorf("Failed ensuring image: %w", err)
 	}
 
 	batchStart := func(index int, wg *sync.WaitGroup) {

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -315,7 +315,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	updatedProjects := []string{}
 	for project, entries := range newMetrics {
-		if project == "default" {
+		if project == api.ProjectDefaultName {
 			entries.Merge(intMetrics) // internal metrics are always considered new. Add them to the default project.
 		}
 

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -219,12 +219,14 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	// Total number of instances, both running and stopped.
 	for _, instance := range instances {
-		_, ok := allProjectInstances[instance.Project().Name]
+		projectName := instance.Project().Name
+
+		_, ok := allProjectInstances[projectName]
 		if !ok {
-			allProjectInstances[instance.Project().Name] = make(map[instancetype.Type]int)
+			allProjectInstances[projectName] = make(map[instancetype.Type]int)
 		}
 
-		allProjectInstances[instance.Project().Name][instance.Type()]++
+		allProjectInstances[projectName][instance.Type()]++
 	}
 
 	// Prepare temporary metrics storage.

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -275,8 +275,8 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Fetch what's missing.
+	wg.Add(len(instances))
 	for _, inst := range instances {
-		wg.Add(1)
 		instMetricsCh <- inst
 	}
 

--- a/test/suites/metrics.sh
+++ b/test/suites/metrics.sh
@@ -11,6 +11,10 @@ test_metrics() {
   lxc project create foo -c features.images=false -c features.profiles=false
   lxc launch testimage c3 --project foo
 
+  # create but dont start a container in separate non default project to check for stopped instance accounting.
+  lxc project create foo2 -c features.images=false -c features.profiles=false
+  lxc init testimage c4 --project foo2
+
   # c1 metrics should show as the container is running
   lxc query "/1.0/metrics" | grep "name=\"c1\""
   lxc query "/1.0/metrics?project=default" | grep "name=\"c1\""
@@ -22,9 +26,11 @@ test_metrics() {
   # Check that we can get the count of existing instances.
   lxc query /1.0/metrics | grep -xF 'lxd_instances{project="default",type="container"} 2'
   lxc query /1.0/metrics | grep -xF 'lxd_instances{project="foo",type="container"} 1'
+  lxc query /1.0/metrics | grep -xF 'lxd_instances{project="foo2",type="container"} 1'
   # Ensure lxd_instances reports VM count properly (0)
   lxc query /1.0/metrics | grep -xF 'lxd_instances{project="default",type="virtual-machine"} 0'
   lxc query /1.0/metrics | grep -xF 'lxd_instances{project="foo",type="virtual-machine"} 0'
+  lxc query /1.0/metrics | grep -xF 'lxd_instances{project="foo2",type="virtual-machine"} 0'
 
   # c3 metrics from another project also show up for non metrics unrestricted certificate
   lxc query "/1.0/metrics" | grep "name=\"c3\""
@@ -121,5 +127,7 @@ test_metrics() {
 
   lxc delete -f c1 c2
   lxc delete -f c3 --project foo
+  lxc delete -f c4 --project foo2
   lxc project rm foo
+  lxc project rm foo2
 }


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/13301

Reproduced the issue by using `lxd-benchmark init --count=50 images:alpine/3.19` to create 50 containers and then polled `/1.0/metrics` repeatedly until LXD crashed using: `while true; do lxc query /1.0/metrics; done`

Also noticed that the new `images` remote isn't included in the `lxc` client default config, so have included that now too.
This was preventing using `lxd-benchmark` with the `images:` remote.

Fixes regression introduced by https://github.com/canonical/lxd/pull/13222/commits/07813c4d59058e3ba11b8119e9b4ad67857eb35a#diff-60d020b36265ee4faf6bd479348533eb75f0c8244f573a1ed848fd1a685ae06cR254-R257