### PR TITLE
Device: Allow specific USB ports to be passed through to instances (from Incus)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,6 +156,8 @@ jobs:
           GITHUB_BEFORE: ${{ github.event.before }}
         run: |
           set -eux
+          sudo chmod o+w ./lxd/metadata/configuration.json
+          sudo chmod o+w ./doc/config_options.txt
           make static-analysis
 
       - name: Unit tests (all)

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2407,3 +2407,8 @@ This extension adds a new image restriction, `requirements.nesting` which when `
 
 Adds the {config:option}`instance-miscellaneous:linux.kernel_modules.load` container configuration option. If the option is set to `ondemand`, the `finit_modules()` syscall is intercepted and a privileged user in the container's user namespace can load the Linux kernel modules specified in the
 allow list {config:option}`instance-miscellaneous:linux.kernel_modules`.
+
+## `device_usb_serial`
+
+This adds new configuration keys `serial`, `busnum` and `devnum` for device type `usb`.
+Feature has been added, to make it possible to distinguish between devices with identical `vendorid` and `productid`.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1567,6 +1567,18 @@ The default is `false`, which means that all devices can be hotplugged.
 
 <!-- config group device-unix-hotplug-device-conf end -->
 <!-- config group device-unix-usb-device-conf start -->
+```{config:option} busnum device-unix-usb-device-conf
+:shortdesc: "The bus number of which the USB device is attached"
+:type: "int"
+
+```
+
+```{config:option} devnum device-unix-usb-device-conf
+:shortdesc: "The device number of the USB device"
+:type: "int"
+
+```
+
 ```{config:option} gid device-unix-usb-device-conf
 :condition: "container"
 :defaultdesc: "`0`"
@@ -1594,6 +1606,12 @@ The default is `false`, which means that all devices can be hotplugged.
 :shortdesc: "Whether this device is required to start the instance"
 :type: "bool"
 The default is `false`, which means that all devices can be hotplugged.
+```
+
+```{config:option} serial device-unix-usb-device-conf
+:shortdesc: "The serial number of the USB device"
+:type: "string"
+
 ```
 
 ```{config:option} uid device-unix-usb-device-conf

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5442,6 +5442,11 @@ definitions:
                 example: "2221"
                 type: string
                 x-go-name: ProductID
+            serial:
+                description: USB serial number
+                example: DAE005fp
+                type: string
+                x-go-name: Serial
             speed:
                 description: Transfer speed (Mbit/s)
                 example: 12

--- a/lxd/device/device_utils_usb_events.go
+++ b/lxd/device/device_utils_usb_events.go
@@ -19,6 +19,7 @@ type USBEvent struct {
 
 	Vendor  string
 	Product string
+	Serial  string
 
 	Path        string
 	Major       uint32
@@ -97,7 +98,7 @@ func USBRunHandlers(state *state.State, event *USBEvent) {
 }
 
 // USBNewEvent instantiates a new USBEvent struct.
-func USBNewEvent(action string, vendor string, product string, major string, minor string, busnum string, devnum string, devname string, ueventParts []string, ueventLen int) (USBEvent, error) {
+func USBNewEvent(action string, vendor string, product string, serial string, major string, minor string, busnum string, devnum string, devname string, ueventParts []string, ueventLen int) (USBEvent, error) {
 	majorInt, err := strconv.ParseUint(major, 10, 32)
 	if err != nil {
 		return USBEvent{}, err
@@ -131,6 +132,7 @@ func USBNewEvent(action string, vendor string, product string, major string, min
 		action,
 		vendor,
 		product,
+		serial,
 		path,
 		uint32(majorInt),
 		uint32(minorInt),

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -184,6 +184,11 @@ func deviceNetlinkListener() (chan []string, chan []string, chan device.USBEvent
 					continue
 				}
 
+				serial, ok := props["SERIAL"]
+				if !ok {
+					continue
+				}
+
 				major, ok := props["MAJOR"]
 				if !ok {
 					continue
@@ -221,6 +226,7 @@ func deviceNetlinkListener() (chan []string, chan []string, chan device.USBEvent
 					 */
 					zeroPad(parts[0], 4),
 					zeroPad(parts[1], 4),
+					serial,
 					major,
 					minor,
 					busnum,

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1820,6 +1820,20 @@
 			"device-conf": {
 				"keys": [
 					{
+						"busnum": {
+							"longdesc": "",
+							"shortdesc": "The bus number of which the USB device is attached",
+							"type": "int"
+						}
+					},
+					{
+						"devnum": {
+							"longdesc": "",
+							"shortdesc": "The device number of the USB device",
+							"type": "int"
+						}
+					},
+					{
 						"gid": {
 							"condition": "container",
 							"defaultdesc": "`0`",
@@ -1850,6 +1864,13 @@
 							"longdesc": "The default is `false`, which means that all devices can be hotplugged.",
 							"shortdesc": "Whether this device is required to start the instance",
 							"type": "bool"
+						}
+					},
+					{
+						"serial": {
+							"longdesc": "",
+							"shortdesc": "The serial number of the USB device",
+							"type": "string"
 						}
 					},
 					{

--- a/lxd/resources/usb.go
+++ b/lxd/resources/usb.go
@@ -81,6 +81,17 @@ func GetUSB() (*api.ResourcesUSB, error) {
 			return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(devicePath, "devnum"), err)
 		}
 
+		// Get serial number
+		deviceSerialPath := filepath.Join(devicePath, "iSerial")
+		if sysfsExists(deviceSerialPath) {
+			content, err := os.ReadFile(deviceSerialPath)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to read %q: %w", deviceSerialPath, err)
+			}
+
+			device.Serial = strings.TrimSpace(string(content))
+		}
+
 		// Get product ID
 		var productID uint64
 

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -843,6 +843,12 @@ type ResourcesUSBDevice struct {
 	// Example: 3
 	DeviceAddress uint64 `json:"device_address" yaml:"device_address"`
 
+	// USB serial number
+	// Example: DAE005fp
+	//
+	// API extension: device_usb_serial.
+	Serial string `json:"serial" yaml:"serial"`
+
 	// List of USB interfaces
 	Interfaces []ResourcesUSBDeviceInterface `json:"interfaces" yaml:"interfaces"`
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -405,6 +405,7 @@ var APIExtensions = []string{
 	"instances_files_modify_permissions",
 	"image_restriction_nesting",
 	"container_syscall_intercept_finit_module",
+	"device_usb_serial",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Adds `serial`,  `busnum` and `devnum` as selector config keys for device type `usb`.

Feature has been added, to make it possible to distinguish between devices with identical `vendorid` and `productid`.

Fixes #13411