### PR TITLE
test/storage: Remove zfs rounding test

### DIFF
--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -45,10 +45,6 @@ test_storage() {
   [ "$(lxc storage volume get "$storage_pool" "$storage_volume" snapshots.expiry)" = "3d" ]
   lxc storage volume delete "$storage_pool" "$storage_volume"
 
-  # Ensure non-power-of-two sizes are rounded appropriately (most relevant for zfs)
-  lxc storage volume create "$storage_pool" "$storage_volume" --type=block size=13GB
-  lxc storage volume delete "$storage_pool" "$storage_volume"
-
   lxc storage delete "$storage_pool"
 
   # Test btrfs resize


### PR DESCRIPTION
This test will be added to lxd-ci in https://github.com/canonical/lxd-ci/pull/175

It doesn't fit well anywhere in this suite as it requires a VM image.