### PR TITLE
Add `security.protection.start` to optionally block instance start up.

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -239,6 +239,10 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 			return err
 		}
 
+		if shared.IsFalse(current.ExpandedConfig["security.protection.start"]) {
+			return fmt.Errorf(i18n.G("Cannot start instance ")+"\"%s\""+i18n.G("since security.protection.start is false."), nameArg)
+		}
+
 		// "start" for a frozen instance means "unfreeze"
 		if current.StatusCode == api.Frozen {
 			action = "unfreeze"

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -735,6 +735,16 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	//  shortdesc: Whether to protect the file system from being UID/GID shifted
 	"security.protection.shift": validate.Optional(validate.IsBool),
 
+	// lxdmeta:generate(entities=instance; group=security; key=security.protection.start)
+	// Set this option to `false` to prevent the instance from starting up.
+	// ---
+	//  type: bool
+	//  defaultdesc: `true`
+	//  liveupdate: yes
+	//  condition: container
+	//  shortdesc: Whether to protect the file system from being UID/GID shifted
+	"security.protection.start": validate.Optional(validate.IsBool),
+
 	// lxdmeta:generate(entities=instance; group=security; key=security.syscalls.allow)
 	// A `\n`-separated list of syscalls to allow.
 	// This list must be mutually exclusive with `security.syscalls.deny*`.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2468,6 +2468,15 @@
 						}
 					},
 					{
+						"security.protection.start": {
+							"defaultdesc": "`true`",
+							"liveupdate": "yes",
+							"longdesc": "",
+							"shortdesc": "Prevents the instance from starting",
+							"type": "bool"
+						}
+					},
+					{
 						"security.secureboot": {
 							"condition": "virtual machine",
 							"defaultdesc": "`true`",


### PR DESCRIPTION
This PR addresses #12110:
- Adds `security.protection.start` to instance configuration options.
- Throws an error in `lxc start` if a given instance has this option set to `false`, preventing startup.