### PR TITLE
storage/driver_btrfs_utils: properly calculate BTRFS_IOC_SET_RECEIVED_SUBVOL

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -1,5 +1,37 @@
 package drivers
 
+/*
+
+#include <linux/types.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+
+// definitions are borrowed from include/uapi/linux/btrfs.h
+
+#define BTRFS_IOCTL_MAGIC 0x94
+#define BTRFS_UUID_SIZE 16
+
+struct btrfs_ioctl_timespec {
+	__u64 sec;
+	__u32 nsec;
+};
+
+struct btrfs_ioctl_received_subvol_args {
+	char	uuid[BTRFS_UUID_SIZE];
+	__u64	stransid;
+	__u64	rtransid;
+	struct btrfs_ioctl_timespec stime;
+	struct btrfs_ioctl_timespec rtime;
+	__u64	flags;
+	__u64	reserved[16];
+};
+
+#define BTRFS_IOC_SET_RECEIVED_SUBVOL _IOWR(BTRFS_IOCTL_MAGIC, 37, \
+				struct btrfs_ioctl_received_subvol_args)
+
+*/
+import "C"
+
 import (
 	"bufio"
 	"bytes"
@@ -61,8 +93,7 @@ func setReceivedUUID(path string, UUID string) error {
 
 	copy(args.uuid[:], binUUID)
 
-	// 0xC0C09425 = _IOWR(BTRFS_IOCTL_MAGIC, 37, struct btrfs_ioctl_received_subvol_args)
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), 0xC0C09425, uintptr(unsafe.Pointer(&args)))
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), C.BTRFS_IOC_SET_RECEIVED_SUBVOL, uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
 		return fmt.Errorf("Failed setting received UUID: %w", unix.Errno(errno))
 	}


### PR DESCRIPTION
ioctl() numbers are architecture-dependent (endianness and not only)