### PR TITLE
Device: Fix diskAddRootUserNSEntry to add root mapping only if it's required

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -279,7 +279,7 @@ func diskAddRootUserNSEntry(idmaps []idmap.IdmapEntry, hostRootID int64) []idmap
 				needsNSGIDRootEntry = false // Root GID mapping already present.
 			}
 
-			if !needsNSUIDRootEntry && needsNSGIDRootEntry {
+			if !needsNSUIDRootEntry && !needsNSGIDRootEntry {
 				break // If we've found a root entry for UID and GID then we don't need to add one.
 			}
 		}


### PR DESCRIPTION
Fix diskAddRootUserNSEntry logic to correcly handle case when we have not-groupped UID/GID mapping like this:
`[{true false 1000 0 1} {false true 1000 0 1}]`

because right now it assumes that mapping should be like [{true true 1000 0 1}]

which is logically equivalent.

This become noticable after my change in #12718, before that this issue in logic was reproducible only if user will do something like this:
  cat << EOF
uid $(id -u) 1000000
gid $(id -g) 1000000
EOF
  ) | lxc config set idmap raw.idmap -
which is an extremely rare usecase.

Fixes: #13325