### PR TITLE
doc: pin version of myst-parser (stable-5.0)

### DIFF
--- a/doc/.sphinx/requirements.txt
+++ b/doc/.sphinx/requirements.txt
@@ -27,7 +27,7 @@ sphinxcontrib-serializinghtml
 sphinxcontrib-jquery
 tornado
 urllib3
-myst-parser
+myst-parser==2.0.0
 sphinx-tabs
 sphinx-reredirects
 linkify-it-py


### PR DESCRIPTION
myst-parser 3.0.0 causes a build failure - need to investigate more, but pinning the version is a quick workaround.