### PR TITLE
Storage: Round ZFS volume sizes to nearest 16KiB

### DIFF
--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -551,7 +551,7 @@ func (d *common) DeleteBucketKey(bucket Volume, keyName string, op *operations.O
 
 // roundVolumeBlockSizeBytes returns size rounded to the nearest multiple of MinBlockBoundary bytes that is equal
 // to or larger than sizeBytes.
-func (d *common) roundVolumeBlockSizeBytes(sizeBytes int64) int64 {
+func (d *common) roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) int64 {
 	// QEMU requires image files to be in traditional storage block boundaries.
 	// We use 8k here to ensure our images are compatible with all of our backend drivers.
 	if sizeBytes < MinBlockBoundary {

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -549,23 +549,12 @@ func (d *common) DeleteBucketKey(bucket Volume, keyName string, op *operations.O
 	return nil
 }
 
-// roundVolumeBlockSizeBytes returns size rounded to the nearest multiple of MinBlockBoundary bytes that is equal
-// to or larger than sizeBytes.
+// roundVolumeBlockSizeBytes returns sizeBytes rounded up to the next multiple
+// of MinBlockBoundary.
 func (d *common) roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) int64 {
 	// QEMU requires image files to be in traditional storage block boundaries.
 	// We use 8k here to ensure our images are compatible with all of our backend drivers.
-	if sizeBytes < MinBlockBoundary {
-		sizeBytes = MinBlockBoundary
-	}
-
-	roundedSizeBytes := int64(sizeBytes/MinBlockBoundary) * MinBlockBoundary
-
-	// Ensure the rounded size is at least the size specified in sizeBytes.
-	if roundedSizeBytes < sizeBytes {
-		roundedSizeBytes += MinBlockBoundary
-	}
-
-	return roundedSizeBytes
+	return roundAbove(MinBlockBoundary, sizeBytes)
 }
 
 func (d *common) isBlockBacked(vol Volume) bool {

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -503,6 +503,8 @@ func (d *lvm) Delete(op *operations.Operation) error {
 	return nil
 }
 
+// Validate checks that all provide keys are supported and that no conflicting
+// or missing configuration is present.
 func (d *lvm) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
 		"size": validate.Optional(validate.IsSize),

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -782,21 +782,10 @@ func (d *lvm) GetResources() (*api.ResourcesStoragePool, error) {
 	return &res, nil
 }
 
-// roundVolumeBlockSizeBytes returns size rounded to the nearest multiple of the volume group extent size that is
-// equal to or larger than sizeBytes.
+// roundVolumeBlockSizeBytes returns sizeBytes rounded up to the next multiple
+// of the volume group extent size.
 func (d *lvm) roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) int64 {
 	// Get the volume group's physical extent size, and use that as minimum size.
 	vgExtentSize, _ := d.volumeGroupExtentSize(d.config["lvm.vg_name"])
-	if sizeBytes < vgExtentSize {
-		sizeBytes = vgExtentSize
-	}
-
-	roundedSizeBytes := int64(sizeBytes/vgExtentSize) * vgExtentSize
-
-	// Ensure the rounded size is at least the size specified in sizeBytes.
-	if roundedSizeBytes < sizeBytes {
-		roundedSizeBytes += vgExtentSize
-	}
-
-	return roundedSizeBytes
+	return roundAbove(vgExtentSize, sizeBytes)
 }

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -784,7 +784,7 @@ func (d *lvm) GetResources() (*api.ResourcesStoragePool, error) {
 
 // roundVolumeBlockSizeBytes returns size rounded to the nearest multiple of the volume group extent size that is
 // equal to or larger than sizeBytes.
-func (d *lvm) roundVolumeBlockSizeBytes(sizeBytes int64) int64 {
+func (d *lvm) roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) int64 {
 	// Get the volume group's physical extent size, and use that as minimum size.
 	vgExtentSize, _ := d.volumeGroupExtentSize(d.config["lvm.vg_name"])
 	if sizeBytes < vgExtentSize {

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -755,16 +755,5 @@ func (d *zfs) roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) int64 {
 		minBlockSize = 16 * 1024
 	}
 
-	if sizeBytes < minBlockSize {
-		sizeBytes = minBlockSize
-	}
-
-	roundedSizeBytes := int64(sizeBytes/minBlockSize) * minBlockSize
-
-	// Ensure the rounded size is at least the size specified in sizeBytes.
-	if roundedSizeBytes < sizeBytes {
-		roundedSizeBytes += minBlockSize
-	}
-
-	return roundedSizeBytes
+	return roundAbove(minBlockSize, sizeBytes)
 }

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -623,6 +623,7 @@ func (d *zfs) Unmount() (bool, error) {
 	return true, nil
 }
 
+// GetResources returns utilization statistics for the storage pool.
 func (d *zfs) GetResources() (*api.ResourcesStoragePool, error) {
 	// Get the total amount of space.
 	availableStr, err := d.getDatasetProperty(d.config["zfs.pool_name"], "available")
@@ -655,7 +656,8 @@ func (d *zfs) GetResources() (*api.ResourcesStoragePool, error) {
 	return &res, nil
 }
 
-// MigrationType returns the type of transfer methods to be used when doing migrations between pools in preference order.
+// MigrationTypes returns the type of transfer methods to be used when doing
+// migrations between pools in preference order.
 func (d *zfs) MigrationTypes(contentType ContentType, refresh bool, copySnapshots bool) []migration.Type {
 	var rsyncFeatures []string
 

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -82,8 +82,6 @@ func (d *zfs) createDataset(dataset string, options ...string) error {
 }
 
 func (d *zfs) createVolume(dataset string, size int64, options ...string) error {
-	size = d.roundVolumeBlockSizeBytes(size)
-
 	args := []string{"create", "-s", "-V", fmt.Sprintf("%d", size)}
 	for _, option := range options {
 		args = append(args, "-o")

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1024,7 +1024,7 @@ func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser,
 			return fmt.Errorf("Failed sending ZFS migration header: %w", err)
 		}
 
-		err = conn.Close() //End the frame.
+		err = conn.Close() // End the frame.
 		if err != nil {
 			return fmt.Errorf("Failed closing ZFS migration header frame: %w", err)
 		}
@@ -2517,7 +2517,7 @@ func (d *zfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs 
 			return fmt.Errorf("Failed sending ZFS migration header: %w", err)
 		}
 
-		err = conn.Close() //End the frame.
+		err = conn.Close() // End the frame.
 		if err != nil {
 			return fmt.Errorf("Failed closing ZFS migration header frame: %w", err)
 		}
@@ -3187,7 +3187,7 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 	return cleanup, nil
 }
 
-// UnmountVolume simulates unmounting a volume snapshot.
+// UnmountVolumeSnapshot simulates unmounting a volume snapshot.
 func (d *zfs) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
 	unlock, err := snapVol.MountLock()
 	if err != nil {

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -28,7 +28,7 @@ type Driver interface {
 	// Internal.
 	Info() Info
 	HasVolume(vol Volume) (bool, error)
-	roundVolumeBlockSizeBytes(sizeBytes int64) int64
+	roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) int64
 	isBlockBacked(vol Volume) bool
 
 	// Export struct details.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -876,3 +876,19 @@ func wipeBlockHeaders(path string) error {
 func IsContentBlock(contentType ContentType) bool {
 	return contentType == ContentTypeBlock || contentType == ContentTypeISO
 }
+
+// roundAbove returns the next multiple of `above` greater than `val`.
+func roundAbove(above, val int64) int64 {
+	if val < above {
+		val = above
+	}
+
+	rounded := int64(val/above) * above
+
+	// Ensure the rounded size is at least x.
+	if rounded < val {
+		rounded += above
+	}
+
+	return rounded
+}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -819,18 +819,20 @@ func loopFileSizeDefault() (uint64, error) {
 // It tries to enable direct I/O if supported.
 func loopDeviceSetup(sourcePath string) (string, error) {
 	out, err := shared.RunCommand("losetup", "--find", "--nooverlap", "--direct-io=on", "--show", sourcePath)
-	if err != nil {
-		if strings.Contains(err.Error(), "direct io") || strings.Contains(err.Error(), "Invalid argument") {
-			out, err = shared.RunCommand("losetup", "--find", "--nooverlap", "--show", sourcePath)
-			if err != nil {
-				return "", err
-			}
-		} else {
-			return "", err
-		}
+	if err == nil {
+		return strings.TrimSpace(out), nil
 	}
 
-	return strings.TrimSpace(out), nil
+	if !(strings.Contains(err.Error(), "direct io") || strings.Contains(err.Error(), "Invalid argument")) {
+		return "", err
+	}
+
+	out, err = shared.RunCommand("losetup", "--find", "--nooverlap", "--show", sourcePath)
+	if err == nil {
+		return strings.TrimSpace(out), nil
+	}
+
+	return "", err
 }
 
 // loopFileAutoDetach enables auto detach mode for a loop device.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -327,7 +327,7 @@ func ensureVolumeBlockFile(vol Volume, path string, sizeBytes int64, allowUnsafe
 	}
 
 	// Get rounded block size to avoid QEMU boundary issues.
-	sizeBytes = vol.driver.roundVolumeBlockSizeBytes(sizeBytes)
+	sizeBytes = vol.driver.roundVolumeBlockSizeBytes(vol, sizeBytes)
 
 	if shared.PathExists(path) {
 		fi, err := os.Stat(path)

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -520,7 +520,7 @@ func (v Volume) ConfigSizeFromSource(srcVol Volume) (string, error) {
 		// directly usable with the same size setting without also rounding for this check.
 		// Because we are not altering the actual size returned to use for the new volume, this will not
 		// affect storage drivers that do not use rounding.
-		volSizeBytes = v.driver.roundVolumeBlockSizeBytes(volSizeBytes)
+		volSizeBytes = v.driver.roundVolumeBlockSizeBytes(v, volSizeBytes)
 
 		// The volume/pool specified size is smaller than image minimum size. We must not continue as
 		// these specified sizes provide protection against unpacking a massive image and filling the pool.

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -45,6 +45,10 @@ test_storage() {
   [ "$(lxc storage volume get "$storage_pool" "$storage_volume" snapshots.expiry)" = "3d" ]
   lxc storage volume delete "$storage_pool" "$storage_volume"
 
+  # Ensure non-power-of-two sizes are rounded appropriately (most relevant for zfs)
+  lxc storage volume create "$storage_pool" "$storage_volume" --type=block size=13GB
+  lxc storage volume delete "$storage_pool" "$storage_volume"
+
   lxc storage delete "$storage_pool"
 
   # Test btrfs resize


### PR DESCRIPTION
This rounds ZFS volume sizes using `zfs.blocksize` or the openzfs default 16KiB instead of LXD's default 8KiB. Reported in #13420.

It looks like the default was changed in OpenZFS in Q3 2021: https://github.com/openzfs/zfs/pull/12406

I'm not super pleased with the refactor of `roundVolumeBlockSizeBytes` to take a `vol Volume`, but we need a reference to the volume in order to query its config keys. This seemed like the least invasive way to accomplish it.

The new test fails before patches and passes after.