### PR TITLE
Finer grain builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run LXD build
         run: |
           set -eux
-          make
+          make lxd
 
       - name: Check lxc/lxd-agent binary sizes
         run: |
@@ -315,7 +315,7 @@ jobs:
       - name: Run LXD build
         run: |
           set -eux
-          make
+          make lxd
 
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -545,7 +545,7 @@ jobs:
           ssh-keyscan git.launchpad.net >> ~/.ssh/known_hosts
           ssh-keygen -qlF git.launchpad.net | grep -xF 'git.launchpad.net RSA SHA256:UNOzlP66WpDuEo34Wgs8mewypV0UzqHLsIFoqwe8dYo'
 
-      - name: Install Go (${{ matrix.go }})
+      - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.x

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ lxd-agent:
 	CGO_ENABLED=0 go install -v -tags agent,netgo ./lxd-agent
 	@echo "LXD agent built successfully"
 
+.PHONY: lxd-benchmark
+lxd-benchmark:
+	CGO_ENABLED=0 go install -v ./lxd-benchmark
+	@echo "LXD benchmark built successfully"
+
 .PHONY: lxd-metadata
 lxd-metadata:
 	CGO_ENABLED=0 go install -v -tags lxd-metadata ./lxd/lxd-metadata

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 default: lxd
 
 .PHONY: all
-all: client lxd lxd-agent lxd-migrate
+all: client lxd lxd-agent lxd-benchmark lxd-migrate
 
 .PHONY: build
 build: lxd

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ ifeq "$(TAG_SQLITE3)" ""
 	@echo "Missing dqlite, run \"make deps\" to setup."
 	exit 1
 endif
-	CGO_ENABLED=0 go install -v -tags lxd-metadata ./lxd/lxd-metadata
 	CC="$(CC)" CGO_LDFLAGS_ALLOW="$(CGO_LDFLAGS_ALLOW)" go install -v -tags "$(TAG_SQLITE3)" $(DEBUG) ./...
 	@echo "LXD built successfully"
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 default: build
 
 .PHONY: build
-build:
+build: lxd-metadata
 ifeq "$(TAG_SQLITE3)" ""
 	@echo "Missing dqlite, run \"make deps\" to setup."
 	exit 1

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ else
 endif
 
 .PHONY: default
-default: lxd
+default: all
 
 .PHONY: all
 all: client lxd lxd-agent lxd-benchmark lxd-migrate

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@ else
 endif
 
 .PHONY: default
-default: build
+default: lxd
 
 .PHONY: build
-build: lxd-metadata
+build: lxd
+.PHONY: lxd
+lxd: lxd-metadata
 ifeq "$(TAG_SQLITE3)" ""
 	@echo "Missing dqlite, run \"make deps\" to setup."
 	exit 1

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,8 @@ ifeq "$(TAG_SQLITE3)" ""
 	@echo "Missing dqlite, run \"make deps\" to setup."
 	exit 1
 endif
-
 	CGO_ENABLED=0 go install -v -tags lxd-metadata ./lxd/lxd-metadata
 	CC="$(CC)" CGO_LDFLAGS_ALLOW="$(CGO_LDFLAGS_ALLOW)" go install -v -tags "$(TAG_SQLITE3)" $(DEBUG) ./...
-	CGO_ENABLED=0 go install -v -tags netgo ./lxd-migrate
-	CGO_ENABLED=0 go install -v -tags agent,netgo ./lxd-agent
 	@echo "LXD built successfully"
 
 .PHONY: client

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ endif
 .PHONY: default
 default: lxd
 
+.PHONY: all
+all: client lxd lxd-agent lxd-migrate
+
 .PHONY: build
 build: lxd
 .PHONY: lxd

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ lxd-agent:
 	CGO_ENABLED=0 go install -v -tags agent,netgo ./lxd-agent
 	@echo "LXD agent built successfully"
 
+.PHONY: lxd-metadata
+lxd-metadata:
+	CGO_ENABLED=0 go install -v -tags lxd-metadata ./lxd/lxd-metadata
+	@echo "LXD metadata built successfully"
+
 .PHONY: lxd-migrate
 lxd-migrate:
 	CGO_ENABLED=0 go install -v -tags netgo ./lxd-migrate


### PR DESCRIPTION
Stop building `lxd-agent` and `lxd-migrate` in the default `make` target.