### PR TITLE
Config: Don't panic and forward errors

### DIFF
--- a/lxd/acme.go
+++ b/lxd/acme.go
@@ -44,7 +44,10 @@ func acmeProvideChallenge(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// This gives me the correct value
-		clusterAddress := s.LocalConfig.ClusterAddress()
+		clusterAddress, err := s.LocalConfig.ClusterAddress()
+		if err != nil {
+			return response.SmartError(err)
+		}
 
 		if clusterAddress != "" && clusterAddress != leader {
 			// Forward the request to the leader
@@ -76,7 +79,10 @@ func acmeProvideChallenge(d *Daemon, r *http.Request) response.Response {
 func autoRenewCertificate(ctx context.Context, d *Daemon, force bool) error {
 	s := d.State()
 
-	domain, email, caURL, agreeToS := s.GlobalConfig.ACME()
+	domain, email, caURL, agreeToS, err := s.GlobalConfig.ACME()
+	if err != nil {
+		return err
+	}
 
 	if domain == "" || email == "" || !agreeToS {
 		return nil
@@ -90,7 +96,10 @@ func autoRenewCertificate(ctx context.Context, d *Daemon, force bool) error {
 		}
 
 		// Figure out our own cluster address.
-		clusterAddress := s.LocalConfig.ClusterAddress()
+		clusterAddress, err := s.LocalConfig.ClusterAddress()
+		if err != nil {
+			return err
+		}
 
 		if clusterAddress != leader {
 			return nil

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -45,7 +45,12 @@ var metricsCmd = APIEndpoint{
 func allowMetrics(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	if !s.GlobalConfig.MetricsAuthentication() {
+	authentication, err := s.GlobalConfig.MetricsAuthentication()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if !authentication {
 		return response.EmptySyncResponse
 	}
 
@@ -349,8 +354,13 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 }
 
 func getFilteredMetrics(s *state.State, r *http.Request, compress bool, metricSet *metrics.MetricSet) response.Response {
+	authentication, err := s.GlobalConfig.MetricsAuthentication()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	// Ignore filtering in case the authentication for metrics is disabled.
-	if !s.GlobalConfig.MetricsAuthentication() {
+	if !authentication {
 		return response.SyncResponsePlain(true, compress, metricSet.String())
 	}
 

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -925,7 +925,12 @@ func projectStateGet(d *Daemon, r *http.Request) response.Response {
 
 	// Get current limits and usage.
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		result, err := projecthelpers.GetCurrentAllocations(s.GlobalConfig.Dump(), ctx, tx, name)
+		dump, err := s.GlobalConfig.Dump()
+		if err != nil {
+			return err
+		}
+
+		result, err := projecthelpers.GetCurrentAllocations(dump, ctx, tx, name)
 		if err != nil {
 			return err
 		}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -96,7 +96,10 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		if p.Config["backups.compression_algorithm"] != "" {
 			compress = p.Config["backups.compression_algorithm"]
 		} else {
-			compress = s.GlobalConfig.BackupsCompressionAlgorithm()
+			compress, err = s.GlobalConfig.BackupsCompressionAlgorithm()
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -433,7 +436,10 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 	if backupRow.CompressionAlgorithm != "" {
 		compress = backupRow.CompressionAlgorithm
 	} else {
-		compress = s.GlobalConfig.BackupsCompressionAlgorithm()
+		compress, err = s.GlobalConfig.BackupsCompressionAlgorithm()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create the target path if needed.

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -375,7 +375,10 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	localHTTPSAddress := s.LocalConfig.HTTPSAddress()
+	localHTTPSAddress, err := s.LocalConfig.HTTPSAddress()
+	if err != nil {
+		return response.SmartError(err)
+	}
 
 	// Quick check.
 	if req.Token && req.Certificate != "" {
@@ -401,7 +404,10 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		secret = config.TrustPassword()
+		secret, err = config.TrustPassword()
+		if err != nil {
+			return err
+		}
 
 		return nil
 	})
@@ -541,7 +547,10 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// If tokens should expire, add the expiry date to the op's metadata.
-		expiry := s.GlobalConfig.RemoteTokenExpiry()
+		expiry, err := s.GlobalConfig.RemoteTokenExpiry()
+		if err != nil {
+			return response.SmartError(err)
+		}
 
 		if expiry != "" {
 			expiresAt, err := shared.GetExpiry(time.Now(), expiry)

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -44,222 +44,345 @@ func Load(ctx context.Context, tx *db.ClusterTx) (*Config, error) {
 }
 
 // BackupsCompressionAlgorithm returns the compression algorithm to use for backups.
-func (c *Config) BackupsCompressionAlgorithm() string {
+func (c *Config) BackupsCompressionAlgorithm() (string, error) {
 	return c.m.GetString("backups.compression_algorithm")
 }
 
 // MetricsAuthentication checks whether metrics API requires authentication.
-func (c *Config) MetricsAuthentication() bool {
+func (c *Config) MetricsAuthentication() (bool, error) {
 	return c.m.GetBool("core.metrics_authentication")
 }
 
 // BGPASN returns the BGP ASN setting.
-func (c *Config) BGPASN() int64 {
+func (c *Config) BGPASN() (int64, error) {
 	return c.m.GetInt64("core.bgp_asn")
 }
 
 // HTTPSAllowedHeaders returns the relevant CORS setting.
-func (c *Config) HTTPSAllowedHeaders() string {
+func (c *Config) HTTPSAllowedHeaders() (string, error) {
 	return c.m.GetString("core.https_allowed_headers")
 }
 
 // HTTPSAllowedMethods returns the relevant CORS setting.
-func (c *Config) HTTPSAllowedMethods() string {
+func (c *Config) HTTPSAllowedMethods() (string, error) {
 	return c.m.GetString("core.https_allowed_methods")
 }
 
 // HTTPSAllowedOrigin returns the relevant CORS setting.
-func (c *Config) HTTPSAllowedOrigin() string {
+func (c *Config) HTTPSAllowedOrigin() (string, error) {
 	return c.m.GetString("core.https_allowed_origin")
 }
 
 // HTTPSAllowedCredentials returns the relevant CORS setting.
-func (c *Config) HTTPSAllowedCredentials() bool {
+func (c *Config) HTTPSAllowedCredentials() (bool, error) {
 	return c.m.GetBool("core.https_allowed_credentials")
 }
 
 // TrustPassword returns the LXD trust password for authenticating clients.
-func (c *Config) TrustPassword() string {
+func (c *Config) TrustPassword() (string, error) {
 	return c.m.GetString("core.trust_password")
 }
 
 // TrustCACertificates returns whether client certificates are checked
 // against a CA.
-func (c *Config) TrustCACertificates() bool {
+func (c *Config) TrustCACertificates() (bool, error) {
 	return c.m.GetBool("core.trust_ca_certificates")
 }
 
 // ProxyHTTPS returns the configured HTTPS proxy, if any.
-func (c *Config) ProxyHTTPS() string {
+func (c *Config) ProxyHTTPS() (string, error) {
 	return c.m.GetString("core.proxy_https")
 }
 
 // ProxyHTTP returns the configured HTTP proxy, if any.
-func (c *Config) ProxyHTTP() string {
+func (c *Config) ProxyHTTP() (string, error) {
 	return c.m.GetString("core.proxy_http")
 }
 
 // ProxyIgnoreHosts returns the configured ignore-hosts proxy setting, if any.
-func (c *Config) ProxyIgnoreHosts() string {
+func (c *Config) ProxyIgnoreHosts() (string, error) {
 	return c.m.GetString("core.proxy_ignore_hosts")
 }
 
 // HTTPSTrustedProxy returns the configured HTTPS trusted proxy setting, if any.
-func (c *Config) HTTPSTrustedProxy() string {
+func (c *Config) HTTPSTrustedProxy() (string, error) {
 	return c.m.GetString("core.https_trusted_proxy")
 }
 
 // MAASController the configured MAAS url and key, if any.
-func (c *Config) MAASController() (apiURL string, apiKey string) {
-	url := c.m.GetString("maas.api.url")
-	key := c.m.GetString("maas.api.key")
-	return url, key
+func (c *Config) MAASController() (apiURL string, apiKey string, err error) {
+	url, err := c.m.GetString("maas.api.url")
+	if err != nil {
+		return "", "", err
+	}
+
+	key, err := c.m.GetString("maas.api.key")
+	if err != nil {
+		return "", "", err
+	}
+
+	return url, key, err
 }
 
 // OfflineThreshold returns the configured heartbeat threshold, i.e. the
 // number of seconds before after which an unresponsive node is considered
 // offline..
-func (c *Config) OfflineThreshold() time.Duration {
-	n := c.m.GetInt64("cluster.offline_threshold")
-	return time.Duration(n) * time.Second
+func (c *Config) OfflineThreshold() (time.Duration, error) {
+	n, err := c.m.GetInt64("cluster.offline_threshold")
+	if err != nil {
+		return 0, err
+	}
+
+	return time.Duration(n) * time.Second, nil
 }
 
 // ImagesMinimalReplica returns the numbers of nodes for cluster images replication.
-func (c *Config) ImagesMinimalReplica() int64 {
+func (c *Config) ImagesMinimalReplica() (int64, error) {
 	return c.m.GetInt64("cluster.images_minimal_replica")
 }
 
 // MaxVoters returns the maximum number of members in a cluster that will be
 // assigned the voter role.
-func (c *Config) MaxVoters() int64 {
+func (c *Config) MaxVoters() (int64, error) {
 	return c.m.GetInt64("cluster.max_voters")
 }
 
 // MaxStandBy returns the maximum number of standby members in a cluster that
 // will be assigned the stand-by role.
-func (c *Config) MaxStandBy() int64 {
+func (c *Config) MaxStandBy() (int64, error) {
 	return c.m.GetInt64("cluster.max_standby")
 }
 
 // NetworkOVNIntegrationBridge returns the integration OVS bridge to use for OVN networks.
-func (c *Config) NetworkOVNIntegrationBridge() string {
+func (c *Config) NetworkOVNIntegrationBridge() (string, error) {
 	return c.m.GetString("network.ovn.integration_bridge")
 }
 
 // NetworkOVNNorthboundConnection returns the OVN northbound database connection string for OVN networks.
-func (c *Config) NetworkOVNNorthboundConnection() string {
+func (c *Config) NetworkOVNNorthboundConnection() (string, error) {
 	return c.m.GetString("network.ovn.northbound_connection")
 }
 
 // NetworkOVNSSL returns all three SSL configuration keys needed for a connection.
-func (c *Config) NetworkOVNSSL() (caCert string, clientCert string, clientKey string) {
-	return c.m.GetString("network.ovn.ca_cert"), c.m.GetString("network.ovn.client_cert"), c.m.GetString("network.ovn.client_key")
+func (c *Config) NetworkOVNSSL() (caCert string, clientCert string, clientKey string, err error) {
+	caCert, err = c.m.GetString("network.ovn.ca_cert")
+	if err != nil {
+		return "", "", "", err
+	}
+
+	clientCert, err = c.m.GetString("network.ovn.client_cert")
+	if err != nil {
+		return "", "", "", err
+	}
+
+	clientKey, err = c.m.GetString("network.ovn.client_key")
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return caCert, clientCert, clientKey, err
 }
 
 // ShutdownTimeout returns the number of minutes to wait for running operation to complete
 // before LXD server shut down.
-func (c *Config) ShutdownTimeout() time.Duration {
-	n := c.m.GetInt64("core.shutdown_timeout")
-	return time.Duration(n) * time.Minute
+func (c *Config) ShutdownTimeout() (time.Duration, error) {
+	n, err := c.m.GetInt64("core.shutdown_timeout")
+	if err != nil {
+		return 0, err
+	}
+
+	return time.Duration(n) * time.Minute, nil
 }
 
 // ImagesDefaultArchitecture returns the default architecture.
-func (c *Config) ImagesDefaultArchitecture() string {
+func (c *Config) ImagesDefaultArchitecture() (string, error) {
 	return c.m.GetString("images.default_architecture")
 }
 
 // ImagesCompressionAlgorithm returns the compression algorithm to use for images.
-func (c *Config) ImagesCompressionAlgorithm() string {
+func (c *Config) ImagesCompressionAlgorithm() (string, error) {
 	return c.m.GetString("images.compression_algorithm")
 }
 
 // ImagesAutoUpdateCached returns whether or not to auto update cached images.
-func (c *Config) ImagesAutoUpdateCached() bool {
+func (c *Config) ImagesAutoUpdateCached() (bool, error) {
 	return c.m.GetBool("images.auto_update_cached")
 }
 
 // ImagesAutoUpdateIntervalHours returns interval in hours at which to look for update to cached images.
-func (c *Config) ImagesAutoUpdateIntervalHours() int64 {
+func (c *Config) ImagesAutoUpdateIntervalHours() (int64, error) {
 	return c.m.GetInt64("images.auto_update_interval")
 }
 
 // ImagesRemoteCacheExpiryDays returns the number of days after which an unused cached remote image will be flushed.
-func (c *Config) ImagesRemoteCacheExpiryDays() int64 {
+func (c *Config) ImagesRemoteCacheExpiryDays() (int64, error) {
 	return c.m.GetInt64("images.remote_cache_expiry")
 }
 
 // InstancesNICHostname returns hostname mode to use for instance NICs.
-func (c *Config) InstancesNICHostname() string {
+func (c *Config) InstancesNICHostname() (string, error) {
 	return c.m.GetString("instances.nic.host_name")
 }
 
 // InstancesPlacementScriptlet returns the instances placement scriptlet source code.
-func (c *Config) InstancesPlacementScriptlet() string {
+func (c *Config) InstancesPlacementScriptlet() (string, error) {
 	return c.m.GetString("instances.placement.scriptlet")
 }
 
 // InstancesMigrationStateful returns the whether or not to auto enable migration.stateful for all VM instances.
-func (c *Config) InstancesMigrationStateful() bool {
+func (c *Config) InstancesMigrationStateful() (bool, error) {
 	return c.m.GetBool("instances.migration.stateful")
 }
 
 // LokiServer returns all the Loki settings needed to connect to a server.
-func (c *Config) LokiServer() (apiURL string, authUsername string, authPassword string, apiCACert string, instance string, logLevel string, labels []string, types []string) {
-	if c.m.GetString("loki.types") != "" {
-		types = strings.Split(c.m.GetString("loki.types"), ",")
+func (c *Config) LokiServer() (apiURL string, authUsername string, authPassword string, apiCACert string, instance string, logLevel string, labels []string, types []string, err error) {
+	typesString, err := c.m.GetString("loki.types")
+	if err != nil {
+		return "", "", "", "", "", "", nil, nil, err
 	}
 
-	if c.m.GetString("loki.labels") != "" {
-		labels = strings.Split(c.m.GetString("loki.labels"), ",")
+	if typesString != "" {
+		types = strings.Split(typesString, ",")
 	}
 
-	return c.m.GetString("loki.api.url"), c.m.GetString("loki.auth.username"), c.m.GetString("loki.auth.password"), c.m.GetString("loki.api.ca_cert"), c.m.GetString("loki.instance"), c.m.GetString("loki.loglevel"), labels, types
+	labelsString, err := c.m.GetString("loki.labels")
+	if err != nil {
+		return "", "", "", "", "", "", nil, nil, err
+	}
+
+	if labelsString != "" {
+		labels = strings.Split(labelsString, ",")
+	}
+
+	apiURL, err = c.m.GetString("loki.api.url")
+	if err != nil {
+		return "", "", "", "", "", "", nil, nil, err
+	}
+
+	authUsername, err = c.m.GetString("loki.auth.username")
+	if err != nil {
+		return "", "", "", "", "", "", nil, nil, err
+	}
+
+	authPassword, err = c.m.GetString("loki.auth.password")
+	if err != nil {
+		return "", "", "", "", "", "", nil, nil, err
+	}
+
+	apiCACert, err = c.m.GetString("loki.api.ca_cert")
+	if err != nil {
+		return "", "", "", "", "", "", nil, nil, err
+	}
+
+	instance, err = c.m.GetString("loki.instance")
+	if err != nil {
+		return "", "", "", "", "", "", nil, nil, err
+	}
+
+	logLevel, err = c.m.GetString("loki.loglevel")
+	if err != nil {
+		return "", "", "", "", "", "", nil, nil, err
+	}
+
+	return apiURL, authUsername, authPassword, apiCACert, instance, logLevel, labels, types, nil
 }
 
 // ACME returns all ACME settings needed for certificate renewal.
-func (c *Config) ACME() (domain string, email string, caURL string, agreeTOS bool) {
-	return c.m.GetString("acme.domain"), c.m.GetString("acme.email"), c.m.GetString("acme.ca_url"), c.m.GetBool("acme.agree_tos")
+func (c *Config) ACME() (domain string, email string, caURL string, agreeTOS bool, err error) {
+	domain, err = c.m.GetString("acme.domain")
+	if err != nil {
+		return "", "", "", false, err
+	}
+
+	email, err = c.m.GetString("acme.email")
+	if err != nil {
+		return "", "", "", false, err
+	}
+
+	caURL, err = c.m.GetString("acme.ca_url")
+	if err != nil {
+		return "", "", "", false, err
+	}
+
+	agreeTOS, err = c.m.GetBool("acme.agree_tos")
+	if err != nil {
+		return "", "", "", false, err
+	}
+
+	return domain, email, caURL, agreeTOS, nil
 }
 
 // ClusterJoinTokenExpiry returns the cluster join token expiry.
-func (c *Config) ClusterJoinTokenExpiry() string {
+func (c *Config) ClusterJoinTokenExpiry() (string, error) {
 	return c.m.GetString("cluster.join_token_expiry")
 }
 
 // RemoteTokenExpiry returns the time after which a remote add token expires.
-func (c *Config) RemoteTokenExpiry() string {
+func (c *Config) RemoteTokenExpiry() (string, error) {
 	return c.m.GetString("core.remote_token_expiry")
 }
 
 // OIDCServer returns all the OpenID Connect settings needed to connect to a server.
-func (c *Config) OIDCServer() (issuer string, clientID string, audience string, groupsClaim string) {
-	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim")
+func (c *Config) OIDCServer() (issuer string, clientID string, audience string, groupsClaim string, err error) {
+	issuer, err = c.m.GetString("oidc.issuer")
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	clientID, err = c.m.GetString("oidc.client.id")
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	audience, err = c.m.GetString("oidc.audience")
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	groupsClaim, err = c.m.GetString("oidc.groups.claim")
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	return issuer, clientID, audience, groupsClaim, nil
 }
 
 // ClusterHealingThreshold returns the configured healing threshold, i.e. the
 // number of seconds after which an offline node will be evacuated automatically. If the config key
 // is set but its value is lower than cluster.offline_threshold it returns
 // the value of cluster.offline_threshold instead. If this feature is disabled, it returns 0.
-func (c *Config) ClusterHealingThreshold() time.Duration {
-	n := c.m.GetInt64("cluster.healing_threshold")
+func (c *Config) ClusterHealingThreshold() (time.Duration, error) {
+	n, err := c.m.GetInt64("cluster.healing_threshold")
+	if err != nil {
+		return 0, err
+	}
+
 	if n == 0 {
-		return 0
+		return 0, nil
 	}
 
 	healingThreshold := time.Duration(n) * time.Second
-	offlineThreshold := c.OfflineThreshold()
-
-	if healingThreshold < offlineThreshold {
-		return offlineThreshold
+	offlineThreshold, err := c.OfflineThreshold()
+	if err != nil {
+		return 0, err
 	}
 
-	return healingThreshold
+	if healingThreshold < offlineThreshold {
+		return offlineThreshold, nil
+	}
+
+	return healingThreshold, nil
 }
 
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
-func (c *Config) Dump() map[string]string {
-	return c.m.Dump()
+func (c *Config) Dump() (map[string]string, error) {
+	m, err := c.m.Dump()
+	if err != nil {
+		return nil, fmt.Errorf("Failed dumping config map: %w", err)
+	}
+
+	return m, nil
 }
 
 // Replace the current configuration with the given values.
@@ -273,7 +396,11 @@ func (c *Config) Replace(values map[string]string) (map[string]string, error) {
 //
 // Return what has actually changed.
 func (c *Config) Patch(patch map[string]string) (map[string]string, error) {
-	values := c.Dump() // Use current values as defaults
+	values, err := c.Dump() // Use current values as defaults
+	if err != nil {
+		return nil, err
+	}
+
 	for name, value := range patch {
 		values[name] = value
 	}

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -325,7 +325,13 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	s := g.state()
 
 	if s.LocalConfig != nil {
-		localClusterAddress = s.LocalConfig.ClusterAddress()
+		clusterAddress, err := s.LocalConfig.ClusterAddress()
+		if err != nil {
+			logger.Error("Failed to get local cluster address", logger.Ctx{"err": err})
+			return
+		}
+
+		localClusterAddress = clusterAddress
 	}
 
 	var members []db.NodeInfo

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -294,9 +294,19 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 		Name: name,
 	}
 
-	if count > 1 && voters < int(state.GlobalConfig.MaxVoters()) {
+	maxVoters, err := state.GlobalConfig.MaxVoters()
+	if err != nil {
+		return nil, err
+	}
+
+	maxStandBy, err := state.GlobalConfig.MaxStandBy()
+	if err != nil {
+		return nil, err
+	}
+
+	if count > 1 && voters < int(maxVoters) {
 		node.Role = db.RaftVoter
-	} else if standbys < int(state.GlobalConfig.MaxStandBy()) {
+	} else if standbys < int(maxStandBy) {
 		node.Role = db.RaftStandBy
 	}
 
@@ -1100,10 +1110,20 @@ func newRolesChanges(state *state.State, gateway *Gateway, nodes []db.RaftNode, 
 		}
 	}
 
+	maxVoters, err := state.GlobalConfig.MaxVoters()
+	if err != nil {
+		return nil, err
+	}
+
+	maxStandBy, err := state.GlobalConfig.MaxStandBy()
+	if err != nil {
+		return nil, err
+	}
+
 	roles := &app.RolesChanges{
 		Config: app.RolesConfig{
-			Voters:   int(state.GlobalConfig.MaxVoters()),
-			StandBys: int(state.GlobalConfig.MaxStandBy()),
+			Voters:   int(maxVoters),
+			StandBys: int(maxStandBy),
 		},
 		State: cluster,
 	}

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -55,7 +55,12 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 			return fmt.Errorf("Failed to fetch node configuration: %w", err)
 		}
 
-		localClusterAddress = config.ClusterAddress()
+		clusterAddress, err := config.ClusterAddress()
+		if err != nil {
+			return err
+		}
+
+		localClusterAddress = clusterAddress
 
 		// Make sure node-local database state is in order.
 		err = membershipCheckNodeStateForBootstrapOrJoin(ctx, tx, localClusterAddress)
@@ -336,7 +341,12 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 			return fmt.Errorf("Failed to fetch node configuration: %w", err)
 		}
 
-		localClusterAddress = config.ClusterAddress()
+		clusterAddress, err := config.ClusterAddress()
+		if err != nil {
+			return err
+		}
+
+		localClusterAddress = clusterAddress
 
 		// Make sure node-local database state is in order.
 		err = membershipCheckNodeStateForBootstrapOrJoin(ctx, tx, localClusterAddress)
@@ -672,7 +682,12 @@ func NotifyHeartbeat(state *state.State, gateway *Gateway) {
 			return err
 		}
 
-		localClusterAddress = config.ClusterAddress()
+		clusterAddress, err := config.ClusterAddress()
+		if err != nil {
+			return err
+		}
+
+		localClusterAddress = clusterAddress
 
 		return nil
 	})
@@ -754,7 +769,12 @@ func Rebalance(state *state.State, gateway *Gateway, unavailableMembers []string
 		return "", nodes, nil
 	}
 
-	localClusterAddress := state.LocalConfig.ClusterAddress()
+	clusterAddress, err := state.LocalConfig.ClusterAddress()
+	if err != nil {
+		return "", nil, err
+	}
+
+	localClusterAddress := clusterAddress
 
 	// Check if we have a spare node that we can promote to the missing role.
 	candidateAddress := candidates[0].Address

--- a/lxd/cluster/notify.go
+++ b/lxd/cluster/notify.go
@@ -31,7 +31,10 @@ const (
 // NewNotifier builds a Notifier that can be used to notify other peers using
 // the given policy.
 func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *shared.CertInfo, policy NotifierPolicy) (Notifier, error) {
-	localClusterAddress := state.LocalConfig.ClusterAddress()
+	localClusterAddress, err := state.LocalConfig.ClusterAddress()
+	if err != nil {
+		return nil, err
+	}
 
 	// Fast-track the case where we're not clustered at all.
 	if localClusterAddress == "" {
@@ -39,7 +42,6 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 		return nullNotifier, nil
 	}
 
-	var err error
 	var members []db.NodeInfo
 	var offlineThreshold time.Duration
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/config/errors.go
+++ b/lxd/config/errors.go
@@ -14,7 +14,7 @@ type Error struct {
 
 // Error implements the error interface.
 func (e Error) Error() string {
-	message := fmt.Sprintf("cannot set '%s'", e.Name)
+	message := fmt.Sprintf("Cannot set '%s'", e.Name)
 	if e.Value != nil {
 		message += fmt.Sprintf(" to '%v'", e.Value)
 	}
@@ -30,7 +30,7 @@ type ErrorList []*Error
 func (l ErrorList) Error() string {
 	switch len(l) {
 	case 0:
-		return "no errors"
+		return "No errors"
 	case 1:
 		return l[0].Error()
 	}

--- a/lxd/config/errors_internal_test.go
+++ b/lxd/config/errors_internal_test.go
@@ -13,5 +13,5 @@ func TestErrorList_Error(t *testing.T) {
 	errors.add("foo", "xxx", "boom")
 	errors.add("bar", "yyy", "ugh")
 	errors.sort()
-	assert.EqualError(t, errors, "cannot set 'bar' to 'yyy': ugh (and 1 more errors)")
+	assert.EqualError(t, errors, "Cannot set 'bar' to 'yyy': ugh (and 1 more errors)")
 }

--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -47,7 +47,7 @@ func (m *Map) Change(changes map[string]string) (map[string]string, error) {
 		// Ensure that we were actually passed a string.
 		s := reflect.ValueOf(change)
 		if s.Kind() != reflect.String {
-			errors.add(name, nil, fmt.Sprintf("invalid type %s", s.Kind()))
+			errors.add(name, nil, fmt.Sprintf("Invalid type %s", s.Kind()))
 			continue
 		}
 
@@ -168,7 +168,7 @@ func (m *Map) GetInt64(name string) (int64, error) {
 
 	n, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to convert to int64: %w", err))
+		return 0, fmt.Errorf("Failed to convert to int64: %w", err)
 	}
 
 	return n, nil
@@ -242,7 +242,7 @@ func (m *Map) set(name string, value string, initial bool) (bool, error) {
 
 	key, ok := m.schema[name]
 	if !ok {
-		return false, fmt.Errorf("unknown key")
+		return false, fmt.Errorf("Unknown key")
 	}
 
 	// When unsetting a config key, the value argument will be empty.

--- a/lxd/config/safe_test.go
+++ b/lxd/config/safe_test.go
@@ -20,5 +20,7 @@ func TestSafeLoad_IgnoreInvalidKeys(t *testing.T) {
 	m, err := config.SafeLoad(schema, values)
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]string{"bar": "x"}, m.Dump())
+	dump, err := m.Dump()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"bar": "x"}, dump)
 }

--- a/lxd/config/schema.go
+++ b/lxd/config/schema.go
@@ -41,7 +41,7 @@ func (s Schema) Defaults() map[string]string {
 func (s Schema) getKey(name string) (Key, error) {
 	key, ok := s[name]
 	if !ok {
-		return Key{}, fmt.Errorf("Not found in schema", name)
+		return Key{}, fmt.Errorf("Not found in schema")
 	}
 
 	return key, nil
@@ -108,21 +108,21 @@ func (v *Key) validate(value string) error {
 	case String:
 	case Bool:
 		if !shared.ValueInSlice(strings.ToLower(value), booleans) {
-			return fmt.Errorf("invalid boolean")
+			return fmt.Errorf("Invalid boolean")
 		}
 
 	case Int64:
 		_, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			return fmt.Errorf("invalid integer")
+			return fmt.Errorf("Invalid integer")
 		}
 
 	default:
-		panic(fmt.Sprintf("unexpected value type: %d", v.Type))
+		return fmt.Errorf("Unexpected value type: %d", v.Type)
 	}
 
 	if v.Deprecated != "" && value != v.Default {
-		return fmt.Errorf("deprecated: %s", v.Deprecated)
+		return fmt.Errorf("Deprecated: %s", v.Deprecated)
 	}
 
 	// Run external validation function

--- a/lxd/config/schema.go
+++ b/lxd/config/schema.go
@@ -37,23 +37,29 @@ func (s Schema) Defaults() map[string]string {
 	return values
 }
 
-// Get the Key associated with the given name, or panic.
-func (s Schema) mustGetKey(name string) Key {
+// Gets the Key associated with the given name or return an error.
+func (s Schema) getKey(name string) (Key, error) {
 	key, ok := s[name]
 	if !ok {
-		panic(fmt.Sprintf("attempt to access unknown key '%s'", name))
+		return Key{}, fmt.Errorf("Not found in schema", name)
 	}
 
-	return key
+	return key, nil
 }
 
-// Assert that the Key with the given name as the given type. Panic if no Key
-// with such name exists, or if it does not match the tiven type.
-func (s Schema) assertKeyType(name string, code Type) {
-	key := s.mustGetKey(name)
-	if key.Type != code {
-		panic(fmt.Sprintf("key '%s' has type code %d, not %d", name, key.Type, code))
+// Assert that the Key with the given name as the given type.
+// Return error if no key with such name exists, or if it does not match the given type.
+func (s Schema) assertKeyType(name string, code Type) error {
+	key, err := s.getKey(name)
+	if err != nil {
+		return fmt.Errorf("Failed to get key %q: %w", name, err)
 	}
+
+	if key.Type != code {
+		return fmt.Errorf("Key %q has type code %d, not %d", name, key.Type, code)
+	}
+
+	return nil
 }
 
 // Key defines the type of the value of a particular config key, along with

--- a/lxd/config/schema_internal_test.go
+++ b/lxd/config/schema_internal_test.go
@@ -55,15 +55,17 @@ var validateErrorCases = []struct {
 	value   string
 	message string
 }{
-	{Key{Type: Int64}, "1.2", "invalid integer"},
-	{Key{Type: Bool}, "yyy", "invalid boolean"},
+	{Key{Type: Int64}, "1.2", "Invalid integer"},
+	{Key{Type: Bool}, "yyy", "Invalid boolean"},
 	{Key{Validator: func(string) error { return fmt.Errorf("ugh") }}, "", "ugh"},
-	{Key{Deprecated: "don't use this"}, "foo", "deprecated: don't use this"},
+	{Key{Deprecated: "don't use this"}, "foo", "Deprecated: don't use this"},
 }
 
-// If a value has an expected kind code, a panic is thrown.
+// If a value has an expected kind code, an error is returned.
 func TestKey_UnexpectedKind(t *testing.T) {
 	value := Key{Type: 999}
-	f := func() { _ = value.validate("foo") }
-	assert.PanicsWithValue(t, "unexpected value type: 999", f)
+	err := value.validate("foo")
+	if assert.Error(t, err) {
+		assert.Equal(t, err.Error(), "Unexpected value type: 999")
+	}
 }

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -137,7 +137,10 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 	// server/protocol/alias, regardless of whether it's stale or
 	// not (we can assume that it will be not *too* stale since
 	// auto-update is on).
-	interval := s.GlobalConfig.ImagesAutoUpdateIntervalHours()
+	interval, err := s.GlobalConfig.ImagesAutoUpdateIntervalHours()
+	if err != nil {
+		return nil, err
+	}
 
 	if args.PreferCached && interval > 0 && alias != fp {
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -29,8 +29,15 @@ func daemonStorageVolumesUnmount(s *state.State) error {
 			return err
 		}
 
-		storageBackups = nodeConfig.StorageBackupsVolume()
-		storageImages = nodeConfig.StorageImagesVolume()
+		storageBackups, err = nodeConfig.StorageBackupsVolume()
+		if err != nil {
+			return err
+		}
+
+		storageImages, err = nodeConfig.StorageImagesVolume()
+		if err != nil {
+			return err
+		}
 
 		return nil
 	})
@@ -85,8 +92,15 @@ func daemonStorageMount(s *state.State) error {
 			return err
 		}
 
-		storageBackups = nodeConfig.StorageBackupsVolume()
-		storageImages = nodeConfig.StorageImagesVolume()
+		storageBackups, err = nodeConfig.StorageBackupsVolume()
+		if err != nil {
+			return err
+		}
+
+		storageImages, err = nodeConfig.StorageImagesVolume()
+		if err != nil {
+			return err
+		}
 
 		return nil
 	})

--- a/lxd/device/device_common.go
+++ b/lxd/device/device_common.go
@@ -101,7 +101,10 @@ func (d *deviceCommon) Remove() error {
 // Accepts optional hwaddr MAC address to use for generating the interface name in mac mode.
 // In mac mode the interface prefix is always "lxd".
 func (d *deviceCommon) generateHostName(prefix string, hwaddr string) (string, error) {
-	hostNameMode := d.state.GlobalConfig.InstancesNICHostname()
+	hostNameMode, err := d.state.GlobalConfig.InstancesNICHostname()
+	if err != nil {
+		return "", err
+	}
 
 	// Handle instances.nic.host_name mac mode if a MAC address has been supplied.
 	if hostNameMode == "mac" && hwaddr != "" {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -368,7 +368,10 @@ func (d *nicOVN) validateEnvironment() error {
 		return fmt.Errorf("Requires name property to start")
 	}
 
-	integrationBridge := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+	integrationBridge, err := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+	if err != nil {
+		return err
+	}
 
 	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", integrationBridge)) {
 		return fmt.Errorf("OVS integration bridge device %q doesn't exist", integrationBridge)
@@ -428,7 +431,10 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 				}
 			}
 
-			integrationBridge := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+			integrationBridge, err := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+			if err != nil {
+				return nil, err
+			}
 
 			// Find free VF exclusively.
 			network.SRIOVVirtualFunctionMutex.Lock()
@@ -480,7 +486,10 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 				}
 			}
 
-			integrationBridge := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+			integrationBridge, err := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+			if err != nil {
+				return nil, err
+			}
 
 			// Find free VF exclusively.
 			network.SRIOVVirtualFunctionMutex.Lock()
@@ -862,7 +871,10 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 	// as if the instance is being migrated, this can cause port conflicts in OVN if the instance comes up on
 	// another LXD host later.
 	if integrationBridgeNICName != "" {
-		integrationBridge := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+		integrationBridge, err := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+		if err != nil {
+			return nil, err
+		}
 
 		// Detach host-side end of veth pair from OVS integration bridge.
 		err = ovs.BridgePortDelete(integrationBridge, integrationBridgeNICName)
@@ -1143,7 +1155,10 @@ func (d *nicOVN) setupHostNIC(hostName string, ovnPortName openvswitch.OVNSwitch
 	}
 
 	// Attach host side veth interface to bridge.
-	integrationBridge := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+	integrationBridge, err := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
+	if err != nil {
+		return nil, err
+	}
 
 	ovs := openvswitch.NewOVS()
 	err = ovs.BridgePortAdd(integrationBridge, hostName, true)

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -511,7 +511,11 @@ func (d *common) deviceVolatileSetFunc(devName string) func(save map[string]stri
 func (d *common) expandConfig() error {
 	var globalConfigDump map[string]string
 	if d.state.GlobalConfig != nil {
-		globalConfigDump = d.state.GlobalConfig.Dump()
+		var err error
+		globalConfigDump, err = d.state.GlobalConfig.Dump()
+		if err != nil {
+			return err
+		}
 	}
 
 	d.expandedConfig = instancetype.ExpandInstanceConfig(globalConfigDump, d.localConfig, d.profiles)
@@ -840,7 +844,10 @@ func (d *common) getStartupSnapNameAndExpiry(inst instance.Instance) (string, *t
 // Internal MAAS handling.
 func (d *common) maasUpdate(inst instance.Instance, oldDevices map[string]map[string]string) error {
 	// Check if MAAS is configured
-	maasURL, _ := d.state.GlobalConfig.MAASController()
+	maasURL, _, err := d.state.GlobalConfig.MAASController()
+	if err != nil {
+		return err
+	}
 
 	if maasURL == "" {
 		return nil
@@ -936,7 +943,10 @@ func (d *common) maasInterfaces(inst instance.Instance, devices map[string]map[s
 }
 
 func (d *common) maasRename(inst instance.Instance, newName string) error {
-	maasURL, _ := d.state.GlobalConfig.MAASController()
+	maasURL, _, err := d.state.GlobalConfig.MAASController()
+	if err != nil {
+		return err
+	}
 
 	if maasURL == "" {
 		return nil
@@ -968,7 +978,10 @@ func (d *common) maasRename(inst instance.Instance, newName string) error {
 }
 
 func (d *common) maasDelete(inst instance.Instance) error {
-	maasURL, _ := d.state.GlobalConfig.MAASController()
+	maasURL, _, err := d.state.GlobalConfig.MAASController()
+	if err != nil {
+		return err
+	}
 
 	if maasURL == "" {
 		return nil

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -294,7 +294,10 @@ func doInstancesGet(s *state.State, r *http.Request) (any, error) {
 			filteredProjects = []string{projectName}
 		}
 
-		offlineThreshold := s.GlobalConfig.OfflineThreshold()
+		offlineThreshold, err := s.GlobalConfig.OfflineThreshold()
+		if err != nil {
+			return err
+		}
 
 		memberAddressInstances, err = tx.GetInstancesByMemberAddress(ctx, offlineThreshold, filteredProjects, instanceType)
 		if err != nil {

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -210,7 +210,10 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Get local cluster address.
-		localClusterAddress := s.LocalConfig.ClusterAddress()
+		localClusterAddress, err := s.LocalConfig.ClusterAddress()
+		if err != nil {
+			return err
+		}
 
 		// Record the results.
 		failures := map[string]error{}

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -82,7 +82,10 @@ func (c *cmdActivateifneeded) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	localHTTPAddress := localConfig.HTTPSAddress()
+	localHTTPAddress, err := localConfig.HTTPSAddress()
+	if err != nil {
+		return err
+	}
 
 	// Look for network socket
 	if localHTTPAddress != "" {

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -138,7 +138,11 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		clusterAddress := config.ClusterAddress()
+		clusterAddress, err := config.ClusterAddress()
+		if err != nil {
+			return err
+		}
+
 		if clusterAddress == "" {
 			return fmt.Errorf(`Can't edit cluster configuration as server isn't clustered (missing "cluster.https_address" config)`)
 		}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1818,7 +1818,10 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		}
 
 		// Setup clustered DNS.
-		localClusterAddress := n.state.LocalConfig.ClusterAddress()
+		localClusterAddress, err := n.state.LocalConfig.ClusterAddress()
+		if err != nil {
+			return err
+		}
 
 		// If clusterAddress is non-empty, this indicates the intention for this node to be
 		// part of a cluster and so we should ensure that dnsmasq and forkdns are started
@@ -2384,7 +2387,10 @@ func (n *bridge) HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error {
 	}
 
 	addresses := []string{}
-	localClusterAddress := n.state.LocalConfig.ClusterAddress()
+	localClusterAddress, err := n.state.LocalConfig.ClusterAddress()
+	if err != nil {
+		return err
+	}
 
 	n.logger.Info("Refreshing forkdns peers")
 

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -64,7 +64,11 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 			// Expand configs so we take into account profile devices.
 			var globalConfigDump map[string]string
 			if s.GlobalConfig != nil {
-				globalConfigDump = s.GlobalConfig.Dump()
+				var err error
+				globalConfigDump, err = s.GlobalConfig.Dump()
+				if err != nil {
+					return err
+				}
 			}
 
 			dbInst.Config = instancetype.ExpandInstanceConfig(globalConfigDump, dbInst.Config, dbInst.Profiles)

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -181,7 +181,11 @@ type OVNRouterPeering struct {
 // NewOVN initialises new OVN client wrapper with the connection set in network.ovn.northbound_connection config.
 func NewOVN(s *state.State) (*OVN, error) {
 	// Get database connection strings.
-	nbConnection := s.GlobalConfig.NetworkOVNNorthboundConnection()
+	nbConnection, err := s.GlobalConfig.NetworkOVNNorthboundConnection()
+	if err != nil {
+		return nil, err
+	}
+
 	sbConnection, err := NewOVS().OVNSouthboundDBRemoteAddress()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get OVN southbound connection string: %w", err)
@@ -195,7 +199,10 @@ func NewOVN(s *state.State) (*OVN, error) {
 
 	// If using SSL, then get the CA and client key pair.
 	if strings.Contains(nbConnection, "ssl:") {
-		sslCACert, sslClientCert, sslClientKey := s.GlobalConfig.NetworkOVNSSL()
+		sslCACert, sslClientCert, sslClientKey, err := s.GlobalConfig.NetworkOVNSSL()
+		if err != nil {
+			return nil, err
+		}
 
 		if sslCACert == "" {
 			content, err := os.ReadFile("/etc/ovn/ovn-central.crt")

--- a/lxd/node/config_test.go
+++ b/lxd/node/config_test.go
@@ -17,9 +17,11 @@ func TestConfigLoad_Initial(t *testing.T) {
 	defer cleanup()
 
 	config, err := node.ConfigLoad(context.Background(), tx)
-
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{}, config.Dump())
+
+	dump, err := config.Dump()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{}, dump)
 }
 
 // If the database contains invalid keys, they are ignored.
@@ -34,10 +36,12 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	config, err := node.ConfigLoad(context.Background(), tx)
-
 	require.NoError(t, err)
+
 	values := map[string]string{"core.https_address": "127.0.0.1:666"}
-	assert.Equal(t, values, config.Dump())
+	dump, err := config.Dump()
+	require.NoError(t, err)
+	assert.Equal(t, values, dump)
 }
 
 // Triggers can be specified to execute custom code on config key changes.
@@ -46,9 +50,11 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	defer cleanup()
 
 	config, err := node.ConfigLoad(context.Background(), tx)
-
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{}, config.Dump())
+
+	dump, err := config.Dump()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{}, dump)
 }
 
 // If some previously set values are missing from the ones passed to Replace(),
@@ -68,7 +74,9 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": ""}, changed)
 
-	assert.Equal(t, "", config.HTTPSAddress())
+	address, err := config.HTTPSAddress()
+	assert.NoError(t, err)
+	assert.Equal(t, "", address)
 
 	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
@@ -90,7 +98,9 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	_, err = config.Patch(map[string]string{})
 	assert.NoError(t, err)
 
-	assert.Equal(t, "127.0.0.1:666", config.HTTPSAddress())
+	address, err := config.HTTPSAddress()
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:666", address)
 
 	values, err := tx.Config(context.Background())
 	require.NoError(t, err)
@@ -111,8 +121,9 @@ func TestHTTPSAddress(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	address, err := config.HTTPSAddress()
 	require.NoError(t, err)
-	assert.Equal(t, "", config.HTTPSAddress())
+	assert.Equal(t, "", address)
 
 	err = nodeDB.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		config, err = node.ConfigLoad(ctx, tx)
@@ -131,8 +142,9 @@ func TestHTTPSAddress(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	address, err = config.HTTPSAddress()
 	require.NoError(t, err)
-	assert.Equal(t, "127.0.0.1:666", config.HTTPSAddress())
+	assert.Equal(t, "127.0.0.1:666", address)
 }
 
 // The cluster.https_address config key is fetched from the db with a new
@@ -149,7 +161,9 @@ func TestClusterAddress(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, "", nodeConfig.ClusterAddress())
+	address, err := nodeConfig.ClusterAddress()
+	require.NoError(t, err)
+	assert.Equal(t, "", address)
 
 	err = nodeDB.Transaction(context.Background(), func(ctx context.Context, tx *db.NodeTx) error {
 		nodeConfig, err = node.ConfigLoad(ctx, tx)
@@ -168,5 +182,7 @@ func TestClusterAddress(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, "127.0.0.1:666", nodeConfig.ClusterAddress())
+	address, err = nodeConfig.ClusterAddress()
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:666", address)
 }

--- a/lxd/node/raft.go
+++ b/lxd/node/raft.go
@@ -35,7 +35,10 @@ func DetermineRaftNode(ctx context.Context, tx *db.NodeTx) (*db.RaftNode, error)
 		return nil, err
 	}
 
-	address := config.ClusterAddress()
+	address, err := config.ClusterAddress()
+	if err != nil {
+		return nil, err
+	}
 
 	// If cluster.https_address is the empty string, then this LXD instance is
 	// not running in clustering mode.

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -654,8 +654,15 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Get local address.
-	localClusterAddress := s.LocalConfig.ClusterAddress()
-	offlineThreshold := s.GlobalConfig.OfflineThreshold()
+	localClusterAddress, err := s.LocalConfig.ClusterAddress()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	offlineThreshold, err := s.GlobalConfig.OfflineThreshold()
+	if err != nil {
+		return response.SmartError(err)
+	}
 
 	memberOnline := func(memberAddress string) bool {
 		for _, member := range members {
@@ -781,8 +788,15 @@ func operationsGetByType(s *state.State, r *http.Request, projectName string, op
 	}
 
 	// Get local address.
-	localClusterAddress := s.LocalConfig.ClusterAddress()
-	offlineThreshold := s.GlobalConfig.OfflineThreshold()
+	localClusterAddress, err := s.LocalConfig.ClusterAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	offlineThreshold, err := s.GlobalConfig.OfflineThreshold()
+	if err != nil {
+		return nil, err
+	}
 
 	memberOnline := func(memberAddress string) bool {
 		for _, member := range members {
@@ -1176,7 +1190,11 @@ func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
 		s := d.State()
 
-		localClusterAddress := s.LocalConfig.ClusterAddress()
+		localClusterAddress, err := s.LocalConfig.ClusterAddress()
+		if err != nil {
+			logger.Error("Failed to get local cluster member address", logger.Ctx{"err": err})
+			return
+		}
 
 		leader, err := d.gateway.LeaderAddress()
 		if err != nil {
@@ -1226,9 +1244,12 @@ func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {
 func autoRemoveOrphanedOperations(ctx context.Context, s *state.State) error {
 	logger.Debug("Removing orphaned operations across the cluster")
 
-	offlineThreshold := s.GlobalConfig.OfflineThreshold()
+	offlineThreshold, err := s.GlobalConfig.OfflineThreshold()
+	if err != nil {
+		return err
+	}
 
-	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		members, err := tx.GetNodes(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed getting cluster members: %w", err)

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -421,7 +421,12 @@ func patchDBNodesAutoInc(name string, d *Daemon) error {
 			return err
 		}
 
-		if localConfig.ClusterAddress() == leaderAddress {
+		clusterAddress, err := localConfig.ClusterAddress()
+		if err != nil {
+			return err
+		}
+
+		if clusterAddress == leaderAddress {
 			break // Apply change on leader node.
 		}
 

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -29,7 +29,11 @@ import (
 func AllowInstanceCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, req api.InstancesPost) error {
 	var globalConfigDump map[string]string
 	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
+		var err error
+		globalConfigDump, err = globalConfig.Dump()
+		if err != nil {
+			return err
+		}
 	}
 
 	info, err := fetchProject(globalConfigDump, tx, projectName, true)
@@ -238,7 +242,11 @@ func checkRestrictionsOnVolatileConfig(project api.Project, instanceType instanc
 func AllowVolumeCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, req api.StorageVolumesPost) error {
 	var globalConfigDump map[string]string
 	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
+		var err error
+		globalConfigDump, err = globalConfig.Dump()
+		if err != nil {
+			return err
+		}
 	}
 
 	info, err := fetchProject(globalConfigDump, tx, projectName, true)
@@ -276,7 +284,11 @@ func AllowVolumeCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 func GetImageSpaceBudget(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string) (int64, error) {
 	var globalConfigDump map[string]string
 	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
+		var err error
+		globalConfigDump, err = globalConfig.Dump()
+		if err != nil {
+			return -1, err
+		}
 	}
 
 	info, err := fetchProject(globalConfigDump, tx, projectName, true)
@@ -348,7 +360,11 @@ func checkRestrictionsAndAggregateLimits(globalConfig *clusterConfig.Config, tx 
 
 	var globalConfigDump map[string]string
 	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
+		var err error
+		globalConfigDump, err = globalConfig.Dump()
+		if err != nil {
+			return err
+		}
 	}
 
 	instances, err := expandInstancesConfigAndDevices(globalConfigDump, info.Instances, info.Profiles)
@@ -886,7 +902,11 @@ func AllowInstanceUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 
 	var globalConfigDump map[string]string
 	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
+		var err error
+		globalConfigDump, err = globalConfig.Dump()
+		if err != nil {
+			return err
+		}
 	}
 
 	info, err := fetchProject(globalConfigDump, tx, projectName, true)
@@ -936,7 +956,11 @@ func AllowInstanceUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 func AllowVolumeUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, volumeName string, req api.StorageVolumePut, currentConfig map[string]string) error {
 	var globalConfigDump map[string]string
 	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
+		var err error
+		globalConfigDump, err = globalConfig.Dump()
+		if err != nil {
+			return err
+		}
 	}
 
 	info, err := fetchProject(globalConfigDump, tx, projectName, true)
@@ -975,7 +999,11 @@ func AllowVolumeUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, pro
 func AllowProfileUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, profileName string, req api.ProfilePut) error {
 	var globalConfigDump map[string]string
 	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
+		var err error
+		globalConfigDump, err = globalConfig.Dump()
+		if err != nil {
+			return err
+		}
 	}
 
 	info, err := fetchProject(globalConfigDump, tx, projectName, true)
@@ -1009,7 +1037,11 @@ func AllowProfileUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, pr
 func AllowProjectUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, config map[string]string, changed []string) error {
 	var globalConfigDump map[string]string
 	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
+		var err error
+		globalConfigDump, err = globalConfig.Dump()
+		if err != nil {
+			return err
+		}
 	}
 
 	info, err := fetchProject(globalConfigDump, tx, projectName, false)

--- a/lxd/scriptlet/instance_placement.go
+++ b/lxd/scriptlet/instance_placement.go
@@ -273,11 +273,16 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 			return fmt.Errorf("Failed getting max member version: %w", err)
 		}
 
+		offlineThreshold, err := s.GlobalConfig.OfflineThreshold()
+		if err != nil {
+			return err
+		}
+
 		args := db.NodeInfoArgs{
 			LeaderAddress:        leaderAddress,
 			FailureDomains:       failureDomains,
 			MemberFailureDomains: memberFailureDomains,
-			OfflineThreshold:     s.GlobalConfig.OfflineThreshold(),
+			OfflineThreshold:     offlineThreshold,
 			MaxMemberVersion:     maxVersion,
 			RaftNodes:            raftNodes,
 		}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -1090,8 +1090,15 @@ func VolumeUsedByDaemon(s *state.State, poolName string, volumeName string) (boo
 			return err
 		}
 
-		storageBackups = nodeConfig.StorageBackupsVolume()
-		storageImages = nodeConfig.StorageImagesVolume()
+		storageBackups, err = nodeConfig.StorageBackupsVolume()
+		if err != nil {
+			return err
+		}
+
+		storageImages, err = nodeConfig.StorageImagesVolume()
+		if err != nil {
+			return err
+		}
 
 		return nil
 	})

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1403,6 +1403,11 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	if s.ServerClustered && target != "" && req.Source.Location != "" && req.Migration {
 		var sourceNodeOffline bool
 
+		offlineThreshold, err := s.GlobalConfig.OfflineThreshold()
+		if err != nil {
+			return response.SmartError(err)
+		}
+
 		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Load source node.
 			nodeInfo, err := tx.GetNodeByName(ctx, req.Source.Location)
@@ -1423,7 +1428,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 				return fmt.Errorf("Failed to get source member for %q: %w", sourceAddress, err)
 			}
 
-			sourceNodeOffline = sourceMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold())
+			sourceNodeOffline = sourceMemberInfo.IsOffline(offlineThreshold)
 
 			return nil
 		})
@@ -1520,7 +1525,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		if targetMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold()) {
+		if targetMemberInfo.IsOffline(offlineThreshold) {
 			return response.BadRequest(fmt.Errorf("Target cluster member is offline"))
 		}
 
@@ -1703,7 +1708,12 @@ func migrateStorageVolume(s *state.State, r *http.Request, sourceVolumeName stri
 }
 
 func storageVolumePostClusteringMigrate(s *state.State, r *http.Request, srcPool storagePools.Pool, srcProjectName string, srcVolumeName string, newPoolName string, newProjectName string, newVolumeName string, srcMember db.NodeInfo, newMember db.NodeInfo, volumeOnly bool) (func(op *operations.Operation) error, error) {
-	srcMemberOffline := srcMember.IsOffline(s.GlobalConfig.OfflineThreshold())
+	offlineThreshold, err := s.GlobalConfig.OfflineThreshold()
+	if err != nil {
+		return nil, err
+	}
+
+	srcMemberOffline := srcMember.IsOffline(offlineThreshold)
 
 	// Make sure that the source member is online if we end up being called from another member after a
 	// redirection due to the source member being offline.

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1251,9 +1251,14 @@ func pruneExpiredAndAutoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, t
 
 				memberCount = len(members)
 
+				offlineThreshold, err := s.GlobalConfig.OfflineThreshold()
+				if err != nil {
+					return err
+				}
+
 				// Filter to online members.
 				for _, member := range members {
-					if member.IsOffline(s.GlobalConfig.OfflineThreshold()) {
+					if member.IsOffline(offlineThreshold) {
 						continue
 					}
 


### PR DESCRIPTION
This removes several `panic()` calls from the `lxd/config` package when trying to read configuration and instead forward the errors.

As the changes feel quite invasive now I am wondering if a better approach would be to instead perform the validation when setting the respective value. A read operation would then just return a valid value. This would also be in line with what we do for storage driver configuration (there we just read from `map[string]string`).

Any thoughts?