### PR TITLE
Auth: Use correct pool name in storage volume URLs when calling the permission checker.

### DIFF
--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -767,7 +767,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 			vol := &dbVol.StorageVolume
 
 			volumeName, _, _ := api.GetParentAndSnapshotName(vol.Name)
-			if !userHasPermission(entity.StorageVolumeURL(vol.Project, "", poolName, dbVol.Type, volumeName)) {
+			if !userHasPermission(entity.StorageVolumeURL(vol.Project, "", dbVol.Pool, dbVol.Type, volumeName)) {
 				continue
 			}
 
@@ -791,7 +791,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	for _, dbVol := range dbVolumes {
 		volumeName, _, _ := api.GetParentAndSnapshotName(dbVol.Name)
 
-		if !userHasPermission(entity.StorageVolumeURL(dbVol.Project, "", poolName, dbVol.Type, volumeName)) {
+		if !userHasPermission(entity.StorageVolumeURL(dbVol.Project, "", dbVol.Pool, dbVol.Type, volumeName)) {
 			continue
 		}
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -316,6 +316,8 @@ user_is_project_operator() {
     lxc_remote network zone delete oidc:test-network-zone
     pool_name="$(lxc_remote storage list oidc: -f csv | cut -d, -f1)"
     lxc_remote storage volume create "oidc:${pool_name}" test-volume
+    lxc_remote query oidc:/1.0/storage-volumes | grep -F "/1.0/storage-pools/${pool_name}/volumes/custom/test-volume"
+    lxc_remote query oidc:/1.0/storage-volumes/custom | grep -F "/1.0/storage-pools/${pool_name}/volumes/custom/test-volume"
     lxc_remote storage volume delete "oidc:${pool_name}" test-volume
     lxc_remote launch testimage oidc:operator-foo
     LXC_LOCAL='' lxc_remote exec oidc:operator-foo -- echo "bar"


### PR DESCRIPTION
When calling `GET /1.0/storage-volumes`, the `poolName` mux variable is not populated. Using this parameter in the call to `entity.StorageVolumeURL` was leading to invalid storage volume URLs that were not in the list of URLs that the permission checker performs a lookup with.

Closes #13357