### PR TITLE
doc: unpin version of myst-parser

### DIFF
--- a/doc/.sphinx/build_requirements.py
+++ b/doc/.sphinx/build_requirements.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         requirements.append("sphinxext-opengraph")
 
     if IsMyStParserUsed():
-        requirements.append("myst-parser==2.0.0")
+        requirements.append("myst-parser")
         requirements.append("linkify-it-py")
 
     # removes duplicate entries


### PR DESCRIPTION
The regression in `myst-parser` has been fixed, so we can use the latest version again.