### PR TITLE
Network: Work around OVN lb-add bug that allows multiple Load_Balancer records to be created with same name

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4916,7 +4916,7 @@ func (n *ovn) ForwardCreate(forward api.NetworkForwardsPost, clientType request.
 
 		vips := n.forwardFlattenVIPs(net.ParseIP(forward.ListenAddress), net.ParseIP(forward.Config["target_address"]), portMaps)
 
-		err = client.LoadBalancerApply(n.getLoadBalancerName(forward.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, []openvswitch.OVNSwitch{n.getIntSwitchName()}, vips...)
+		err = client.LoadBalancerApply(n.getLoadBalancerName(forward.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, vips...)
 		if err != nil {
 			return nil, fmt.Errorf("Failed applying OVN load balancer: %w", err)
 		}
@@ -4998,7 +4998,7 @@ func (n *ovn) ForwardUpdate(listenAddress string, req api.NetworkForwardPut, cli
 		}
 
 		vips := n.forwardFlattenVIPs(net.ParseIP(newForward.ListenAddress), net.ParseIP(newForward.Config["target_address"]), portMaps)
-		err = client.LoadBalancerApply(n.getLoadBalancerName(newForward.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, []openvswitch.OVNSwitch{n.getIntSwitchName()}, vips...)
+		err = client.LoadBalancerApply(n.getLoadBalancerName(newForward.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, vips...)
 		if err != nil {
 			return fmt.Errorf("Failed applying OVN load balancer: %w", err)
 		}
@@ -5008,7 +5008,7 @@ func (n *ovn) ForwardUpdate(listenAddress string, req api.NetworkForwardPut, cli
 			portMaps, err := n.forwardValidate(net.ParseIP(curForward.ListenAddress), curForward.Writable())
 			if err == nil {
 				vips := n.forwardFlattenVIPs(net.ParseIP(curForward.ListenAddress), net.ParseIP(curForward.Config["target_address"]), portMaps)
-				_ = client.LoadBalancerApply(n.getLoadBalancerName(curForward.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, []openvswitch.OVNSwitch{n.getIntSwitchName()}, vips...)
+				_ = client.LoadBalancerApply(n.getLoadBalancerName(curForward.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, vips...)
 				_ = n.forwardBGPSetupPrefixes()
 			}
 		})
@@ -5289,7 +5289,7 @@ func (n *ovn) LoadBalancerCreate(loadBalancer api.NetworkLoadBalancersPost, clie
 
 		vips := n.loadBalancerFlattenVIPs(net.ParseIP(loadBalancer.ListenAddress), portMaps)
 
-		err = client.LoadBalancerApply(n.getLoadBalancerName(loadBalancer.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, []openvswitch.OVNSwitch{n.getIntSwitchName()}, vips...)
+		err = client.LoadBalancerApply(n.getLoadBalancerName(loadBalancer.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, vips...)
 		if err != nil {
 			return nil, fmt.Errorf("Failed applying OVN load balancer: %w", err)
 		}
@@ -5372,7 +5372,7 @@ func (n *ovn) LoadBalancerUpdate(listenAddress string, req api.NetworkLoadBalanc
 
 		vips := n.loadBalancerFlattenVIPs(net.ParseIP(newLoadBalancer.ListenAddress), portMaps)
 
-		err = client.LoadBalancerApply(n.getLoadBalancerName(newLoadBalancer.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, []openvswitch.OVNSwitch{n.getIntSwitchName()}, vips...)
+		err = client.LoadBalancerApply(n.getLoadBalancerName(newLoadBalancer.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, vips...)
 		if err != nil {
 			return fmt.Errorf("Failed applying OVN load balancer: %w", err)
 		}
@@ -5382,7 +5382,7 @@ func (n *ovn) LoadBalancerUpdate(listenAddress string, req api.NetworkLoadBalanc
 			portMaps, err := n.loadBalancerValidate(net.ParseIP(curLoadBalancer.ListenAddress), curLoadBalancer.Writable())
 			if err == nil {
 				vips := n.loadBalancerFlattenVIPs(net.ParseIP(curLoadBalancer.ListenAddress), portMaps)
-				_ = client.LoadBalancerApply(n.getLoadBalancerName(curLoadBalancer.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, []openvswitch.OVNSwitch{n.getIntSwitchName()}, vips...)
+				_ = client.LoadBalancerApply(n.getLoadBalancerName(curLoadBalancer.ListenAddress), []openvswitch.OVNRouter{n.getRouterName()}, vips...)
 				_ = n.forwardBGPSetupPrefixes()
 			}
 		})

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1943,10 +1943,14 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 			return fmt.Errorf("Missing VIP target(s)")
 		}
 
+		if len(args) > 0 {
+			args = append(args, "--")
+		}
+
 		if r.Protocol == "udp" {
-			args = append(args, "--", "lb-add", lbUDPName)
+			args = append(args, "lb-add", lbUDPName)
 		} else {
-			args = append(args, "--", "lb-add", lbTCPName)
+			args = append(args, "lb-add", lbTCPName)
 		}
 
 		targetArgs := make([]string, 0, len(r.Targets))

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -874,19 +874,19 @@ func (o *OVN) LogicalSwitchDHCPv4RevervationsGet(switchName OVNSwitch) ([]shared
 		if ip == nil {
 			// Check if IP range part.
 			start, end, found := strings.Cut(excludeIPsPart, "..")
-			if found {
-				startIP := net.ParseIP(start)
-				endIP := net.ParseIP(end)
-
-				if startIP == nil || endIP == nil {
-					return nil, fmt.Errorf("Invalid exclude_ips range: %q", excludeIPsPart)
-				}
-
-				// Add range IP part to list.
-				excludeIPs = append(excludeIPs, shared.IPRange{Start: startIP, End: endIP})
-			} else {
+			if !found {
 				return nil, fmt.Errorf("Unrecognised exclude_ips part: %q", excludeIPsPart)
 			}
+
+			startIP := net.ParseIP(start)
+			endIP := net.ParseIP(end)
+
+			if startIP == nil || endIP == nil {
+				return nil, fmt.Errorf("Invalid exclude_ips range: %q", excludeIPsPart)
+			}
+
+			// Add range IP part to list.
+			excludeIPs = append(excludeIPs, shared.IPRange{Start: startIP, End: endIP})
 		} else {
 			// Add single IP part to list.
 			excludeIPs = append(excludeIPs, shared.IPRange{Start: ip})


### PR DESCRIPTION
The OVN `lb-add` command that adds entries to the `Load_Balancer` OVN northbound table has a bug that in certain situations allows multiple records with the same name to be created.

This then causes issues with the `lb-del` command that does not support the scenario of duplicate records of the same name.

This fix has multiple facets:

1. Changes the way LXD deletes existing load balancer entries by searching for them by name and then deleting them by UUID, this supports multiple records of the same name existing.
2. Changes the way LXD associates load balancer entries to a logical router by using the `add` database command directly rather than `lr-lb-add` that allows multiple records to exist with the same name.
3. Drops unused associated of load balancers to logical switches.


Fixes https://github.com/canonical/lxd/issues/13462

