### PR TITLE
Update network_increase_bandwidth.md document with details for u18.04+

### DIFF
--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -29,7 +29,6 @@ Complete the following steps to increase the network bandwidth on the LXD host:
 
        KERNEL=="enp5s0f1", RUN+="/sbin/ip link set %k txqueuelen 10000"
        KERNEL=="lxdbr0", RUN+="/sbin/ip link set %k txqueuelen 10000"
-      
    Apply the above `udev` rules via:
 
         udevadm trigger

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -31,7 +31,7 @@ Complete the following steps to increase the network bandwidth on the LXD host:
 
        sudo udevadm trigger
 
-2. Increase the receive queue length (`net.core.netdev_max_backlog`).
+1. Increase the receive queue length (`net.core.netdev_max_backlog`).
    To make the change permanent, add the following configuration to `/etc/sysctl.conf`:
 
        net.core.netdev_max_backlog = 182757

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -17,7 +17,10 @@ In general, you should use small `txqueuelen` values with slow devices with a hi
 For the `net.core.netdev_max_backlog` value, a good guideline is to use the minimum value of the `net.ipv4.tcp_mem` configuration.
 ```
 
-## Ubuntu >= 18.04: Increase the network bandwidth on the LXD host
+## Increase the network bandwidth on the LXD host
+````{tabs}
+
+```{group-tab} Ubuntu >= 18.04
 
 Complete the following steps to increase the network bandwidth on the LXD host:
 
@@ -39,8 +42,8 @@ Complete the following steps to increase the network bandwidth on the LXD host:
    Apply the above `sysctl.conf` change via:
 
         sysctl -p
-
-## Ubuntu <= 17.04: Increase the network bandwidth on the LXD host
+```
+```{group-tab} Ubuntu <= 17.04
 
 Complete the following steps to increase the network bandwidth on the LXD host:
 
@@ -61,6 +64,9 @@ Complete the following steps to increase the network bandwidth on the LXD host:
    To make the change permanent, add the following configuration to `/etc/sysctl.conf`:
 
        net.core.netdev_max_backlog = 182757
+```
+
+````
 
 ## Increase the transmit queue length on the instances
 

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -77,4 +77,4 @@ To do this, use one of the following methods:
 - Set the `queue.tx.length` device option on the instance profile or configuration.
   For example, to do this for the LXD default profile:
 
-       lxc profile device set default eth0 queue.tx.length "10000" 
+       lxc profile device set default eth0 queue.tx.length "10000"

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -25,7 +25,7 @@ For the `net.core.netdev_max_backlog` value, a good guideline is to use the mini
 Complete the following steps to increase the network bandwidth on the LXD host:
 
 1. Increase the transmit queue length (`txqueuelen`) of both the real NIC (for example, `enp5s0f1`) and the LXD NIC (for example, `lxdbr0`).
-   To make the change permanent, create a file name `/etc/udev/rules.d/60-custom-txqueuelen.rules` with the following content:
+   To make the change permanent, create a file named `/etc/udev/rules.d/60-custom-txqueuelen.rules` with the following content:
 
        KERNEL=="enp5s0f1", RUN+="/sbin/ip link set %k txqueuelen 10000"
        KERNEL=="lxdbr0", RUN+="/sbin/ip link set %k txqueuelen 10000"

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -22,7 +22,7 @@ For the `net.core.netdev_max_backlog` value, a good guideline is to use the mini
 Complete the following steps to increase the network bandwidth on the LXD host:
 
 1. Increase the transmit queue length (`txqueuelen`) of both the real NIC (for example, `enp5s0f1`) and the LXD NIC (for example, `lxdbr0`).
-   To make the change permanent, create file /etc/udev/rules.d/60-custom-txqueuelen.rules with the following:
+   To make the change permanent, create a file name `/etc/udev/rules.d/60-custom-txqueuelen.rules` with the following content:
 
        KERNEL=="enp5s0f1", RUN+="/sbin/ip link set %k txqueuelen 10000"
        KERNEL=="lxdbr0", RUN+="/sbin/ip link set %k txqueuelen 10000"

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -17,7 +17,30 @@ In general, you should use small `txqueuelen` values with slow devices with a hi
 For the `net.core.netdev_max_backlog` value, a good guideline is to use the minimum value of the `net.ipv4.tcp_mem` configuration.
 ```
 
-## Increase the network bandwidth on the LXD host
+## Ubuntu >= 18.04: Increase the network bandwidth on the LXD host
+
+Complete the following steps to increase the network bandwidth on the LXD host:
+
+1. Increase the transmit queue length (`txqueuelen`) of both the real NIC (for example, `enp5s0f1`) and the LXD NIC (for example, `lxdbr0`).
+   To make the change permanent, create file /etc/udev/rules.d/60-custom-txqueuelen.rules with the following:
+
+       KERNEL=="enp5s0f1", RUN+="/sbin/ip link set %k txqueuelen 10000"
+       KERNEL=="lxdbr0", RUN+="/sbin/ip link set %k txqueuelen 10000"
+      
+   Apply the above udev rules via:
+
+       sudo udevadm trigger
+
+2. Increase the receive queue length (`net.core.netdev_max_backlog`).
+   To make the change permanent, add the following configuration to `/etc/sysctl.conf`:
+
+       net.core.netdev_max_backlog = 182757
+
+   Apply the above sysctl.conf change via:
+
+       sudo sysctl -p
+
+## Ubuntu <= 17.04: Increase the network bandwidth on the LXD host
 
 Complete the following steps to increase the network bandwidth on the LXD host:
 
@@ -46,3 +69,6 @@ To do this, use one of the following methods:
 
 - Apply the same changes as described above for the LXD host.
 - Set the `queue.tx.length` device option on the instance profile or configuration.
+  For example, to do this for the LXD default profile:
+
+       sudo lxc profile device set default eth0 queue.tx.length "10000" 

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -18,6 +18,7 @@ For the `net.core.netdev_max_backlog` value, a good guideline is to use the mini
 ```
 
 ## Increase the network bandwidth on the LXD host
+
 ````{tabs}
 
 ```{group-tab} Ubuntu >= 18.04

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -27,7 +27,7 @@ Complete the following steps to increase the network bandwidth on the LXD host:
        KERNEL=="enp5s0f1", RUN+="/sbin/ip link set %k txqueuelen 10000"
        KERNEL=="lxdbr0", RUN+="/sbin/ip link set %k txqueuelen 10000"
       
-   Apply the above udev rules via:
+   Apply the above `udev` rules via:
 
        sudo udevadm trigger
 

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -36,7 +36,7 @@ Complete the following steps to increase the network bandwidth on the LXD host:
 
        net.core.netdev_max_backlog = 182757
 
-   Apply the above sysctl.conf change via:
+   Apply the above `sysctl.conf` change via:
 
        sudo sysctl -p
 

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -29,7 +29,7 @@ Complete the following steps to increase the network bandwidth on the LXD host:
       
    Apply the above `udev` rules via:
 
-       sudo udevadm trigger
+        udevadm trigger
 
 1. Increase the receive queue length (`net.core.netdev_max_backlog`).
    To make the change permanent, add the following configuration to `/etc/sysctl.conf`:
@@ -38,7 +38,7 @@ Complete the following steps to increase the network bandwidth on the LXD host:
 
    Apply the above `sysctl.conf` change via:
 
-       sudo sysctl -p
+        sysctl -p
 
 ## Ubuntu <= 17.04: Increase the network bandwidth on the LXD host
 
@@ -71,4 +71,4 @@ To do this, use one of the following methods:
 - Set the `queue.tx.length` device option on the instance profile or configuration.
   For example, to do this for the LXD default profile:
 
-       sudo lxc profile device set default eth0 queue.tx.length "10000" 
+       lxc profile device set default eth0 queue.tx.length "10000" 


### PR DESCRIPTION
The current document does not work properly for Ubuntu 22.04 and probably any version >= 18.04.

I updated this page to include details on how to do this for versions 18.04+ and kept the original section, renaming that to be for versions <= 17.04.

Also added an example command at the bottom on how to change the queue.tx.length in the default LXD profile so that change would apply to all containers.