### PR TITLE
Config: Remove concept of hidden config entries and consistently use strings

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1396,11 +1396,12 @@ definitions:
     InitLocalPreseed:
         properties:
             config:
-                additionalProperties: {}
+                additionalProperties:
+                    type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
-                    core.trust_password: true
+                    core.trust_password: xyz
                 type: object
                 x-go-name: Config
             networks:
@@ -5559,11 +5560,12 @@ definitions:
                 type: string
                 x-go-name: AuthUserName
             config:
-                additionalProperties: {}
+                additionalProperties:
+                    type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
-                    core.trust_password: true
+                    core.trust_password: xyz
                 type: object
                 x-go-name: Config
             environment:
@@ -5739,11 +5741,12 @@ definitions:
         description: ServerPut represents the modifiable fields of a LXD server configuration
         properties:
             config:
-                additionalProperties: {}
+                additionalProperties:
+                    type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
-                    core.trust_password: true
+                    core.trust_password: xyz
                 type: object
                 x-go-name: Config
         type: object

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -644,7 +644,7 @@ func (c *cmdClusterEnable) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to retrieve current server config: %w", err)
 	}
 
-	if server.Config["core.https_address"] == "" {
+	if server.Config["core.https_address"] == "" && server.Config["cluster.https_address"] == "" {
 		return fmt.Errorf(i18n.G("This LXD server is not available on the network"))
 	}
 

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -487,14 +487,6 @@ func (c *cmdConfigGet) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		value := resp.Config[args[len(args)-1]]
-		if value == nil {
-			value = ""
-		} else if value == true {
-			value = "true"
-		} else if value == false {
-			value = "false"
-		}
-
 		fmt.Println(value)
 	}
 
@@ -708,7 +700,7 @@ func (c *cmdConfigSet) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if server.Config == nil {
-		server.Config = map[string]any{}
+		server.Config = map[string]string{}
 	}
 
 	for k, v := range keys {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -414,7 +414,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 			return fmt.Errorf("Cannot use wildcard core.https_address %q for cluster.https_address. Please specify a new cluster.https_address or core.https_address", localClusterAddress)
 		}
 
-		_, err = config.Patch(map[string]any{
+		_, err = config.Patch(map[string]string{
 			"cluster.https_address": localHTTPSAddress,
 		})
 		if err != nil {
@@ -485,7 +485,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
 
-			_, err = config.Patch(map[string]any{
+			_, err = config.Patch(map[string]string{
 				"core.https_address":    req.ServerAddress,
 				"cluster.https_address": req.ServerAddress,
 			})
@@ -518,7 +518,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
 
-			_, err = config.Patch(map[string]any{
+			_, err = config.Patch(map[string]string{
 				"cluster.https_address": localHTTPSAddress,
 			})
 			return err
@@ -789,7 +789,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		existingConfigDump := currentClusterConfig.Dump()
 		changes := make(map[string]string, len(existingConfigDump))
 		for k, v := range existingConfigDump {
-			changes[k], _ = v.(string)
+			changes[k] = v
 		}
 
 		err = doAPI10UpdateTriggers(d, nil, changes, nodeConfig, currentClusterConfig)

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -505,7 +505,7 @@ var ConfigSchema = config.Schema{
 	//  type: string
 	//  scope: global
 	//  shortdesc: Password to be provided by clients to set up a trust
-	"core.trust_password": {Hidden: true, Setter: passwordSetter},
+	"core.trust_password": {Setter: passwordSetter},
 
 	// lxdmeta:generate(entities=server; group=core; key=core.trust_ca_certificates)
 	//

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -603,7 +603,7 @@ var ConfigSchema = config.Schema{
 	//  type: string
 	//  scope: global
 	//  shortdesc: Password used for Loki authentication
-	"loki.auth.password": {Hidden: true},
+	"loki.auth.password": {},
 
 	// lxdmeta:generate(entities=server; group=loki; key=loki.api.ca_cert)
 	//

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -258,21 +258,21 @@ func (c *Config) ClusterHealingThreshold() time.Duration {
 
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
-func (c *Config) Dump() map[string]any {
+func (c *Config) Dump() map[string]string {
 	return c.m.Dump()
 }
 
 // Replace the current configuration with the given values.
 //
 // Return what has actually changed.
-func (c *Config) Replace(values map[string]any) (map[string]string, error) {
+func (c *Config) Replace(values map[string]string) (map[string]string, error) {
 	return c.update(values)
 }
 
 // Patch changes only the configuration keys in the given map.
 //
 // Return what has actually changed.
-func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
+func (c *Config) Patch(patch map[string]string) (map[string]string, error) {
 	values := c.Dump() // Use current values as defaults
 	for name, value := range patch {
 		values[name] = value
@@ -281,7 +281,7 @@ func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
 	return c.update(values)
 }
 
-func (c *Config) update(values map[string]any) (map[string]string, error) {
+func (c *Config) update(values map[string]string) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {
 		return nil, err

--- a/lxd/cluster/config/config_test.go
+++ b/lxd/cluster/config/config_test.go
@@ -19,7 +19,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]any{}, config.Dump())
+	assert.Equal(t, map[string]string{}, config.Dump())
 
 	assert.Equal(t, float64(20), config.OfflineThreshold().Seconds())
 }
@@ -38,7 +38,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
-	values := map[string]any{"core.proxy_http": "foo.bar"}
+	values := map[string]string{"core.proxy_http": "foo.bar"}
 	assert.Equal(t, values, config.Dump())
 }
 
@@ -50,7 +50,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]any{}, config.Dump())
+	assert.Equal(t, map[string]string{}, config.Dump())
 }
 
 // Offline threshold must be greater than the heartbeat interval.
@@ -61,7 +61,7 @@ func TestConfigLoad_OfflineThresholdValidator(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Patch(map[string]any{"cluster.offline_threshold": "2"})
+	_, err = config.Patch(map[string]string{"cluster.offline_threshold": "2"})
 	require.EqualError(t, err, "cannot set 'cluster.offline_threshold' to '2': Value must be greater than '10'")
 }
 
@@ -73,7 +73,7 @@ func TestConfigLoad_MaxVotersValidator(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Patch(map[string]any{"cluster.max_voters": "4"})
+	_, err = config.Patch(map[string]string{"cluster.max_voters": "4"})
 	require.EqualError(t, err, "cannot set 'cluster.max_voters' to '4': Value must be an odd number equal to or higher than 3")
 }
 
@@ -86,11 +86,11 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	changed, err := config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
+	changed, err := config.Replace(map[string]string{"core.proxy_http": "foo.bar"})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.proxy_http": "foo.bar"}, changed)
 
-	_, err = config.Replace(map[string]any{})
+	_, err = config.Replace(map[string]string{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", config.ProxyHTTP())
@@ -109,10 +109,10 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
+	_, err = config.Replace(map[string]string{"core.proxy_http": "foo.bar"})
 	assert.NoError(t, err)
 
-	_, err = config.Patch(map[string]any{})
+	_, err = config.Patch(map[string]string{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "foo.bar", config.ProxyHTTP())

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -49,7 +49,7 @@ func TestNewNotifier(t *testing.T) {
 	hook := func(client lxd.InstanceServer) error {
 		server, _, err := client.GetServer()
 		require.NoError(t, err)
-		peers <- server.Config["cluster.https_address"].(string)
+		peers <- server.Config["cluster.https_address"]
 		return nil
 	}
 
@@ -177,7 +177,7 @@ func (h *notifyFixtures) Nodes(cert *shared.CertInfo, n int) func() {
 		config, err := node.ConfigLoad(ctx, tx)
 		require.NoError(h.t, err)
 		address := servers[0].Listener.Addr().String()
-		values := map[string]any{"cluster.https_address": address}
+		values := map[string]string{"cluster.https_address": address}
 		_, err = config.Patch(values)
 		require.NoError(h.t, err)
 		return nil
@@ -232,7 +232,7 @@ func newRestServer(cert *shared.CertInfo) *httptest.Server {
 
 	mux.HandleFunc("/1.0/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		config := map[string]any{"cluster.https_address": server.Listener.Addr().String()}
+		config := map[string]string{"cluster.https_address": server.Listener.Addr().String()}
 		metadata := api.ServerPut{Config: config}
 		_ = util.WriteJSON(w, api.ResponseRaw{Metadata: metadata}, nil)
 	})

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -111,7 +111,7 @@ func updateLocalAddress(database *db.Node, address string) error {
 			return err
 		}
 
-		newConfig := map[string]any{"cluster.https_address": address}
+		newConfig := map[string]string{"cluster.https_address": address}
 		_, err = config.Patch(newConfig)
 		if err != nil {
 			return err

--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -44,15 +44,6 @@ func (m *Map) Change(changes map[string]string) (map[string]string, error) {
 
 	errors := ErrorList{}
 	for name, change := range changes {
-		key, ok := m.schema[name]
-
-		// When a hidden value is set to "true" in the change set, it
-		// means "keep it unchanged", so we replace it with our current
-		// value.
-		if ok && key.Hidden && change == "true" {
-			change = m.GetRaw(name)
-		}
-
 		// Ensure that we were actually passed a string.
 		s := reflect.ValueOf(change)
 		if s.Kind() != reflect.String {
@@ -87,9 +78,7 @@ func (m *Map) Change(changes map[string]string) (map[string]string, error) {
 
 // Dump the current configuration held by this Map.
 //
-// Keys that match their default value will not be included in the dump. Also,
-// if a Key has its Hidden attribute set to true, it will be rendered as
-// "true", for obfuscating the actual value.
+// Keys that match their default value will not be included in the dump.
 func (m *Map) Dump() map[string]string {
 	values := map[string]string{}
 
@@ -99,11 +88,7 @@ func (m *Map) Dump() map[string]string {
 			// Schema key
 			value := m.GetRaw(name)
 			if value != key.Default {
-				if key.Hidden {
-					values[name] = "true"
-				} else {
-					values[name] = value
-				}
+				values[name] = value
 			}
 		} else if shared.IsUserConfig(name) {
 			// User key, just include it as is

--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -39,7 +39,7 @@ func Load(schema Schema, values map[string]string) (Map, error) {
 //
 // Return a map of key/value pairs that were actually changed. If some keys
 // fail to apply, details are included in the returned ErrorList.
-func (m *Map) Change(changes map[string]any) (map[string]string, error) {
+func (m *Map) Change(changes map[string]string) (map[string]string, error) {
 	values := make(map[string]string, len(m.schema))
 
 	errors := ErrorList{}
@@ -49,13 +49,8 @@ func (m *Map) Change(changes map[string]any) (map[string]string, error) {
 		// When a hidden value is set to "true" in the change set, it
 		// means "keep it unchanged", so we replace it with our current
 		// value.
-		if ok && key.Hidden && change == true {
+		if ok && key.Hidden && change == "true" {
 			change = m.GetRaw(name)
-		}
-
-		// A nil object means the empty string.
-		if change == nil {
-			change = ""
 		}
 
 		// Ensure that we were actually passed a string.
@@ -65,7 +60,7 @@ func (m *Map) Change(changes map[string]any) (map[string]string, error) {
 			continue
 		}
 
-		values[name] = change.(string)
+		values[name] = change
 	}
 
 	if errors.Len() > 0 {
@@ -95,8 +90,8 @@ func (m *Map) Change(changes map[string]any) (map[string]string, error) {
 // Keys that match their default value will not be included in the dump. Also,
 // if a Key has its Hidden attribute set to true, it will be rendered as
 // "true", for obfuscating the actual value.
-func (m *Map) Dump() map[string]any {
-	values := map[string]any{}
+func (m *Map) Dump() map[string]string {
+	values := map[string]string{}
 
 	for name, value := range m.values {
 		key, ok := m.schema[name]
@@ -105,7 +100,7 @@ func (m *Map) Dump() map[string]any {
 			value := m.GetRaw(name)
 			if value != key.Default {
 				if key.Hidden {
-					values[name] = true
+					values[name] = "true"
 				} else {
 					values[name] = value
 				}

--- a/lxd/config/map_test.go
+++ b/lxd/config/map_test.go
@@ -113,42 +113,37 @@ func TestChange(t *testing.T) {
 
 	cases := []struct {
 		title  string
-		values map[string]any    // New values
+		values map[string]string // New values
 		result map[string]string // Expected values after change
 	}{
 		{
 			`plain change of regular key`,
-			map[string]any{"foo": "world"},
+			map[string]string{"foo": "world"},
 			map[string]string{"foo": "world"},
 		},
 		{
 			`key setter is honored`,
-			map[string]any{"bar": "y"},
+			map[string]string{"bar": "y"},
 			map[string]string{"bar": "Y"},
 		},
 		{
 			`bool true values are normalized`,
-			map[string]any{"egg": "yes"},
+			map[string]string{"egg": "yes"},
 			map[string]string{"egg": "true"},
 		},
 		{
 			`bool false values are normalized`,
-			map[string]any{"yuk": "0"},
+			map[string]string{"yuk": "0"},
 			map[string]string{"yuk": "false"},
 		},
 		{
 			`the special value 'true' is a passthrough for hidden keys`,
-			map[string]any{"xyz": true},
+			map[string]string{"xyz": "true"},
 			map[string]string{"xyz": "sekret"},
 		},
 		{
-			`the special value nil is converted to empty string`,
-			map[string]any{"foo": nil},
-			map[string]string{"foo": ""},
-		},
-		{
 			`multiple values are all mutated`,
-			map[string]any{"foo": "x", "bar": "hey", "egg": "0"},
+			map[string]string{"foo": "x", "bar": "hey", "egg": "0"},
 			map[string]string{"foo": "x", "bar": "HEY", "egg": ""},
 		},
 	}
@@ -179,32 +174,32 @@ func TestMap_ChangeReturnsChangedKeys(t *testing.T) {
 
 	cases := []struct {
 		title   string
-		changes map[string]any    // New values
+		changes map[string]string // New values
 		changed map[string]string // Keys that should have actually changed
 	}{
 		{
 			`plain single change`,
-			map[string]any{"foo": "no"},
+			map[string]string{"foo": "no"},
 			map[string]string{"foo": "false"},
 		},
 		{
 			`unchanged boolean value, even if it's spelled 'yes' and not 'true'`,
-			map[string]any{"foo": "yes"},
+			map[string]string{"foo": "yes"},
 			map[string]string{},
 		},
 		{
 			`unset value`,
-			map[string]any{"foo": ""},
+			map[string]string{"foo": ""},
 			map[string]string{"foo": "false"},
 		},
 		{
 			`unchanged value, since it matches the default`,
-			map[string]any{"foo": "true", "bar": "egg"},
+			map[string]string{"foo": "true", "bar": "egg"},
 			map[string]string{},
 		},
 		{
 			`multiple changes`,
-			map[string]any{"foo": "false", "bar": "baz"},
+			map[string]string{"foo": "false", "bar": "baz"},
 			map[string]string{"foo": "false", "bar": "baz"},
 		},
 	}
@@ -231,28 +226,23 @@ func TestMap_ChangeError(t *testing.T) {
 
 	var cases = []struct {
 		title   string
-		changes map[string]any
+		changes map[string]string
 		message string
 	}{
 		{
 			`schema has no key with the given name`,
-			map[string]any{"xxx": ""},
+			map[string]string{"xxx": ""},
 			"cannot set 'xxx' to '': unknown key",
 		},
 		{
 			`validation fails`,
-			map[string]any{"foo": "yyy"},
+			map[string]string{"foo": "yyy"},
 			"cannot set 'foo' to 'yyy': invalid boolean",
 		},
 		{
 			`custom setter fails`,
-			map[string]any{"egg": "xxx"},
+			map[string]string{"egg": "xxx"},
 			"cannot set 'egg' to 'xxx': boom",
-		},
-		{
-			`non string value`,
-			map[string]any{"egg": 123},
-			"cannot set 'egg': invalid type int",
 		},
 	}
 
@@ -285,9 +275,9 @@ func TestMap_Dump(t *testing.T) {
 	m, err := config.Load(schema, values)
 	assert.NoError(t, err)
 
-	dump := map[string]any{
+	dump := map[string]string{
 		"foo": "hello",
-		"egg": true,
+		"egg": "true",
 	}
 
 	assert.Equal(t, dump, m.Dump())

--- a/lxd/config/map_test.go
+++ b/lxd/config/map_test.go
@@ -102,13 +102,11 @@ func TestChange(t *testing.T) {
 		"bar": {Setter: upperCase},
 		"egg": {Type: config.Bool},
 		"yuk": {Type: config.Bool, Default: "true"},
-		"xyz": {Hidden: true},
 	}
 
 	values := map[string]string{ // Initial values
 		"foo": "hello",
 		"bar": "x",
-		"xyz": "sekret",
 	}
 
 	cases := []struct {
@@ -135,11 +133,6 @@ func TestChange(t *testing.T) {
 			`bool false values are normalized`,
 			map[string]string{"yuk": "0"},
 			map[string]string{"yuk": "false"},
-		},
-		{
-			`the special value 'true' is a passthrough for hidden keys`,
-			map[string]string{"xyz": "true"},
-			map[string]string{"xyz": "sekret"},
 		},
 		{
 			`multiple values are all mutated`,
@@ -257,19 +250,16 @@ func TestMap_ChangeError(t *testing.T) {
 	}
 }
 
-// A Map dump contains only values that differ from their default. Hidden
-// values are obfuscated.
+// A Map dump contains only values that differ from their default.
 func TestMap_Dump(t *testing.T) {
 	schema := config.Schema{
 		"foo": {},
 		"bar": {Default: "x"},
-		"egg": {Hidden: true},
 	}
 
 	values := map[string]string{
 		"foo": "hello",
 		"bar": "x",
-		"egg": "123",
 	}
 
 	m, err := config.Load(schema, values)
@@ -277,7 +267,6 @@ func TestMap_Dump(t *testing.T) {
 
 	dump := map[string]string{
 		"foo": "hello",
-		"egg": "true",
 	}
 
 	assert.Equal(t, dump, m.Dump())

--- a/lxd/config/safe_test.go
+++ b/lxd/config/safe_test.go
@@ -20,5 +20,5 @@ func TestSafeLoad_IgnoreInvalidKeys(t *testing.T) {
 	m, err := config.SafeLoad(schema, values)
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]any{"bar": "x"}, m.Dump())
+	assert.Equal(t, map[string]string{"bar": "x"}, m.Dump())
 }

--- a/lxd/config/schema.go
+++ b/lxd/config/schema.go
@@ -28,8 +28,8 @@ func (s Schema) Keys() []string {
 
 // Defaults returns a map of all key names in the schema along with their default
 // values.
-func (s Schema) Defaults() map[string]any {
-	values := make(map[string]any, len(s))
+func (s Schema) Defaults() map[string]string {
+	values := make(map[string]string, len(s))
 	for name, key := range s {
 		values[name] = key.Default
 	}

--- a/lxd/config/schema.go
+++ b/lxd/config/schema.go
@@ -61,7 +61,6 @@ func (s Schema) assertKeyType(name string, code Type) {
 type Key struct {
 	Type       Type   // Type of the value. It defaults to String.
 	Default    string // If the key is not set in a Map, use this value instead.
-	Hidden     bool   // Hide this key when dumping the object.
 	Deprecated string // Optional message to set if this config value is deprecated.
 
 	// Optional function used to validate the values. It's called by Map

--- a/lxd/config/schema_test.go
+++ b/lxd/config/schema_test.go
@@ -14,7 +14,7 @@ func TestSchema_Defaults(t *testing.T) {
 		"bar": {Default: "x"},
 	}
 
-	values := map[string]any{"foo": "", "bar": "x"}
+	values := map[string]string{"foo": "", "bar": "x"}
 	assert.Equal(t, values, schema.Defaults())
 }
 

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -10,8 +10,8 @@ import (
 	"github.com/canonical/lxd/shared"
 )
 
-func daemonConfigRender(state *state.State) (map[string]any, error) {
-	config := map[string]any{}
+func daemonConfigRender(state *state.State) (map[string]string, error) {
+	config := map[string]string{}
 
 	// Turn the config into a JSON-compatible map.
 	for key, value := range state.GlobalConfig.Dump() {

--- a/lxd/db/cluster/instances.go
+++ b/lxd/db/cluster/instances.go
@@ -77,7 +77,7 @@ type InstanceFilter struct {
 }
 
 // ToAPI converts the database Instance to API type.
-func (i *Instance) ToAPI(ctx context.Context, tx *sql.Tx, globalConfig map[string]any) (*api.Instance, error) {
+func (i *Instance) ToAPI(ctx context.Context, tx *sql.Tx, globalConfig map[string]string) (*api.Instance, error) {
 	profiles, err := GetInstanceProfiles(ctx, tx, i.ID)
 	if err != nil {
 		return nil, err

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1956,17 +1956,7 @@ func distributeImage(ctx context.Context, s *state.State, nodes []string, oldFin
 		if err != nil {
 			logger.Error("Failed to retrieve information about cluster member", logger.Ctx{"err": err, "remote": nodeAddress})
 		} else {
-			vol := ""
-
-			val := resp.Config["storage.images_volume"]
-			if val != nil {
-				var ok bool
-				vol, ok = val.(string)
-				if !ok {
-					return fmt.Errorf("Invalid type for field \"storage.images_volume\"")
-				}
-			}
-
+			vol := resp.Config["storage.images_volume"]
 			skipDistribution := false
 
 			// If storage.images_volume is set on the cluster member, check if

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -509,7 +509,7 @@ func (d *common) deviceVolatileSetFunc(devName string) func(save map[string]stri
 
 // expandConfig applies the config of each profile in order, followed by the local config.
 func (d *common) expandConfig() error {
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if d.state.GlobalConfig != nil {
 		globalConfigDump = d.state.GlobalConfig.Dump()
 	}

--- a/lxd/instance/instancetype/instance_utils.go
+++ b/lxd/instance/instancetype/instance_utils.go
@@ -8,12 +8,12 @@ import (
 )
 
 // ExpandInstanceConfig expands the given instance config with the config values of the given profiles.
-func ExpandInstanceConfig(globalConfig map[string]any, config map[string]string, profiles []api.Profile) map[string]string {
+func ExpandInstanceConfig(globalConfig map[string]string, config map[string]string, profiles []api.Profile) map[string]string {
 	expandedConfig := map[string]string{}
 
 	// Apply global config overriding
 	if globalConfig != nil {
-		globalInstancesMigrationStatefulStr, ok := globalConfig["instances.migration.stateful"].(string)
+		globalInstancesMigrationStatefulStr, ok := globalConfig["instances.migration.stateful"]
 		if ok {
 			globalInstancesMigrationStateful, _ := strconv.ParseBool(globalInstancesMigrationStatefulStr)
 			if globalInstancesMigrationStateful {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1134,7 +1134,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				Reason:        apiScriptlet.InstancePlacementReasonNew,
 			}
 
-			var globalConfigDump map[string]any
+			var globalConfigDump map[string]string
 			if s.GlobalConfig != nil {
 				globalConfigDump = s.GlobalConfig.Dump()
 			}

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -201,8 +201,8 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	// If clustering is enabled, and no cluster.https_address network address
 	// was specified, we fallback to core.https_address.
 	if config.Cluster != nil &&
-		config.Node.Config["core.https_address"] != nil &&
-		config.Node.Config["cluster.https_address"] == nil {
+		config.Node.Config["core.https_address"] != "" &&
+		config.Node.Config["cluster.https_address"] == "" {
 		config.Node.Config["cluster.https_address"] = config.Node.Config["core.https_address"]
 	}
 

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -62,7 +62,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 
 	// Fill in the node configuration
 	config := api.InitLocalPreseed{}
-	config.Config = map[string]any{}
+	config.Config = map[string]string{}
 
 	// Network listening
 	if c.flagNetworkAddress != "" {

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -29,7 +29,7 @@ import (
 func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*api.InitPreseed, error) {
 	// Initialize config
 	config := api.InitPreseed{}
-	config.Node.Config = map[string]any{}
+	config.Node.Config = map[string]string{}
 	config.Node.Networks = []api.InitNetworksProjectPost{}
 	config.Node.StoragePools = []api.StoragePoolsPost{}
 	config.Node.Profiles = []api.ProfilesPost{
@@ -447,7 +447,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 					config.Node.Profiles[0].Devices["eth0"]["nictype"] = "bridged"
 				}
 
-				if config.Node.Config["maas.api.url"] != nil {
+				if config.Node.Config["maas.api.url"] != "" {
 					maasConnect, err := c.global.asker.AskBool("Is this interface connected to your MAAS server? (yes/no) [default=yes]: ", "yes")
 					if err != nil {
 						return err

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -62,7 +62,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		return tx.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
 			// Expand configs so we take into account profile devices.
-			var globalConfigDump map[string]any
+			var globalConfigDump map[string]string
 			if s.GlobalConfig != nil {
 				globalConfigDump = s.GlobalConfig.Dump()
 			}

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -125,17 +125,17 @@ func (c *Config) SyslogSocket() bool {
 
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
-func (c *Config) Dump() map[string]any {
+func (c *Config) Dump() map[string]string {
 	return c.m.Dump()
 }
 
 // Replace the current configuration with the given values.
-func (c *Config) Replace(values map[string]any) (map[string]string, error) {
+func (c *Config) Replace(values map[string]string) (map[string]string, error) {
 	return c.update(values)
 }
 
 // Patch changes only the configuration keys in the given map.
-func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
+func (c *Config) Patch(patch map[string]string) (map[string]string, error) {
 	values := c.Dump() // Use current values as defaults
 	for name, value := range patch {
 		values[name] = value
@@ -144,7 +144,7 @@ func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
 	return c.update(values)
 }
 
-func (c *Config) update(values map[string]any) (map[string]string, error) {
+func (c *Config) update(values map[string]string) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {
 		return nil, err

--- a/lxd/node/config_test.go
+++ b/lxd/node/config_test.go
@@ -19,7 +19,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]any{}, config.Dump())
+	assert.Equal(t, map[string]string{}, config.Dump())
 }
 
 // If the database contains invalid keys, they are ignored.
@@ -36,7 +36,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
-	values := map[string]any{"core.https_address": "127.0.0.1:666"}
+	values := map[string]string{"core.https_address": "127.0.0.1:666"}
 	assert.Equal(t, values, config.Dump())
 }
 
@@ -48,7 +48,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]any{}, config.Dump())
+	assert.Equal(t, map[string]string{}, config.Dump())
 }
 
 // If some previously set values are missing from the ones passed to Replace(),
@@ -60,11 +60,11 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 	require.NoError(t, err)
 
-	changed, err := config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
+	changed, err := config.Replace(map[string]string{"core.https_address": "127.0.0.1:666"})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": "127.0.0.1:666"}, changed)
 
-	changed, err = config.Replace(map[string]any{})
+	changed, err = config.Replace(map[string]string{})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": ""}, changed)
 
@@ -84,10 +84,10 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
+	_, err = config.Replace(map[string]string{"core.https_address": "127.0.0.1:666"})
 	assert.NoError(t, err)
 
-	_, err = config.Patch(map[string]any{})
+	_, err = config.Patch(map[string]string{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "127.0.0.1:666", config.HTTPSAddress())
@@ -120,7 +120,7 @@ func TestHTTPSAddress(t *testing.T) {
 			return err
 		}
 
-		_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
+		_, err = config.Replace(map[string]string{"core.https_address": "127.0.0.1:666"})
 		return err
 	})
 	require.NoError(t, err)
@@ -157,7 +157,7 @@ func TestClusterAddress(t *testing.T) {
 			return err
 		}
 
-		_, err = nodeConfig.Replace(map[string]any{"cluster.https_address": "127.0.0.1:666"})
+		_, err = nodeConfig.Replace(map[string]string{"cluster.https_address": "127.0.0.1:666"})
 		return err
 	})
 	require.NoError(t, err)

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -27,7 +27,7 @@ import (
 // AllowInstanceCreation returns an error if any project-specific limit or
 // restriction is violated when creating a new instance.
 func AllowInstanceCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, req api.InstancesPost) error {
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -236,7 +236,7 @@ func checkRestrictionsOnVolatileConfig(project api.Project, instanceType instanc
 // AllowVolumeCreation returns an error if any project-specific limit or
 // restriction is violated when creating a new custom volume in a project.
 func AllowVolumeCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, req api.StorageVolumesPost) error {
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -274,7 +274,7 @@ func AllowVolumeCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 //
 // If no limit is in place, return -1.
 func GetImageSpaceBudget(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string) (int64, error) {
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -346,7 +346,7 @@ func checkRestrictionsAndAggregateLimits(globalConfig *clusterConfig.Config, tx 
 		return nil
 	}
 
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -884,7 +884,7 @@ func isVMLowLevelOptionForbidden(key string) bool {
 func AllowInstanceUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, instanceName string, req api.InstancePut, currentConfig map[string]string) error {
 	var updatedInstance *api.Instance
 
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -934,7 +934,7 @@ func AllowInstanceUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 // AllowVolumeUpdate returns an error if any project-specific limit or
 // restriction is violated when updating an existing custom volume.
 func AllowVolumeUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, volumeName string, req api.StorageVolumePut, currentConfig map[string]string) error {
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -973,7 +973,7 @@ func AllowVolumeUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, pro
 // AllowProfileUpdate checks that project limits and restrictions are not
 // violated when changing a profile.
 func AllowProfileUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, profileName string, req api.ProfilePut) error {
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -1007,7 +1007,7 @@ func AllowProfileUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, pr
 
 // AllowProjectUpdate checks the new config to be set on a project is valid.
 func AllowProjectUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, config map[string]string, changed []string) error {
-	var globalConfigDump map[string]any
+	var globalConfigDump map[string]string
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -1194,7 +1194,7 @@ type projectInfo struct {
 // If the skipIfNoLimits flag is true, then profiles, instances and volumes
 // won't be loaded if the profile has no limits set on it, and nil will be
 // returned.
-func fetchProject(globalConfig map[string]any, tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*projectInfo, error) {
+func fetchProject(globalConfig map[string]string, tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*projectInfo, error) {
 	ctx := context.Background()
 	dbProject, err := cluster.GetProject(ctx, tx.Tx(), projectName)
 	if err != nil {
@@ -1269,7 +1269,7 @@ func fetchProject(globalConfig map[string]any, tx *db.ClusterTx, projectName str
 
 // Expand the configuration and devices of the given instances, taking the give
 // project profiles into account.
-func expandInstancesConfigAndDevices(globalConfig map[string]any, instances []api.Instance, profiles []api.Profile) ([]api.Instance, error) {
+func expandInstancesConfigAndDevices(globalConfig map[string]string, instances []api.Instance, profiles []api.Profile) ([]api.Instance, error) {
 	expandedInstances := make([]api.Instance, len(instances))
 
 	// Index of all profiles by name.

--- a/lxd/project/state.go
+++ b/lxd/project/state.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetCurrentAllocations returns the current resource utilization for a given project.
-func GetCurrentAllocations(globalConfig map[string]any, ctx context.Context, tx *db.ClusterTx, projectName string) (map[string]api.ProjectStateResource, error) {
+func GetCurrentAllocations(globalConfig map[string]string, ctx context.Context, tx *db.ClusterTx, projectName string) (map[string]api.ProjectStateResource, error) {
 	result := map[string]api.ProjectStateResource{}
 
 	// Get the project.

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -157,8 +157,8 @@ type ServerStorageDriverInfo struct {
 // swagger:model
 type ServerPut struct {
 	// Server configuration map (refer to doc/server.md)
-	// Example: {"core.https_address": ":8443", "core.trust_password": true}
-	Config map[string]any `json:"config" yaml:"config"`
+	// Example: {"core.https_address": ":8443", "core.trust_password": "xyz"}
+	Config map[string]string `json:"config" yaml:"config"`
 }
 
 // ServerUntrusted represents a LXD server for an untrusted client


### PR DESCRIPTION
This PR includes cherry picks from https://github.com/lxc/incus/pull/62, https://github.com/lxc/incus/pull/63 and https://github.com/lxc/incus/pull/64. 

Essentially the concept of hidden config entries is removed and the overall server configuration is normalized to use a `map[string]string` instead of `map[string]any` which was required to support the hiding of passwords using the special `true` indicator as value. 

As we now have the fine grained permission concept in place a user requires at least the `can_edit` entitlement on the `server` entity type in order to view and edit the server configuration. Just by having the `viewer` entitlement on `server` doesn't return the server's configuration.
If the necessary permissions are granted we can also safely return the passwords.