### PR TITLE
Config: Revert `map[string]string` change for server settings

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1396,8 +1396,7 @@ definitions:
     InitLocalPreseed:
         properties:
             config:
-                additionalProperties:
-                    type: string
+                additionalProperties: {}
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
@@ -5565,8 +5564,7 @@ definitions:
                 type: string
                 x-go-name: AuthUserName
             config:
-                additionalProperties:
-                    type: string
+                additionalProperties: {}
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
@@ -5746,8 +5744,7 @@ definitions:
         description: ServerPut represents the modifiable fields of a LXD server configuration
         properties:
             config:
-                additionalProperties:
-                    type: string
+                additionalProperties: {}
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -489,9 +489,9 @@ func (c *cmdConfigGet) Run(cmd *cobra.Command, args []string) error {
 		value := resp.Config[args[len(args)-1]]
 		if value == nil {
 			value = ""
-		} else if value == true {
+		} else if value == true { //nolint:revive
 			value = "true"
-		} else if value == false {
+		} else if value == false { //nolint:revive
 			value = "false"
 		}
 

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -487,6 +487,14 @@ func (c *cmdConfigGet) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		value := resp.Config[args[len(args)-1]]
+		if value == nil {
+			value = ""
+		} else if value == true {
+			value = "true"
+		} else if value == false {
+			value = "false"
+		}
+
 		fmt.Println(value)
 	}
 
@@ -700,7 +708,7 @@ func (c *cmdConfigSet) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if server.Config == nil {
-		server.Config = map[string]string{}
+		server.Config = map[string]any{}
 	}
 
 	for k, v := range keys {

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -631,9 +631,9 @@ func (c *cmdConfigSet) Run(cmd *cobra.Command, args []string) error {
 				}
 
 				return op.Wait()
-			} else {
-				return fmt.Errorf(i18n.G("The is no config key to set on an instance snapshot."))
 			}
+
+			return fmt.Errorf(i18n.G("There is no config key to set on an instance snapshot."))
 		}
 
 		inst, etag, err := resource.server.GetInstance(resource.name)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -414,7 +414,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 			return fmt.Errorf("Cannot use wildcard core.https_address %q for cluster.https_address. Please specify a new cluster.https_address or core.https_address", localClusterAddress)
 		}
 
-		_, err = config.Patch(map[string]string{
+		_, err = config.Patch(map[string]any{
 			"cluster.https_address": localHTTPSAddress,
 		})
 		if err != nil {
@@ -485,7 +485,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
 
-			_, err = config.Patch(map[string]string{
+			_, err = config.Patch(map[string]any{
 				"core.https_address":    req.ServerAddress,
 				"cluster.https_address": req.ServerAddress,
 			})
@@ -518,7 +518,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
 
-			_, err = config.Patch(map[string]string{
+			_, err = config.Patch(map[string]any{
 				"cluster.https_address": localHTTPSAddress,
 			})
 			return err
@@ -789,7 +789,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		existingConfigDump := currentClusterConfig.Dump()
 		changes := make(map[string]string, len(existingConfigDump))
 		for k, v := range existingConfigDump {
-			changes[k] = v
+			changes[k], _ = v.(string)
 		}
 
 		err = doAPI10UpdateTriggers(d, nil, changes, nodeConfig, currentClusterConfig)

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -258,21 +258,21 @@ func (c *Config) ClusterHealingThreshold() time.Duration {
 
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
-func (c *Config) Dump() map[string]string {
+func (c *Config) Dump() map[string]any {
 	return c.m.Dump()
 }
 
 // Replace the current configuration with the given values.
 //
 // Return what has actually changed.
-func (c *Config) Replace(values map[string]string) (map[string]string, error) {
+func (c *Config) Replace(values map[string]any) (map[string]string, error) {
 	return c.update(values)
 }
 
 // Patch changes only the configuration keys in the given map.
 //
 // Return what has actually changed.
-func (c *Config) Patch(patch map[string]string) (map[string]string, error) {
+func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
 	values := c.Dump() // Use current values as defaults
 	for name, value := range patch {
 		values[name] = value
@@ -281,7 +281,7 @@ func (c *Config) Patch(patch map[string]string) (map[string]string, error) {
 	return c.update(values)
 }
 
-func (c *Config) update(values map[string]string) (map[string]string, error) {
+func (c *Config) update(values map[string]any) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {
 		return nil, err

--- a/lxd/cluster/config/config_test.go
+++ b/lxd/cluster/config/config_test.go
@@ -19,7 +19,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{}, config.Dump())
+	assert.Equal(t, map[string]any{}, config.Dump())
 
 	assert.Equal(t, float64(20), config.OfflineThreshold().Seconds())
 }
@@ -38,7 +38,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
-	values := map[string]string{"core.proxy_http": "foo.bar"}
+	values := map[string]any{"core.proxy_http": "foo.bar"}
 	assert.Equal(t, values, config.Dump())
 }
 
@@ -50,7 +50,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{}, config.Dump())
+	assert.Equal(t, map[string]any{}, config.Dump())
 }
 
 // Offline threshold must be greater than the heartbeat interval.
@@ -61,7 +61,7 @@ func TestConfigLoad_OfflineThresholdValidator(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Patch(map[string]string{"cluster.offline_threshold": "2"})
+	_, err = config.Patch(map[string]any{"cluster.offline_threshold": "2"})
 	require.EqualError(t, err, "cannot set 'cluster.offline_threshold' to '2': Value must be greater than '10'")
 }
 
@@ -73,7 +73,7 @@ func TestConfigLoad_MaxVotersValidator(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Patch(map[string]string{"cluster.max_voters": "4"})
+	_, err = config.Patch(map[string]any{"cluster.max_voters": "4"})
 	require.EqualError(t, err, "cannot set 'cluster.max_voters' to '4': Value must be an odd number equal to or higher than 3")
 }
 
@@ -86,11 +86,11 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	changed, err := config.Replace(map[string]string{"core.proxy_http": "foo.bar"})
+	changed, err := config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.proxy_http": "foo.bar"}, changed)
 
-	_, err = config.Replace(map[string]string{})
+	_, err = config.Replace(map[string]any{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", config.ProxyHTTP())
@@ -109,10 +109,10 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	config, err := clusterConfig.Load(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Replace(map[string]string{"core.proxy_http": "foo.bar"})
+	_, err = config.Replace(map[string]any{"core.proxy_http": "foo.bar"})
 	assert.NoError(t, err)
 
-	_, err = config.Patch(map[string]string{})
+	_, err = config.Patch(map[string]any{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "foo.bar", config.ProxyHTTP())

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -49,7 +49,7 @@ func TestNewNotifier(t *testing.T) {
 	hook := func(client lxd.InstanceServer) error {
 		server, _, err := client.GetServer()
 		require.NoError(t, err)
-		peers <- server.Config["cluster.https_address"]
+		peers <- server.Config["cluster.https_address"].(string)
 		return nil
 	}
 
@@ -177,7 +177,7 @@ func (h *notifyFixtures) Nodes(cert *shared.CertInfo, n int) func() {
 		config, err := node.ConfigLoad(ctx, tx)
 		require.NoError(h.t, err)
 		address := servers[0].Listener.Addr().String()
-		values := map[string]string{"cluster.https_address": address}
+		values := map[string]any{"cluster.https_address": address}
 		_, err = config.Patch(values)
 		require.NoError(h.t, err)
 		return nil
@@ -232,7 +232,7 @@ func newRestServer(cert *shared.CertInfo) *httptest.Server {
 
 	mux.HandleFunc("/1.0/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		config := map[string]string{"cluster.https_address": server.Listener.Addr().String()}
+		config := map[string]any{"cluster.https_address": server.Listener.Addr().String()}
 		metadata := api.ServerPut{Config: config}
 		_ = util.WriteJSON(w, api.ResponseRaw{Metadata: metadata}, nil)
 	})

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -29,7 +29,8 @@ func TestNewNotifier(t *testing.T) {
 	cert := shared.TestingKeyPair()
 
 	f := notifyFixtures{t: t, state: state}
-	defer f.Nodes(cert, 3)()
+	cleanupF := f.Nodes(cert, 3)
+	defer cleanupF()
 
 	// Populate state.LocalConfig after nodes created above.
 	var err error
@@ -49,7 +50,9 @@ func TestNewNotifier(t *testing.T) {
 	hook := func(client lxd.InstanceServer) error {
 		server, _, err := client.GetServer()
 		require.NoError(t, err)
-		peers <- server.Config["cluster.https_address"].(string)
+		address, ok := server.Config["cluster.https_address"].(string)
+		require.True(t, ok)
+		peers <- address
 		return nil
 	}
 
@@ -77,7 +80,8 @@ func TestNewNotify_NotifyAllError(t *testing.T) {
 	cert := shared.TestingKeyPair()
 
 	f := notifyFixtures{t: t, state: state}
-	defer f.Nodes(cert, 3)()
+	cleanupF := f.Nodes(cert, 3)
+	defer cleanupF()
 
 	f.Down(1)
 
@@ -107,7 +111,8 @@ func TestNewNotify_NotifyAlive(t *testing.T) {
 	cert := shared.TestingKeyPair()
 
 	f := notifyFixtures{t: t, state: state}
-	defer f.Nodes(cert, 3)()
+	cleanupF := f.Nodes(cert, 3)
+	defer cleanupF()
 
 	f.Down(1)
 

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -111,7 +111,7 @@ func updateLocalAddress(database *db.Node, address string) error {
 			return err
 		}
 
-		newConfig := map[string]string{"cluster.https_address": address}
+		newConfig := map[string]any{"cluster.https_address": address}
 		_, err = config.Patch(newConfig)
 		if err != nil {
 			return err

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	dqlite "github.com/canonical/go-dqlite"
-	client "github.com/canonical/go-dqlite/client"
+	"github.com/canonical/go-dqlite/client"
 
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/node"

--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -39,11 +39,16 @@ func Load(schema Schema, values map[string]string) (Map, error) {
 //
 // Return a map of key/value pairs that were actually changed. If some keys
 // fail to apply, details are included in the returned ErrorList.
-func (m *Map) Change(changes map[string]string) (map[string]string, error) {
+func (m *Map) Change(changes map[string]any) (map[string]string, error) {
 	values := make(map[string]string, len(m.schema))
 
 	errors := ErrorList{}
 	for name, change := range changes {
+		// A nil object means the empty string.
+		if change == nil {
+			change = ""
+		}
+
 		// Ensure that we were actually passed a string.
 		s := reflect.ValueOf(change)
 		if s.Kind() != reflect.String {
@@ -51,7 +56,7 @@ func (m *Map) Change(changes map[string]string) (map[string]string, error) {
 			continue
 		}
 
-		values[name] = change
+		values[name] = change.(string)
 	}
 
 	if errors.Len() > 0 {
@@ -77,10 +82,9 @@ func (m *Map) Change(changes map[string]string) (map[string]string, error) {
 }
 
 // Dump the current configuration held by this Map.
-//
 // Keys that match their default value will not be included in the dump.
-func (m *Map) Dump() map[string]string {
-	values := map[string]string{}
+func (m *Map) Dump() map[string]any {
+	values := map[string]any{}
 
 	for name, value := range m.values {
 		key, ok := m.schema[name]

--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -56,7 +56,13 @@ func (m *Map) Change(changes map[string]any) (map[string]string, error) {
 			continue
 		}
 
-		values[name] = change.(string)
+		value, ok := change.(string)
+		if !ok {
+			errors.add(name, nil, fmt.Sprintf("failed to cast value %q to string", change))
+			continue
+		}
+
+		values[name] = value
 	}
 
 	if errors.Len() > 0 {

--- a/lxd/config/map_test.go
+++ b/lxd/config/map_test.go
@@ -111,33 +111,38 @@ func TestChange(t *testing.T) {
 
 	cases := []struct {
 		title  string
-		values map[string]string // New values
+		values map[string]any    // New values
 		result map[string]string // Expected values after change
 	}{
 		{
 			`plain change of regular key`,
-			map[string]string{"foo": "world"},
+			map[string]any{"foo": "world"},
 			map[string]string{"foo": "world"},
 		},
 		{
 			`key setter is honored`,
-			map[string]string{"bar": "y"},
+			map[string]any{"bar": "y"},
 			map[string]string{"bar": "Y"},
 		},
 		{
 			`bool true values are normalized`,
-			map[string]string{"egg": "yes"},
+			map[string]any{"egg": "yes"},
 			map[string]string{"egg": "true"},
 		},
 		{
 			`bool false values are normalized`,
-			map[string]string{"yuk": "0"},
+			map[string]any{"yuk": "0"},
 			map[string]string{"yuk": "false"},
 		},
 		{
 			`multiple values are all mutated`,
-			map[string]string{"foo": "x", "bar": "hey", "egg": "0"},
+			map[string]any{"foo": "x", "bar": "hey", "egg": "0"},
 			map[string]string{"foo": "x", "bar": "HEY", "egg": ""},
+		},
+		{
+			`the special value nil is converted to empty string`,
+			map[string]any{"foo": nil},
+			map[string]string{"foo": ""},
 		},
 	}
 
@@ -167,32 +172,32 @@ func TestMap_ChangeReturnsChangedKeys(t *testing.T) {
 
 	cases := []struct {
 		title   string
-		changes map[string]string // New values
+		changes map[string]any    // New values
 		changed map[string]string // Keys that should have actually changed
 	}{
 		{
 			`plain single change`,
-			map[string]string{"foo": "no"},
+			map[string]any{"foo": "no"},
 			map[string]string{"foo": "false"},
 		},
 		{
 			`unchanged boolean value, even if it's spelled 'yes' and not 'true'`,
-			map[string]string{"foo": "yes"},
+			map[string]any{"foo": "yes"},
 			map[string]string{},
 		},
 		{
 			`unset value`,
-			map[string]string{"foo": ""},
+			map[string]any{"foo": ""},
 			map[string]string{"foo": "false"},
 		},
 		{
 			`unchanged value, since it matches the default`,
-			map[string]string{"foo": "true", "bar": "egg"},
+			map[string]any{"foo": "true", "bar": "egg"},
 			map[string]string{},
 		},
 		{
 			`multiple changes`,
-			map[string]string{"foo": "false", "bar": "baz"},
+			map[string]any{"foo": "false", "bar": "baz"},
 			map[string]string{"foo": "false", "bar": "baz"},
 		},
 	}
@@ -219,23 +224,28 @@ func TestMap_ChangeError(t *testing.T) {
 
 	var cases = []struct {
 		title   string
-		changes map[string]string
+		changes map[string]any
 		message string
 	}{
 		{
 			`schema has no key with the given name`,
-			map[string]string{"xxx": ""},
+			map[string]any{"xxx": ""},
 			"cannot set 'xxx' to '': unknown key",
 		},
 		{
 			`validation fails`,
-			map[string]string{"foo": "yyy"},
+			map[string]any{"foo": "yyy"},
 			"cannot set 'foo' to 'yyy': invalid boolean",
 		},
 		{
 			`custom setter fails`,
-			map[string]string{"egg": "xxx"},
+			map[string]any{"egg": "xxx"},
 			"cannot set 'egg' to 'xxx': boom",
+		},
+		{
+			`non string value`,
+			map[string]any{"egg": 123},
+			"cannot set 'egg': invalid type int",
 		},
 	}
 
@@ -265,7 +275,7 @@ func TestMap_Dump(t *testing.T) {
 	m, err := config.Load(schema, values)
 	assert.NoError(t, err)
 
-	dump := map[string]string{
+	dump := map[string]any{
 		"foo": "hello",
 	}
 

--- a/lxd/config/safe_test.go
+++ b/lxd/config/safe_test.go
@@ -20,5 +20,5 @@ func TestSafeLoad_IgnoreInvalidKeys(t *testing.T) {
 	m, err := config.SafeLoad(schema, values)
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]string{"bar": "x"}, m.Dump())
+	assert.Equal(t, map[string]any{"bar": "x"}, m.Dump())
 }

--- a/lxd/config/schema.go
+++ b/lxd/config/schema.go
@@ -28,8 +28,8 @@ func (s Schema) Keys() []string {
 
 // Defaults returns a map of all key names in the schema along with their default
 // values.
-func (s Schema) Defaults() map[string]string {
-	values := make(map[string]string, len(s))
+func (s Schema) Defaults() map[string]any {
+	values := make(map[string]any, len(s))
 	for name, key := range s {
 		values[name] = key.Default
 	}

--- a/lxd/config/schema_test.go
+++ b/lxd/config/schema_test.go
@@ -14,7 +14,7 @@ func TestSchema_Defaults(t *testing.T) {
 		"bar": {Default: "x"},
 	}
 
-	values := map[string]string{"foo": "", "bar": "x"}
+	values := map[string]any{"foo": "", "bar": "x"}
 	assert.Equal(t, values, schema.Defaults())
 }
 

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -10,8 +10,8 @@ import (
 	"github.com/canonical/lxd/shared"
 )
 
-func daemonConfigRender(state *state.State) (map[string]string, error) {
-	config := map[string]string{}
+func daemonConfigRender(state *state.State) (map[string]any, error) {
+	config := map[string]any{}
 
 	// Turn the config into a JSON-compatible map.
 	for key, value := range state.GlobalConfig.Dump() {

--- a/lxd/db/cluster/instances.go
+++ b/lxd/db/cluster/instances.go
@@ -77,7 +77,7 @@ type InstanceFilter struct {
 }
 
 // ToAPI converts the database Instance to API type.
-func (i *Instance) ToAPI(ctx context.Context, tx *sql.Tx, globalConfig map[string]string) (*api.Instance, error) {
+func (i *Instance) ToAPI(ctx context.Context, tx *sql.Tx, globalConfig map[string]any) (*api.Instance, error) {
 	profiles, err := GetInstanceProfiles(ctx, tx, i.ID)
 	if err != nil {
 		return nil, err

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1956,7 +1956,17 @@ func distributeImage(ctx context.Context, s *state.State, nodes []string, oldFin
 		if err != nil {
 			logger.Error("Failed to retrieve information about cluster member", logger.Ctx{"err": err, "remote": nodeAddress})
 		} else {
-			vol := resp.Config["storage.images_volume"]
+			vol := ""
+
+			val := resp.Config["storage.images_volume"]
+			if val != nil {
+				var ok bool
+				vol, ok = val.(string)
+				if !ok {
+					return fmt.Errorf("Invalid type for field \"storage.images_volume\"")
+				}
+			}
+
 			skipDistribution := false
 
 			// If storage.images_volume is set on the cluster member, check if

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -509,7 +509,7 @@ func (d *common) deviceVolatileSetFunc(devName string) func(save map[string]stri
 
 // expandConfig applies the config of each profile in order, followed by the local config.
 func (d *common) expandConfig() error {
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if d.state.GlobalConfig != nil {
 		globalConfigDump = d.state.GlobalConfig.Dump()
 	}

--- a/lxd/instance/instancetype/instance_utils.go
+++ b/lxd/instance/instancetype/instance_utils.go
@@ -8,12 +8,12 @@ import (
 )
 
 // ExpandInstanceConfig expands the given instance config with the config values of the given profiles.
-func ExpandInstanceConfig(globalConfig map[string]string, config map[string]string, profiles []api.Profile) map[string]string {
+func ExpandInstanceConfig(globalConfig map[string]any, config map[string]string, profiles []api.Profile) map[string]string {
 	expandedConfig := map[string]string{}
 
 	// Apply global config overriding
 	if globalConfig != nil {
-		globalInstancesMigrationStatefulStr, ok := globalConfig["instances.migration.stateful"]
+		globalInstancesMigrationStatefulStr, ok := globalConfig["instances.migration.stateful"].(string)
 		if ok {
 			globalInstancesMigrationStateful, _ := strconv.ParseBool(globalInstancesMigrationStatefulStr)
 			if globalInstancesMigrationStateful {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1134,7 +1134,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				Reason:        apiScriptlet.InstancePlacementReasonNew,
 			}
 
-			var globalConfigDump map[string]string
+			var globalConfigDump map[string]any
 			if s.GlobalConfig != nil {
 				globalConfigDump = s.GlobalConfig.Dump()
 			}

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -201,8 +201,8 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	// If clustering is enabled, and no cluster.https_address network address
 	// was specified, we fallback to core.https_address.
 	if config.Cluster != nil &&
-		config.Node.Config["core.https_address"] != "" &&
-		config.Node.Config["cluster.https_address"] == "" {
+		config.Node.Config["core.https_address"] != nil &&
+		config.Node.Config["cluster.https_address"] == nil {
 		config.Node.Config["cluster.https_address"] = config.Node.Config["core.https_address"]
 	}
 

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -34,6 +34,7 @@ type cmdInit struct {
 	hostname string
 }
 
+// Command returns a cobra command to configure the LXD daemon.
 func (c *cmdInit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "init"
@@ -65,6 +66,7 @@ func (c *cmdInit) Command() *cobra.Command {
 	return cmd
 }
 
+// Run executes the command to configure the LXD daemon.
 func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	if c.flagAuto && c.flagPreseed {

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -62,7 +62,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 
 	// Fill in the node configuration
 	config := api.InitLocalPreseed{}
-	config.Config = map[string]string{}
+	config.Config = map[string]any{}
 
 	// Network listening
 	if c.flagNetworkAddress != "" {

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
+// RunAuto initializes LXD in automatic (non-interactive) mode.
 func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*api.InitPreseed, error) {
 	// Quick checks.
 	if c.flagStorageBackend != "" && !shared.ValueInSlice(c.flagStorageBackend, storageDrivers.AllDriverNames()) {

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -26,6 +26,7 @@ import (
 	"github.com/canonical/lxd/shared/version"
 )
 
+// RunInteractive executes the command to interactively configure the LXD daemon.
 func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*api.InitPreseed, error) {
 	// Initialize config
 	config := api.InitPreseed{}

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -29,7 +29,7 @@ import (
 func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*api.InitPreseed, error) {
 	// Initialize config
 	config := api.InitPreseed{}
-	config.Node.Config = map[string]string{}
+	config.Node.Config = map[string]any{}
 	config.Node.Networks = []api.InitNetworksProjectPost{}
 	config.Node.StoragePools = []api.StoragePoolsPost{}
 	config.Node.Profiles = []api.ProfilesPost{
@@ -447,7 +447,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 					config.Node.Profiles[0].Devices["eth0"]["nictype"] = "bridged"
 				}
 
-				if config.Node.Config["maas.api.url"] != "" {
+				if config.Node.Config["maas.api.url"] != nil {
 					maasConnect, err := c.global.asker.AskBool("Is this interface connected to your MAAS server? (yes/no) [default=yes]: ", "yes")
 					if err != nil {
 						return err

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -62,7 +62,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		return tx.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
 			// Expand configs so we take into account profile devices.
-			var globalConfigDump map[string]string
+			var globalConfigDump map[string]any
 			if s.GlobalConfig != nil {
 				globalConfigDump = s.GlobalConfig.Dump()
 			}

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -125,17 +125,17 @@ func (c *Config) SyslogSocket() bool {
 
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
-func (c *Config) Dump() map[string]string {
+func (c *Config) Dump() map[string]any {
 	return c.m.Dump()
 }
 
 // Replace the current configuration with the given values.
-func (c *Config) Replace(values map[string]string) (map[string]string, error) {
+func (c *Config) Replace(values map[string]any) (map[string]string, error) {
 	return c.update(values)
 }
 
 // Patch changes only the configuration keys in the given map.
-func (c *Config) Patch(patch map[string]string) (map[string]string, error) {
+func (c *Config) Patch(patch map[string]any) (map[string]string, error) {
 	values := c.Dump() // Use current values as defaults
 	for name, value := range patch {
 		values[name] = value
@@ -144,7 +144,7 @@ func (c *Config) Patch(patch map[string]string) (map[string]string, error) {
 	return c.update(values)
 }
 
-func (c *Config) update(values map[string]string) (map[string]string, error) {
+func (c *Config) update(values map[string]any) (map[string]string, error) {
 	changed, err := c.m.Change(values)
 	if err != nil {
 		return nil, err

--- a/lxd/node/config_test.go
+++ b/lxd/node/config_test.go
@@ -19,7 +19,7 @@ func TestConfigLoad_Initial(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{}, config.Dump())
+	assert.Equal(t, map[string]any{}, config.Dump())
 }
 
 // If the database contains invalid keys, they are ignored.
@@ -36,7 +36,7 @@ func TestConfigLoad_IgnoreInvalidKeys(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
-	values := map[string]string{"core.https_address": "127.0.0.1:666"}
+	values := map[string]any{"core.https_address": "127.0.0.1:666"}
 	assert.Equal(t, values, config.Dump())
 }
 
@@ -48,7 +48,7 @@ func TestConfigLoad_Triggers(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{}, config.Dump())
+	assert.Equal(t, map[string]any{}, config.Dump())
 }
 
 // If some previously set values are missing from the ones passed to Replace(),
@@ -60,11 +60,11 @@ func TestConfig_ReplaceDeleteValues(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 	require.NoError(t, err)
 
-	changed, err := config.Replace(map[string]string{"core.https_address": "127.0.0.1:666"})
+	changed, err := config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": "127.0.0.1:666"}, changed)
 
-	changed, err = config.Replace(map[string]string{})
+	changed, err = config.Replace(map[string]any{})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"core.https_address": ""}, changed)
 
@@ -84,10 +84,10 @@ func TestConfig_PatchKeepsValues(t *testing.T) {
 	config, err := node.ConfigLoad(context.Background(), tx)
 	require.NoError(t, err)
 
-	_, err = config.Replace(map[string]string{"core.https_address": "127.0.0.1:666"})
+	_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
 	assert.NoError(t, err)
 
-	_, err = config.Patch(map[string]string{})
+	_, err = config.Patch(map[string]any{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "127.0.0.1:666", config.HTTPSAddress())
@@ -120,7 +120,7 @@ func TestHTTPSAddress(t *testing.T) {
 			return err
 		}
 
-		_, err = config.Replace(map[string]string{"core.https_address": "127.0.0.1:666"})
+		_, err = config.Replace(map[string]any{"core.https_address": "127.0.0.1:666"})
 		return err
 	})
 	require.NoError(t, err)
@@ -157,7 +157,7 @@ func TestClusterAddress(t *testing.T) {
 			return err
 		}
 
-		_, err = nodeConfig.Replace(map[string]string{"cluster.https_address": "127.0.0.1:666"})
+		_, err = nodeConfig.Replace(map[string]any{"cluster.https_address": "127.0.0.1:666"})
 		return err
 	})
 	require.NoError(t, err)

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -27,7 +27,7 @@ import (
 // AllowInstanceCreation returns an error if any project-specific limit or
 // restriction is violated when creating a new instance.
 func AllowInstanceCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, req api.InstancesPost) error {
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -236,7 +236,7 @@ func checkRestrictionsOnVolatileConfig(project api.Project, instanceType instanc
 // AllowVolumeCreation returns an error if any project-specific limit or
 // restriction is violated when creating a new custom volume in a project.
 func AllowVolumeCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, req api.StorageVolumesPost) error {
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -274,7 +274,7 @@ func AllowVolumeCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 //
 // If no limit is in place, return -1.
 func GetImageSpaceBudget(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string) (int64, error) {
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -346,7 +346,7 @@ func checkRestrictionsAndAggregateLimits(globalConfig *clusterConfig.Config, tx 
 		return nil
 	}
 
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -884,7 +884,7 @@ func isVMLowLevelOptionForbidden(key string) bool {
 func AllowInstanceUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, instanceName string, req api.InstancePut, currentConfig map[string]string) error {
 	var updatedInstance *api.Instance
 
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -934,7 +934,7 @@ func AllowInstanceUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 // AllowVolumeUpdate returns an error if any project-specific limit or
 // restriction is violated when updating an existing custom volume.
 func AllowVolumeUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, volumeName string, req api.StorageVolumePut, currentConfig map[string]string) error {
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -973,7 +973,7 @@ func AllowVolumeUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, pro
 // AllowProfileUpdate checks that project limits and restrictions are not
 // violated when changing a profile.
 func AllowProfileUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, profileName string, req api.ProfilePut) error {
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -1007,7 +1007,7 @@ func AllowProfileUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, pr
 
 // AllowProjectUpdate checks the new config to be set on a project is valid.
 func AllowProjectUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, config map[string]string, changed []string) error {
-	var globalConfigDump map[string]string
+	var globalConfigDump map[string]any
 	if globalConfig != nil {
 		globalConfigDump = globalConfig.Dump()
 	}
@@ -1194,7 +1194,7 @@ type projectInfo struct {
 // If the skipIfNoLimits flag is true, then profiles, instances and volumes
 // won't be loaded if the profile has no limits set on it, and nil will be
 // returned.
-func fetchProject(globalConfig map[string]string, tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*projectInfo, error) {
+func fetchProject(globalConfig map[string]any, tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*projectInfo, error) {
 	ctx := context.Background()
 	dbProject, err := cluster.GetProject(ctx, tx.Tx(), projectName)
 	if err != nil {
@@ -1269,7 +1269,7 @@ func fetchProject(globalConfig map[string]string, tx *db.ClusterTx, projectName 
 
 // Expand the configuration and devices of the given instances, taking the give
 // project profiles into account.
-func expandInstancesConfigAndDevices(globalConfig map[string]string, instances []api.Instance, profiles []api.Profile) ([]api.Instance, error) {
+func expandInstancesConfigAndDevices(globalConfig map[string]any, instances []api.Instance, profiles []api.Profile) ([]api.Instance, error) {
 	expandedInstances := make([]api.Instance, len(instances))
 
 	// Index of all profiles by name.

--- a/lxd/project/state.go
+++ b/lxd/project/state.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetCurrentAllocations returns the current resource utilization for a given project.
-func GetCurrentAllocations(globalConfig map[string]string, ctx context.Context, tx *db.ClusterTx, projectName string) (map[string]api.ProjectStateResource, error) {
+func GetCurrentAllocations(globalConfig map[string]any, ctx context.Context, tx *db.ClusterTx, projectName string) (map[string]api.ProjectStateResource, error) {
 	result := map[string]api.ProjectStateResource{}
 
 	// Get the project.

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -5766,10 +5766,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5889,6 +5885,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -6409,10 +6409,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6536,6 +6532,11 @@ msgstr "entfernte Instanz %s existiert nicht"
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
+
+#: lxc/config.go:636
+#, fuzzy
+msgid "There is no config key to set on an instance snapshot."
+msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/cluster.go:658
 msgid "This LXD server is already clustered"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -5864,10 +5864,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5988,6 +5984,11 @@ msgstr ""
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
+
+#: lxc/config.go:636
+#, fuzzy
+msgid "There is no config key to set on an instance snapshot."
+msgstr "  Χρήση δικτύου:"
 
 #: lxc/cluster.go:658
 msgid "This LXD server is already clustered"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -6178,10 +6178,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6302,6 +6298,11 @@ msgstr ""
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
+
+#: lxc/config.go:636
+#, fuzzy
+msgid "There is no config key to set on an instance snapshot."
+msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/cluster.go:658
 msgid "This LXD server is already clustered"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -6547,10 +6547,6 @@ msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6672,6 +6668,11 @@ msgstr "le périphérique indiqué ne correspond pas au réseau"
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
+
+#: lxc/config.go:636
+#, fuzzy
+msgid "There is no config key to set on an instance snapshot."
+msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/cluster.go:658
 msgid "This LXD server is already clustered"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -5770,10 +5770,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5893,6 +5889,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -6175,10 +6175,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6300,6 +6296,11 @@ msgstr ""
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
+
+#: lxc/config.go:636
+#, fuzzy
+msgid "There is no config key to set on an instance snapshot."
+msgstr "Il nome del container è: %s"
 
 #: lxc/cluster.go:658
 msgid "This LXD server is already clustered"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -6438,10 +6438,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6567,6 +6563,11 @@ msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
+
+#: lxc/config.go:636
+#, fuzzy
+msgid "There is no config key to set on an instance snapshot."
+msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
 #: lxc/cluster.go:658
 msgid "This LXD server is already clustered"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -5766,10 +5766,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5889,6 +5885,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-05-02 10:31+0100\n"
+        "POT-Creation-Date: 2024-05-24 12:39+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -5350,10 +5350,6 @@ msgstr  ""
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: lxc/config.go:635
-msgid   "The is no config key to set on an instance snapshot."
-msgstr  ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid   "The key %q does not exist on cluster member %q"
@@ -5471,6 +5467,10 @@ msgstr  ""
 
 #: lxc/publish.go:84
 msgid   "There is no \"image name\".  Did you want an alias?"
+msgstr  ""
+
+#: lxc/config.go:636
+msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
 #: lxc/cluster.go:658

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -5993,10 +5993,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6116,6 +6112,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -6031,10 +6031,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6154,6 +6150,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -5766,10 +5766,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5889,6 +5885,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -6273,10 +6273,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6397,6 +6393,11 @@ msgstr ""
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
+
+#: lxc/config.go:636
+#, fuzzy
+msgid "There is no config key to set on an instance snapshot."
+msgstr "Nome de membro do cluster"
 
 #: lxc/cluster.go:658
 msgid "This LXD server is already clustered"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -6260,10 +6260,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6384,6 +6380,11 @@ msgstr ""
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
+
+#: lxc/config.go:636
+#, fuzzy
+msgid "There is no config key to set on an instance snapshot."
+msgstr "Копирование образа: %s"
 
 #: lxc/cluster.go:658
 msgid "This LXD server is already clustered"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -5770,10 +5770,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5893,6 +5889,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -5770,10 +5770,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5893,6 +5889,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -5766,10 +5766,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5889,6 +5885,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -5770,10 +5770,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5893,6 +5889,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -5930,10 +5930,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -6053,6 +6049,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-02 10:31+0100\n"
+"POT-Creation-Date: 2024-05-24 12:39+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -5769,10 +5769,6 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:635
-msgid "The is no config key to set on an instance snapshot."
-msgstr ""
-
 #: lxc/cluster.go:348
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
@@ -5892,6 +5888,10 @@ msgstr ""
 
 #: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
+msgstr ""
+
+#: lxc/config.go:636
+msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
 #: lxc/cluster.go:658

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -158,7 +158,7 @@ type ServerStorageDriverInfo struct {
 type ServerPut struct {
 	// Server configuration map (refer to doc/server.md)
 	// Example: {"core.https_address": ":8443", "core.trust_password": "xyz"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config map[string]any `json:"config" yaml:"config"`
 }
 
 // ServerUntrusted represents a LXD server for an untrusted client


### PR DESCRIPTION
This reverts the change of the server config from `map[string]any` to `map[string]string` performed in https://github.com/canonical/lxd/pull/13373 as it breaks the `lxc` client when talking to older servers that still return a `map[string]any` on the clients `GetServer()` call.

See the reproducer steps here https://github.com/canonical/lxd/pull/13373#issuecomment-2122109494.

It still keeps the bits from https://github.com/canonical/lxd/pull/13373 that removed the hidden configuration option as those changes are not connected with each other.

An option would have been to adapt the client to be able to talk with both the newer and older server but users of the pure REST API are also affected by this as config settings that were originally an `int` or `bool` are now returned as a `string`. 
Contrary when setting the value they always have to be provided as a `string` in the JSON payload. 

To not break the API we have to keep `map[string]any`.