### PR TITLE
LXD: Fix start and stop for `FROZEN` instances

### DIFF
--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -249,6 +249,8 @@ func doInstanceStatePut(inst instance.Instance, req api.InstanceStatePut) error 
 			return inst.Stop(req.Stateful)
 		} else if req.Timeout == 0 {
 			return inst.Stop(false)
+		} else if inst.IsFrozen() {
+			return fmt.Errorf("Cannot shutdown frozen instance (try force to stop)")
 		} else {
 			return inst.Shutdown(timeout)
 		}

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -243,7 +243,12 @@ func doInstanceStatePut(inst instance.Instance, req api.InstanceStatePut) error 
 
 	switch instancetype.InstanceAction(req.Action) {
 	case instancetype.Start:
-		return inst.Start(req.Stateful)
+		if inst.IsFrozen() {
+			return inst.Unfreeze()
+		} else {
+			return inst.Start(req.Stateful)
+		}
+
 	case instancetype.Stop:
 		if req.Stateful {
 			return inst.Stop(req.Stateful)

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -132,7 +132,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 			}
 
 		case instancetype.Start:
-			if inst.IsRunning() {
+			if !inst.IsFrozen() && inst.IsRunning() {
 				continue
 			}
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -387,6 +387,14 @@ test_basic_usage() {
     false
   fi
 
+  # Test freeze/pause
+  lxc freeze foo
+  ! lxc stop foo || false
+  lxc stop -f foo
+  lxc start foo
+  lxc freeze foo
+  lxc start foo
+
   # Test instance types
   lxc launch testimage test-limits -t c0.5-m0.2
   [ "$(lxc config get test-limits limits.cpu)" = "1" ]
@@ -548,6 +556,13 @@ test_basic_usage() {
   lxc start --all
   lxc list | grep c1 | grep RUNNING
   lxc list | grep c2 | grep RUNNING
+
+  lxc freeze c2
+  lxc list | grep c2 | grep FROZEN
+  lxc start --all
+  lxc list | grep c1 | grep RUNNING
+  lxc list | grep c2 | grep RUNNING
+
   ! lxc stop --all c1 || false
   lxc stop --all -f
   lxc list | grep c1 | grep STOPPED


### PR DESCRIPTION
- Prevents stopping frozen instances without supplying `--force` (aka `"timeout": 0` in the API); frozen instances must either be started explicitly before graceful stop or forcefully shut down
  - #12578
- `PUT /instances/{name}/state` with `"action": "start"` now unfreezes frozen instances
- Fixes `lxc start --all` for frozen instances
  - #12491

This was fixed in incus with the same patch as in #12493

Not sure if this warrants an API extension: if users were expecting `start` to fail on frozen instances, then this does break that workflow. Happy to add one if needed.