### PR TITLE
doc: pin version of myst-parser

### DIFF
--- a/doc/.sphinx/build_requirements.py
+++ b/doc/.sphinx/build_requirements.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         requirements.append("sphinxext-opengraph")
 
     if IsMyStParserUsed():
-        requirements.append("myst-parser")
+        requirements.append("myst-parser==2.0.0")
         requirements.append("linkify-it-py")
 
     # removes duplicate entries


### PR DESCRIPTION
myst-parser 3.0.0 causes a build failure - need to investigate more, but pinning the version is a quick workaround.