### PR TITLE
Use `math/rand` where appropriate

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -1144,9 +1144,10 @@ func (c *cmdFileMount) sshSFTPServer(ctx context.Context, instName string, resou
 
 	randString := func(length int) string {
 		var chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0987654321")
+		charsLength := len(chars)
 		randStr := make([]rune, length)
 		for i := range randStr {
-			randStr[i] = chars[rand.Intn(len(chars))]
+			randStr[i] = chars[rand.Intn(charsLength)]
 		}
 
 		return string(randStr)


### PR DESCRIPTION
https://go.dev/blog/chacha8rand prompted me to check where/how `math/rand` was used. AFAICT we are using the right random provider everywhere.

[`randomAddressInSubnet`](https://github.com/canonical/lxd/blob/main/lxd/network/network_utils.go#L719) doesn't needs secure random but this was used due to working with bigInt.