### PR TITLE
Update grafana.md with additional details on setting loki.instance key value.

### DIFF
--- a/doc/howto/grafana.md
+++ b/doc/howto/grafana.md
@@ -76,7 +76,7 @@ You can change the `instance` field through the `loki.instance` configuration ke
 
 The Prometheus `job_name` value can be found in `/var/snap/prometheus/current/prometheus.yml` (if you are using the snap) or `/etc/prometheus/prometheus.yaml` (otherwise).
 
-To set the loki.instance configuration key, run the following command:
+To set the `loki.instance` configuration key, run the following command:
 `lxc config set loki.instance=<job_name_value>`
 
 You can check that setting via:

--- a/doc/howto/grafana.md
+++ b/doc/howto/grafana.md
@@ -74,7 +74,7 @@ At the bottom of the page, you can see data for each instance.
 For proper operation of the Loki part of the dashboard, you need to ensure that the `instance` field matches the Prometheus job name.
 You can change the `instance` field through the `loki.instance` configuration key.
 
-The Prometheus job_name value can be found in `/var/snap/prometheus/current/prometheus.yml` (if you are using the snap) or `/etc/prometheus/prometheus.yaml` (otherwise).
+The Prometheus `job_name` value can be found in `/var/snap/prometheus/current/prometheus.yml` (if you are using the snap) or `/etc/prometheus/prometheus.yaml` (otherwise).
 
 To set the loki.instance configuration key, run the following command:
 `lxc config set loki.instance=<job_name_value>`

--- a/doc/howto/grafana.md
+++ b/doc/howto/grafana.md
@@ -72,7 +72,7 @@ At the bottom of the page, you can see data for each instance.
 
 ```{note}
 For proper operation of the Loki part of the dashboard, you need to ensure that the `instance` field matches the Prometheus job name.
-You can change the `instance` field through the `loki.instance` configuration key.
+You can change the `instance` field through the {config:option}`server-loki:loki.instance` configuration key.
 
 The Prometheus `job_name` value can be found in `/var/snap/prometheus/current/prometheus.yml` (if you are using the snap) or `/etc/prometheus/prometheus.yaml` (otherwise).
 

--- a/doc/howto/grafana.md
+++ b/doc/howto/grafana.md
@@ -73,4 +73,12 @@ At the bottom of the page, you can see data for each instance.
 ```{note}
 For proper operation of the Loki part of the dashboard, you need to ensure that the `instance` field matches the Prometheus job name.
 You can change the `instance` field through the `loki.instance` configuration key.
+
+The Prometheus job_name value can be found in `/var/snap/prometheus/current/prometheus.yml` (if you are using the snap) or `/etc/prometheus/prometheus.yaml` (otherwise).
+
+To set the loki.instance configuration key, run the following command:
+`lxc config set loki.instance=<job_name_value>`
+
+You can check that setting via:
+`lxc config get loki.instance`
 ```


### PR DESCRIPTION
Updated note at bottom of page with details on where to find the Prometheus job_name value, the command to set the value as the loki.instance key and the command to check/verify the value that was set.