### PR TITLE
instance/driver_qemu: properly calculate VHOST_VSOCK_SET_GUEST_CID

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1,5 +1,17 @@
 package drivers
 
+/*
+
+#include <linux/types.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+
+#define VHOST_VIRTIO 0xAF
+#define VHOST_VSOCK_SET_GUEST_CID	_IOW(VHOST_VIRTIO, 0x60, __u64)
+
+*/
+import "C"
+
 import (
 	"bufio"
 	"bytes"
@@ -8093,8 +8105,7 @@ func (d *qemu) acquireVsockID(vsockID uint32) (*os.File, error) {
 	// The vsock Context ID cannot be supplied as type uint32.
 	vsockIDInt := uint64(vsockID)
 
-	// 0x4008AF60 = VHOST_VSOCK_SET_GUEST_CID = _IOW(VHOST_VIRTIO, 0x60, __u64)
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, vsockF.Fd(), 0x4008AF60, uintptr(unsafe.Pointer(&vsockIDInt)))
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, vsockF.Fd(), C.VHOST_VSOCK_SET_GUEST_CID, uintptr(unsafe.Pointer(&vsockIDInt)))
 	if errno != 0 {
 		if !errors.Is(errno, unix.EADDRINUSE) {
 			return nil, fmt.Errorf("Failed ioctl syscall to vhost socket: %q", errno.Error())


### PR DESCRIPTION
…GUEST_CID

We can't hardcode VHOST_VSOCK_SET_GUEST_CID ioctl() number, because it may be different depending on the platform.