### PR TITLE
lxc: Introduce support for Tegra iGPU passthrough

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1868,6 +1868,20 @@ The specified version expression is used to set `libnvidia-container NVIDIA_REQU
 The specified version expression is used to set `libnvidia-container NVIDIA_REQUIRE_DRIVER`.
 ```
 
+```{config:option} nvidia.require.tegra instance-nvidia
+:condition: "container"
+:defaultdesc: "empty"
+:liveupdate: "no"
+:shortdesc: "How to configure Tegra iGPU passthrough"
+:type: "string"
+The specified option is used to set the custom `NVIDIA_REQUIRE_TEGRA` environment variable used by the Nvidia LXC hook to set up a Tegra iGPU passthrough.
+The possible values are `base` (only the base `l4t.csv` file will be used to bind mount the devices, libraries and symlinks into the container. You can have an example overview of it [here](https://github.com/OE4T/meta-tegra/blob/master/recipes-bsp/tegra-binaries/tegra-configs/l4t.csv))
+and `all` (all the CSV files in `/etc/nvidia-container-runtime/` will be used to bind mount the devices, libraries and symlinks into the container).
+
+See more information for Jetson configuration [here](https://docs.nvidia.com/jetson/archives/r35.3.1/DeveloperGuide/text/RM/PackageManifest.html?highlight=csv#:~:text=etc/nvidia%2Dcontainer%2Druntime/host%2Dfiles%2Dfor%2Dcontainer.d/l4t,Jetson%20Linux%20device%20nodes%20for%20use%20in%20a%20Docker%20container)
+and an example Tegra CSV file [here](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/test/input/csv_samples/jetson.csv)
+```
+
 ```{config:option} nvidia.runtime instance-nvidia
 :condition: "container"
 :defaultdesc: "`false`"

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1102,6 +1102,20 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 			}
 		}
 
+		nvidiaRequireTegra := d.expandedConfig["nvidia.require.tegra"]
+		if nvidiaRequireTegra != "" {
+			if nvidiaRequireTegra == "base" {
+				nvidiaRequireTegra = "base-only"
+			} else if nvidiaRequireTegra == "all" {
+				nvidiaRequireTegra = "csv-mounts=all"
+			}
+
+			err = lxcSetConfigItem(cc, "lxc.environment", fmt.Sprintf("NVIDIA_REQUIRE_TEGRA=%s", nvidiaRequireTegra))
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		err = lxcSetConfigItem(cc, "lxc.hook.mount", hookPath)
 		if err != nil {
 			return nil, err

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -647,6 +647,21 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	//  shortdesc: Required driver version
 	"nvidia.require.driver": validate.IsAny,
 
+	// lxdmeta:generate(entities=instance; group=nvidia; key=nvidia.require.tegra)
+	// The specified option is used to set the custom `NVIDIA_REQUIRE_TEGRA` environment variable used by the Nvidia LXC hook to set up a Tegra iGPU passthrough.
+	// The possible values are `base` (only the base `l4t.csv` file will be used to bind mount the devices, libraries and symlinks into the container. You can have an example overview of it [here](https://github.com/OE4T/meta-tegra/blob/master/recipes-bsp/tegra-binaries/tegra-configs/l4t.csv))
+	// and `all` (all the CSV files in `/etc/nvidia-container-runtime/` will be used to bind mount the devices, libraries and symlinks into the container).
+	//
+	// See more information for Jetson configuration [here](https://docs.nvidia.com/jetson/archives/r35.3.1/DeveloperGuide/text/RM/PackageManifest.html?highlight=csv#:~:text=etc/nvidia%2Dcontainer%2Druntime/host%2Dfiles%2Dfor%2Dcontainer.d/l4t,Jetson%20Linux%20device%20nodes%20for%20use%20in%20a%20Docker%20container)
+	// and an example Tegra CSV file [here](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/test/input/csv_samples/jetson.csv)
+	// ---
+	//  type: string
+	//  defaultdesc: empty
+	//  liveupdate: no
+	//  condition: container
+	//  shortdesc: How to configure Tegra iGPU passthrough
+	"nvidia.require.tegra": validate.Optional(validate.IsOneOf("base", "all")),
+
 	// Caller is responsible for full validation of any raw.* value.
 
 	// lxdmeta:generate(entities=instance; group=raw; key=raw.lxc)

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2146,6 +2146,16 @@
 						}
 					},
 					{
+						"nvidia.require.tegra": {
+							"condition": "container",
+							"defaultdesc": "empty",
+							"liveupdate": "no",
+							"longdesc": "The specified option is used to set the custom `NVIDIA_REQUIRE_TEGRA` environment variable used by the Nvidia LXC hook to set up a Tegra iGPU passthrough.\nThe possible values are `base` (only the base `l4t.csv` file will be used to bind mount the devices, libraries and symlinks into the container. You can have an example overview of it [here](https://github.com/OE4T/meta-tegra/blob/master/recipes-bsp/tegra-binaries/tegra-configs/l4t.csv))\nand `all` (all the CSV files in `/etc/nvidia-container-runtime/` will be used to bind mount the devices, libraries and symlinks into the container).\n\nSee more information for Jetson configuration [here](https://docs.nvidia.com/jetson/archives/r35.3.1/DeveloperGuide/text/RM/PackageManifest.html?highlight=csv#:~:text=etc/nvidia%2Dcontainer%2Druntime/host%2Dfiles%2Dfor%2Dcontainer.d/l4t,Jetson%20Linux%20device%20nodes%20for%20use%20in%20a%20Docker%20container)\nand an example Tegra CSV file [here](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/test/input/csv_samples/jetson.csv)",
+							"shortdesc": "How to configure Tegra iGPU passthrough",
+							"type": "string"
+						}
+					},
+					{
 						"nvidia.runtime": {
 							"condition": "container",
 							"defaultdesc": "`false`",


### PR DESCRIPTION
JIRA thread: https://warthogs.atlassian.net/browse/PF-4666)

# Part I : we won't need `nvidia-ctk` (in the current state of things)

First, there seems to be a misunderstanding in the JIRA ticket about `nvidia-ctk`. Let's start over in detailing what's currently used in LXD/LXC:

* LXC has a 'hook' file located at `hooks/nvidia` that configure GPU support using the `nvidia-container-cli` tool. My understanding is that it is used to expose NVIDIA GPU drivers and capabilities to an LXC container by configuring the container’s root filesystem before it is started. The tool enters the container's namespace using the specified PID or the current process’s parent, ensuring that all operations are performed in the correct context and it binds the specified GPU device nodes (e.g., /dev/nvidia0) into the container’s root filesystem. This allows the containerized applications to interact with the GPU hardware directly. The tool also binds necessary GPU libraries (e.g., `libcuda.so`) into the container’s library path, ensuring that GPU-accelerated applications can locate and use these libraries.

This tool will soon become deprecated and a new project emerged to centralize the use of NVIDIA devices within containers: the [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit/tree/main) project.

Now, let's explain what's inside it. `nvidia-container-toolkit` contains:

* the `runtime`, which is a shim for OCI-compliant low-level runtimes such as `runc` or `crun`. This is of course specific to OCI-compliant container management software like Containerd or CRI-O. This 'runtime' comes along with a set of binaries:
    * `nvidia-container-runtime` (and its flavours, e.g: `.legacy`, `.cdi` for different OCI runtime shims that have very different architectural differences) to build and run an OCI runtime with NVIDIA devices mounted in the runc/crun-based container. Most of the time, the OCI container management system like Docker, Podman, etc. already integrated it on their side so you don't have to use this tool yourself (but rather pass a CLI parameter to docker or podman) but you can also use it yourself and the tool will use `runc` for its base runtime.
    * `nvidia-ctk` to manage different configurations of `nvidia-container-runtime` following the OCI standard spec.
    * **Finally, you have the last tool called `nvidia-container-runtime-hook`. This one does not use the OCI runtime at all and at the moment... just re-use `nvidia-container-cli` with a thin wrapper of CLI logic on top of it! I believe that is what we want to use and not `nvidia-ctk` or `nvidia-container-runtime`.**

For now, it is unclear on why they kept this dependency for `nvidia-container-cli` in the new `nvidia-container-runtime-hook` tool. Maybe they'll change that in the future (that is probably a question we could ask them). I noticed that they ported the `dxcore` (whatever it means) logic from the library side of `libnvidia-container` to `nvidia-container-toolkit` (in `internal/dxcore`).

## Conclusion of part I

We could perfectly use the `nvidia-container-runtime-hook` tool (part of the new repository), BUT it is for now a wrapper around `nvidia-container-cli` (the supposedly deprecated tool). They are probably in the process of porting the C library to Go in the new repository. I don't know. But for now, only the OCI runtime logic is implemented, which is not what we use in LXC.

In the end, we would still need to install the `nvidia-container-cli` as part of our snap deployment PLUS the `nvidia-container-toolkit` dependency. In my opinion, we should rather wait for NVIDIA to port their `libnvidia-container` logic to the new repo anc continue as is on our side for now.

# Part II : enabling support for Tegra iGPU with the current `nvidia-container-cli`

This should be largely documented in this PR's commits, but long story short, we should be able to enable Tegra iGPU passthrough through 'require' options passed to `nvidia-container-cli` (these weren't just used before now); it also takes into account that the Jetson system acting as the LXD host is well-configured (with the right CSV files in `/etc/nvidia-container-runtime/` folder).

I mark this PR as draft as I don't own a Jetson system myself and will need to test the logic of this PR with the real hardware.