### PR TITLE
Handle long device names when creating QEMU device tags

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -111,6 +111,9 @@ const qemuDeviceIDPrefix = "dev-lxd_"
 // qemuDeviceNamePrefix used as part of the name given QEMU blockdevs, netdevs and device tags generated from user added devices.
 const qemuDeviceNamePrefix = "lxd_"
 
+// qemuDeviceNameMaxLength used to indicate the maximum length of a qemu block node name and device tags.
+const qemuDeviceNameMaxLength = 31
+
 // qemuMigrationNBDExportName is the name of the disk device export by the migration NBD server.
 const qemuMigrationNBDExportName = "lxd_root"
 
@@ -8906,7 +8909,8 @@ func (d *qemu) deviceDetachUSB(usbDev deviceConfig.USBDeviceItem) error {
 
 // Block node names and device tags may only be up to 31 characters long, so use a hash if longer.
 func (d *qemu) generateQemuDeviceName(name string) string {
-	if len(name) > 27 {
+	maxNameLength := qemuDeviceNameMaxLength - len(qemuDeviceNamePrefix)
+	if len(name) > maxNameLength {
 		// If the name is too long, hash it as SHA-256 (32 bytes).
 		// Then encode the SHA-256 binary hash as Base64 Raw URL format and trim down to 27 chars.
 		// Raw URL avoids the use of "+" character and the padding "=" character which QEMU doesn't allow.
@@ -8914,7 +8918,7 @@ func (d *qemu) generateQemuDeviceName(name string) string {
 		hash.Write([]byte(name))
 		binaryHash := hash.Sum(nil)
 		name = base64.RawURLEncoding.EncodeToString(binaryHash)
-		name = name[0:27]
+		name = name[0:maxNameLength]
 	}
 
 	// Apply the lxd_ prefix.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -108,11 +108,8 @@ const qemuPCIDeviceIDStart = 4
 // qemuDeviceIDPrefix used as part of the name given QEMU devices generated from user added devices.
 const qemuDeviceIDPrefix = "dev-lxd_"
 
-// qemuNetDevIDPrefix used as part of the name given QEMU netdevs generated from user added devices.
-const qemuNetDevIDPrefix = "lxd_"
-
-// qemuBlockDevIDPrefix used as part of the name given QEMU blockdevs generated from user added devices.
-const qemuBlockDevIDPrefix = "lxd_"
+// qemuDeviceNamePrefix used as part of the name given QEMU blockdevs and netdevs generated from user added devices.
+const qemuDeviceNamePrefix = "lxd_"
 
 // qemuMigrationNBDExportName is the name of the disk device export by the migration NBD server.
 const qemuMigrationNBDExportName = "lxd_root"
@@ -2526,7 +2523,7 @@ func (d *qemu) deviceDetachNIC(deviceName string) error {
 
 	escapedDeviceName := filesystem.PathNameEncode(deviceName)
 	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
-	netDevID := fmt.Sprintf("%s%s", qemuNetDevIDPrefix, escapedDeviceName)
+	netDevID := fmt.Sprintf("%s%s", qemuDeviceNamePrefix, escapedDeviceName)
 
 	// Request removal of device.
 	err = monitor.RemoveDevice(deviceID)
@@ -4067,7 +4064,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 	}
 
 	qemuDev["drive"] = qemuDevDrive
-	qemuDev["serial"] = fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, escapedDeviceName)
+	qemuDev["serial"] = fmt.Sprintf("%s%s", qemuDeviceNamePrefix, escapedDeviceName)
 
 	if bus == "virtio-scsi" {
 		qemuDev["channel"] = "0"
@@ -4112,7 +4109,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		revert := revert.New()
 		defer revert.Fail()
 
-		nodeName := fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, escapedDeviceName)
+		nodeName := fmt.Sprintf("%s%s", qemuDeviceNamePrefix, escapedDeviceName)
 
 		if isRBDImage {
 			secretID := fmt.Sprintf("pool_%s_%s", blockDev["pool"], blockDev["user"])
@@ -4308,7 +4305,7 @@ func (d *qemu) addNetDevConfig(busName string, qemuDev map[string]string, bootIn
 			}
 
 			qemuNetDev := map[string]any{
-				"id":    fmt.Sprintf("%s%s", qemuNetDevIDPrefix, escapedDeviceName),
+				"id":    fmt.Sprintf("%s%s", qemuDeviceNamePrefix, escapedDeviceName),
 				"type":  "tap",
 				"vhost": vhostNetEnabled,
 			}
@@ -8921,7 +8918,7 @@ func (d *qemu) generateQemuDeviceName(name string) string {
 	}
 
 	// Apply the lxd_ prefix.
-	return fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, name)
+	return fmt.Sprintf("%s%s", qemuDeviceNamePrefix, name)
 }
 
 func (d *qemu) setCPUs(count int) error {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2343,7 +2343,7 @@ func (d *qemu) deviceDetachBlockDevice(deviceName string) error {
 
 	escapedDeviceName := filesystem.PathNameEncode(deviceName)
 	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
-	blockDevName := d.blockNodeName(escapedDeviceName)
+	blockDevName := d.generateQemuDeviceName(escapedDeviceName)
 
 	err = monitor.RemoveFDFromFDSet(blockDevName)
 	if err != nil {
@@ -3952,7 +3952,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		},
 		"discard":   "unmap", // Forward as an unmap request. This is the same as `discard=on` in the qemu config file.
 		"driver":    "file",
-		"node-name": d.blockNodeName(escapedDeviceName),
+		"node-name": d.generateQemuDeviceName(escapedDeviceName),
 		"read-only": false,
 	}
 
@@ -8686,7 +8686,7 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 
 	// Check io_uring feature.
 	blockDev := map[string]any{
-		"node-name": d.blockNodeName("feature-check"),
+		"node-name": d.generateQemuDeviceName("feature-check"),
 		"driver":    "file",
 		"filename":  blockDevPath.Name(),
 		"aio":       "io_uring",
@@ -8908,7 +8908,7 @@ func (d *qemu) deviceDetachUSB(usbDev deviceConfig.USBDeviceItem) error {
 }
 
 // Block node names may only be up to 31 characters long, so use a hash if longer.
-func (d *qemu) blockNodeName(name string) string {
+func (d *qemu) generateQemuDeviceName(name string) string {
 	if len(name) > 27 {
 		// If the name is too long, hash it as SHA-256 (32 bytes).
 		// Then encode the SHA-256 binary hash as Base64 Raw URL format and trim down to 27 chars.


### PR DESCRIPTION
Fixes [#13495](https://github.com/canonical/lxd/issues/13495).
Helps to avoid problems with [these](https://github.com/canonical/lxd-ci/pull/177) tests.
The old `blockNodeName` function was modified, renamed and repurposed to also help generating device tags for QEMU.