### PR TITLE
Storage: Fix `source.wipe` for lvm and correctly detect raw disks in btrfs

### DIFF
--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -155,7 +155,7 @@ func (d *btrfs) Create() error {
 	}
 
 	loopPath := loopFilePath(d.name)
-	if d.config["source"] == "" || d.config["source"] == loopPath {
+	if d.config["volatile.initial_source"] == "" || d.config["volatile.initial_source"] == loopPath {
 		// Create a loop based pool.
 		d.config["source"] = loopPath
 
@@ -210,6 +210,8 @@ func (d *btrfs) Create() error {
 		if tryExists(fmt.Sprintf("/dev/disk/by-uuid/%s", devUUID)) {
 			// Override the config to use the UUID.
 			d.config["source"] = devUUID
+		} else {
+			d.config["source"] = d.config["volatile.initial_source"]
 		}
 	} else if d.config["source"] != "" {
 		hostPath := shared.HostPath(d.config["source"])

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -215,7 +215,7 @@ func (d *lvm) Create() error {
 
 		// Wipe if requested.
 		if shared.IsTrue(d.config["source.wipe"]) {
-			err := wipeBlockHeaders(d.config["source"])
+			err := wipeBlockHeaders(srcPath)
 			if err != nil {
 				return fmt.Errorf("Failed to wipe headers from disk %q: %w", d.config["source"], err)
 			}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -212,10 +212,17 @@ func tryExists(path string) bool {
 }
 
 // fsUUID returns the filesystem UUID for the given block path.
+// error is returned if the given block device exists but has no UUID.
 func fsUUID(path string) (string, error) {
 	val, err := shared.RunCommand("blkid", "-s", "UUID", "-o", "value", path)
 	if err != nil {
 		return "", err
+	}
+
+	// blkid may return 0 and also produce no output for non-empty devices
+	// without a UUID (e.g. a disk device with an MBR/GPT table)
+	if val == "" {
+		return "", fmt.Errorf("No UUID for device %q", path)
 	}
 
 	return strings.TrimSpace(val), nil

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -126,6 +126,10 @@ test_storage() {
       configure_loop_device loop_file_1 loop_device_1
       # shellcheck disable=SC2154
       lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool2" zfs source="${loop_device_1}"
+      lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool2"
+
+      # Ensure that source.wipe allows the device to be reused
+      lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool2" zfs source="${loop_device_1}" source.wipe=true
 
       # Test that no invalid zfs storage pool configuration keys can be set.
       ! lxc storage create "lxdtest-$(basename "${LXD_DIR}")-invalid-zfs-pool-config" zfs lvm.thinpool_name=bla || false
@@ -157,6 +161,10 @@ test_storage() {
       configure_loop_device loop_file_2 loop_device_2
       # shellcheck disable=SC2154
       lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool4" btrfs source="${loop_device_2}"
+      lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool4"
+
+      # Ensure that source.wipe allows the device to be reused
+      lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool4" btrfs source="${loop_device_2}" source.wipe=true
 
       # Check that we cannot create storage pools inside of ${LXD_DIR} other than ${LXD_DIR}/storage-pools/{pool_name}.
       ! lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool5_under_lxd_dir" btrfs source="${LXD_DIR}" || false
@@ -211,6 +219,10 @@ test_storage() {
       configure_loop_device loop_file_3 loop_device_3
       # shellcheck disable=SC2154
       lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool6" lvm source="${loop_device_3}" volume.size=25MiB
+      lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool6"
+
+      # Ensure that source.wipe allows the device to be reused
+      lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool6" lvm source="${loop_device_3}" source.wipe=true volume.size=25MiB
 
       configure_loop_device loop_file_5 loop_device_5
       # shellcheck disable=SC2154


### PR DESCRIPTION
A few goals here RE #13339:
- Add some minimal tests for `source.wipe` so that the logic there is covered at least a little
- Fix two bugs I found while adding those tests:
  - `wipeBlockHeaders` in the LVM backend was given the wrong parameter (lv name instead of the device path)
  - Btrfs would create a default loop device instead of using `source` when `source` is an empty raw block device or MBR/GPT

The tests I've added wouldn't catch the btrfs bug here since it's not directly relevant to `source.wipe`. See my comment below for more details on why this wasn't caught by the tests sooner.