### PR TITLE
Device: Don't require `usb` devices to have a `serial`

### DIFF
--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -327,6 +327,11 @@ func (d *usb) loadRawValues(p string) (map[string]string, error) {
 	for k := range values {
 		v, err := os.ReadFile(path.Join(p, k))
 		if err != nil {
+			// Not all devices have a serial file.
+			if k == "serial" && os.IsNotExist(err) {
+				continue
+			}
+
 			return nil, err
 		}
 

--- a/lxd/fsmonitor/drivers/driver_fanotify.go
+++ b/lxd/fsmonitor/drivers/driver_fanotify.go
@@ -144,7 +144,7 @@ func (d *fanotify) getEvents(ctx context.Context, mountFd int) {
 		fd, err := unix.OpenByHandleAt(mountFd, fh, 0)
 		if err != nil {
 			errno := err.(unix.Errno)
-			if errno != unix.ESTALE {
+			if ctx.Err() == nil && errno != unix.ESTALE {
 				d.logger.Error("Failed to open file", logger.Ctx{"err": err})
 			}
 


### PR DESCRIPTION
Fixes regression from https://github.com/canonical/lxd/pull/13419 which was now requiring that USB devices have a `serial` file before considering them as candidates.

But not all USB devices provide a serial.

Also fixes unnecessary error from fanotify during LXD shutdown.