### PR TITLE
Refactor: Unexport all methods defined on private receivers in the `lxc` package.

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -20,9 +20,9 @@ type cmdStart struct {
 	action *cmdAction
 }
 
-// The function Command() returns a cobra.Command object representing the "start" command.
+// The function  command() returns a cobra.Command object representing the "start" command.
 // It is used to start one or more instances specified by the user.
-func (c *cmdStart) Command() *cobra.Command {
+func (c *cmdStart) command() *cobra.Command {
 	cmdAction := cmdAction{global: c.global}
 	c.action = &cmdAction
 
@@ -41,9 +41,9 @@ type cmdPause struct {
 	action *cmdAction
 }
 
-// The function Command() returns a cobra.Command object representing the "pause" command.
+// The function  command() returns a cobra.Command object representing the "pause" command.
 // It is used to pause (or freeze) one or more instances specified by the user. This command is hidden and has an alias "freeze".
-func (c *cmdPause) Command() *cobra.Command {
+func (c *cmdPause) command() *cobra.Command {
 	cmdAction := cmdAction{global: c.global}
 	c.action = &cmdAction
 
@@ -63,9 +63,9 @@ type cmdRestart struct {
 	action *cmdAction
 }
 
-// The function Command() returns a cobra.Command object representing the "restart" command.
+// The function  command() returns a cobra.Command object representing the "restart" command.
 // It is used to restart one or more instances specified by the user. This command restarts the instances, which is the opposite of the "pause" command.
-func (c *cmdRestart) Command() *cobra.Command {
+func (c *cmdRestart) command() *cobra.Command {
 	cmdAction := cmdAction{global: c.global}
 	c.action = &cmdAction
 
@@ -86,9 +86,9 @@ type cmdStop struct {
 	action *cmdAction
 }
 
-// The function Command() returns a cobra.Command object representing the "stop" command.
+// The function  command() returns a cobra.Command object representing the "stop" command.
 // It is used to stop one or more instances specified by the user. This command stops the instances, effectively shutting them down.
-func (c *cmdStop) Command() *cobra.Command {
+func (c *cmdStop) command() *cobra.Command {
 	cmdAction := cmdAction{global: c.global}
 	c.action = &cmdAction
 
@@ -116,7 +116,7 @@ type cmdAction struct {
 // It creates a command with a specific action, defines flags based on that action, and assigns appropriate help text.
 func (c *cmdAction) Command(action string) *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVar(&c.flagAll, "all", false, i18n.G("Run against all instances"))
 
@@ -302,7 +302,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 
 // Run is a method of the cmdAction structure that implements the execution logic for the given Cobra command.
 // It handles actions on instances (single or all) and manages error handling, console flag restrictions, and batch operations.
-func (c *cmdAction) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdAction) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	var names []string

--- a/lxc/action.go
+++ b/lxc/action.go
@@ -267,7 +267,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		console := cmdConsole{}
 		console.global = c.global
 		console.flagType = c.flagConsole
-		return console.Console(d, name)
+		return console.runConsole(d, name)
 	}
 
 	progress := cli.ProgressRenderer{
@@ -294,7 +294,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		console := cmdConsole{}
 		console.global = c.global
 		console.flagType = c.flagConsole
-		return console.Console(d, name)
+		return console.runConsole(d, name)
 	}
 
 	return nil

--- a/lxc/alias.go
+++ b/lxc/alias.go
@@ -16,7 +16,7 @@ type cmdAlias struct {
 
 // Command is a method of the cmdAlias structure that returns a new cobra Command for managing command aliases.
 // This includes commands for adding, listing, renaming, and removing aliases, along with their usage and descriptions.
-func (c *cmdAlias) Command() *cobra.Command {
+func (c *cmdAlias) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("alias")
 	cmd.Short = i18n.G("Manage command aliases")
@@ -25,19 +25,19 @@ func (c *cmdAlias) Command() *cobra.Command {
 
 	// Add
 	aliasAddCmd := cmdAliasAdd{global: c.global, alias: c}
-	cmd.AddCommand(aliasAddCmd.Command())
+	cmd.AddCommand(aliasAddCmd.command())
 
 	// List
 	aliasListCmd := cmdAliasList{global: c.global, alias: c}
-	cmd.AddCommand(aliasListCmd.Command())
+	cmd.AddCommand(aliasListCmd.command())
 
 	// Rename
 	aliasRenameCmd := cmdAliasRename{global: c.global, alias: c}
-	cmd.AddCommand(aliasRenameCmd.Command())
+	cmd.AddCommand(aliasRenameCmd.command())
 
 	// Remove
 	aliasRemoveCmd := cmdAliasRemove{global: c.global, alias: c}
-	cmd.AddCommand(aliasRemoveCmd.Command())
+	cmd.AddCommand(aliasRemoveCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -53,7 +53,7 @@ type cmdAliasAdd struct {
 
 // Command is a method of the cmdAliasAdd structure that returns a new cobra Command for adding new command aliases.
 // It specifies the command usage, description, and examples, and links it to the RunE method for execution logic.
-func (c *cmdAliasAdd) Command() *cobra.Command {
+func (c *cmdAliasAdd) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("<alias> <target>"))
 	cmd.Short = i18n.G("Add new aliases")
@@ -63,14 +63,14 @@ func (c *cmdAliasAdd) Command() *cobra.Command {
 		`lxc alias add list "list -c ns46S"
     Overwrite the "list" command to pass -c ns46S.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is a method of the cmdAliasAdd structure. It implements the logic to add a new alias command.
 // The function checks for valid arguments, verifies if the alias already exists, and if not, adds the new alias to the configuration.
-func (c *cmdAliasAdd) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdAliasAdd) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -102,7 +102,7 @@ type cmdAliasList struct {
 
 // Command is a method of the cmdAliasList structure that returns a new cobra Command for listing command aliases.
 // It specifies the command usage, description, aliases, and output formatting options, and links it to the RunE method for execution logic.
-func (c *cmdAliasList) Command() *cobra.Command {
+func (c *cmdAliasList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list")
 	cmd.Aliases = []string{"ls"}
@@ -111,14 +111,14 @@ func (c *cmdAliasList) Command() *cobra.Command {
 		`List aliases`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is a method of the cmdAliasList structure. It implements the logic to list existing command aliases.
 // The function checks for valid arguments, collects all the aliases, sorts them, and renders them in the specified format.
-func (c *cmdAliasList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdAliasList) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -151,7 +151,7 @@ type cmdAliasRename struct {
 
 // Command is a method of the cmdAliasRename structure. It returns a new cobra.Command object.
 // This command allows a user to rename existing aliases in the CLI application.
-func (c *cmdAliasRename) Command() *cobra.Command {
+func (c *cmdAliasRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("<old alias> <new alias>"))
 	cmd.Aliases = []string{"mv"}
@@ -162,14 +162,14 @@ func (c *cmdAliasRename) Command() *cobra.Command {
 		`lxc alias rename list my-list
     Rename existing alias "list" to "my-list".`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is a method of the cmdAliasRename structure. It takes a cobra command and a slice of strings as arguments.
 // This method checks the validity of arguments, ensures the existence of the old alias, verifies the non-existence of the new alias, and then proceeds to rename the alias in the configuration.
-func (c *cmdAliasRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdAliasRename) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -206,7 +206,7 @@ type cmdAliasRemove struct {
 
 // Command is a method of the cmdAliasRemove structure. It configures and returns a cobra.Command object.
 // This command enables the removal of a given alias from the command line interface.
-func (c *cmdAliasRemove) Command() *cobra.Command {
+func (c *cmdAliasRemove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("<alias>"))
 	cmd.Aliases = []string{"rm"}
@@ -217,14 +217,14 @@ func (c *cmdAliasRemove) Command() *cobra.Command {
 		`lxc alias remove my-list
     Remove the "my-list" alias.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is a method of the cmdAliasRemove structure that executes the actual operation of the alias removal command.
 // It takes as input the name of the alias to be removed and updates the global configuration file to reflect this change.
-func (c *cmdAliasRemove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdAliasRemove) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -22,7 +22,7 @@ type cmdCluster struct {
 	global *cmdGlobal
 }
 
-func (c *cmdCluster) Command() *cobra.Command {
+func (c *cmdCluster) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("cluster")
 	cmd.Short = i18n.G("Manage cluster members")
@@ -31,73 +31,73 @@ func (c *cmdCluster) Command() *cobra.Command {
 
 	// List
 	clusterListCmd := cmdClusterList{global: c.global, cluster: c}
-	cmd.AddCommand(clusterListCmd.Command())
+	cmd.AddCommand(clusterListCmd.command())
 
 	// Rename
 	clusterRenameCmd := cmdClusterRename{global: c.global, cluster: c}
-	cmd.AddCommand(clusterRenameCmd.Command())
+	cmd.AddCommand(clusterRenameCmd.command())
 
 	// Remove
 	clusterRemoveCmd := cmdClusterRemove{global: c.global, cluster: c}
-	cmd.AddCommand(clusterRemoveCmd.Command())
+	cmd.AddCommand(clusterRemoveCmd.command())
 
 	// Show
 	clusterShowCmd := cmdClusterShow{global: c.global, cluster: c}
-	cmd.AddCommand(clusterShowCmd.Command())
+	cmd.AddCommand(clusterShowCmd.command())
 
 	// Info
 	clusterInfoCmd := cmdClusterInfo{global: c.global, cluster: c}
-	cmd.AddCommand(clusterInfoCmd.Command())
+	cmd.AddCommand(clusterInfoCmd.command())
 
 	// Get
 	clusterGetCmd := cmdClusterGet{global: c.global, cluster: c}
-	cmd.AddCommand(clusterGetCmd.Command())
+	cmd.AddCommand(clusterGetCmd.command())
 
 	// Set
 	clusterSetCmd := cmdClusterSet{global: c.global, cluster: c}
-	cmd.AddCommand(clusterSetCmd.Command())
+	cmd.AddCommand(clusterSetCmd.command())
 
 	// Unset
 	clusterUnsetCmd := cmdClusterUnset{global: c.global, cluster: c, clusterSet: &clusterSetCmd}
-	cmd.AddCommand(clusterUnsetCmd.Command())
+	cmd.AddCommand(clusterUnsetCmd.command())
 
 	// Enable
 	clusterEnableCmd := cmdClusterEnable{global: c.global, cluster: c}
-	cmd.AddCommand(clusterEnableCmd.Command())
+	cmd.AddCommand(clusterEnableCmd.command())
 
 	// Edit
 	clusterEditCmd := cmdClusterEdit{global: c.global, cluster: c}
-	cmd.AddCommand(clusterEditCmd.Command())
+	cmd.AddCommand(clusterEditCmd.command())
 
 	// Add token
 	cmdClusterAdd := cmdClusterAdd{global: c.global, cluster: c}
-	cmd.AddCommand(cmdClusterAdd.Command())
+	cmd.AddCommand(cmdClusterAdd.command())
 
 	// List tokens
 	cmdClusterListTokens := cmdClusterListTokens{global: c.global, cluster: c}
-	cmd.AddCommand(cmdClusterListTokens.Command())
+	cmd.AddCommand(cmdClusterListTokens.command())
 
 	// Revoke tokens
 	cmdClusterRevokeToken := cmdClusterRevokeToken{global: c.global, cluster: c}
-	cmd.AddCommand(cmdClusterRevokeToken.Command())
+	cmd.AddCommand(cmdClusterRevokeToken.command())
 
 	// Update certificate
 	cmdClusterUpdateCertificate := cmdClusterUpdateCertificate{global: c.global, cluster: c}
-	cmd.AddCommand(cmdClusterUpdateCertificate.Command())
+	cmd.AddCommand(cmdClusterUpdateCertificate.command())
 
 	// Evacuate cluster member
 	cmdClusterEvacuate := cmdClusterEvacuate{global: c.global, cluster: c}
-	cmd.AddCommand(cmdClusterEvacuate.Command())
+	cmd.AddCommand(cmdClusterEvacuate.command())
 
 	// Restore cluster member
 	cmdClusterRestore := cmdClusterRestore{global: c.global, cluster: c}
-	cmd.AddCommand(cmdClusterRestore.Command())
+	cmd.AddCommand(cmdClusterRestore.command())
 
 	clusterGroupCmd := cmdClusterGroup{global: c.global, cluster: c}
-	cmd.AddCommand(clusterGroupCmd.Command())
+	cmd.AddCommand(clusterGroupCmd.command())
 
 	clusterRoleCmd := cmdClusterRole{global: c.global, cluster: c}
-	cmd.AddCommand(clusterRoleCmd.Command())
+	cmd.AddCommand(clusterRoleCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -114,7 +114,7 @@ type cmdClusterList struct {
 	flagFormat string
 }
 
-func (c *cmdClusterList) Command() *cobra.Command {
+func (c *cmdClusterList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -123,12 +123,12 @@ func (c *cmdClusterList) Command() *cobra.Command {
 		`List all the cluster members`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -199,19 +199,19 @@ type cmdClusterShow struct {
 	cluster *cmdCluster
 }
 
-func (c *cmdClusterShow) Command() *cobra.Command {
+func (c *cmdClusterShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<member>"))
 	cmd.Short = i18n.G("Show details of a cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show details of a cluster member`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -248,19 +248,19 @@ type cmdClusterInfo struct {
 	cluster *cmdCluster
 }
 
-func (c *cmdClusterInfo) Command() *cobra.Command {
+func (c *cmdClusterInfo) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:]<member>"))
 	cmd.Short = i18n.G("Show useful information about a cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show useful information about a cluster member`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterInfo) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterInfo) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -299,19 +299,19 @@ type cmdClusterGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdClusterGet) Command() *cobra.Command {
+func (c *cmdClusterGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<member> <key>"))
 	cmd.Short = i18n.G("Get values for cluster member configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), cmd.Short)
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a cluster property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -360,19 +360,19 @@ type cmdClusterSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdClusterSet) Command() *cobra.Command {
+func (c *cmdClusterSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<member> <key>=<value>..."))
 	cmd.Short = i18n.G("Set a cluster member's configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), cmd.Short)
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a cluster property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -432,19 +432,19 @@ type cmdClusterUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdClusterUnset) Command() *cobra.Command {
+func (c *cmdClusterUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<member> <key>"))
 	cmd.Short = i18n.G("Unset a cluster member's configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), cmd.Short)
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a cluster property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -454,7 +454,7 @@ func (c *cmdClusterUnset) Run(cmd *cobra.Command, args []string) error {
 	c.clusterSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.clusterSet.Run(cmd, args)
+	return c.clusterSet.run(cmd, args)
 }
 
 // Rename.
@@ -463,7 +463,7 @@ type cmdClusterRename struct {
 	cluster *cmdCluster
 }
 
-func (c *cmdClusterRename) Command() *cobra.Command {
+func (c *cmdClusterRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<member> <new-name>"))
 	cmd.Aliases = []string{"mv"}
@@ -471,12 +471,12 @@ func (c *cmdClusterRename) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Rename a cluster member`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterRename) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -513,7 +513,7 @@ type cmdClusterRemove struct {
 	flagNonInteractive bool
 }
 
-func (c *cmdClusterRemove) Command() *cobra.Command {
+func (c *cmdClusterRemove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<member>"))
 	cmd.Aliases = []string{"rm"}
@@ -521,7 +521,7 @@ func (c *cmdClusterRemove) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove a member from the cluster`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force removing a member, even if degraded"))
 	cmd.Flags().BoolVar(&c.flagNonInteractive, "yes", false, i18n.G("Don't require user confirmation for using --force"))
 
@@ -555,7 +555,7 @@ Are you really sure you want to force removing %s? (yes/no): `), name)
 	return nil
 }
 
-func (c *cmdClusterRemove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterRemove) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -597,7 +597,7 @@ type cmdClusterEnable struct {
 	cluster *cmdCluster
 }
 
-func (c *cmdClusterEnable) Command() *cobra.Command {
+func (c *cmdClusterEnable) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("enable", i18n.G("[<remote>:] <name>"))
 	cmd.Short = i18n.G("Enable clustering on a single non-clustered LXD server")
@@ -611,12 +611,12 @@ func (c *cmdClusterEnable) Command() *cobra.Command {
   that by running 'lxc config get core.https_address', and possibly set a value
   for the address if not yet set.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterEnable) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterEnable) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
 	if exit {
@@ -682,7 +682,7 @@ type cmdClusterEdit struct {
 	cluster *cmdCluster
 }
 
-func (c *cmdClusterEdit) Command() *cobra.Command {
+func (c *cmdClusterEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<cluster member>"))
 	cmd.Short = i18n.G("Edit cluster member configurations as YAML")
@@ -692,7 +692,7 @@ func (c *cmdClusterEdit) Command() *cobra.Command {
 		`lxc cluster edit <cluster member> < member.yaml
     Update a cluster member using the content of member.yaml`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -703,7 +703,7 @@ func (c *cmdClusterEdit) helpTemplate() string {
 ### Any line starting with a '# will be ignored.`)
 }
 
-func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -797,19 +797,19 @@ type cmdClusterAdd struct {
 	flagName string
 }
 
-func (c *cmdClusterAdd) Command() *cobra.Command {
+func (c *cmdClusterAdd) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[[<remote>:]<name>]"))
 	cmd.Short = i18n.G("Request a join token for adding a cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Request a join token for adding a cluster member`))
 	cmd.Flags().StringVar(&c.flagName, "name", "", i18n.G("Cluster member name (alternative to passing it as an argument)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterAdd) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterAdd) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -873,19 +873,19 @@ type cmdClusterListTokens struct {
 	flagFormat string
 }
 
-func (c *cmdClusterListTokens) Command() *cobra.Command {
+func (c *cmdClusterListTokens) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list-tokens", i18n.G("[<remote>:]"))
 	cmd.Short = i18n.G("List all active cluster member join tokens")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`List all active cluster member join tokens`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterListTokens) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -975,17 +975,17 @@ type cmdClusterRevokeToken struct {
 	cluster *cmdCluster
 }
 
-func (c *cmdClusterRevokeToken) Command() *cobra.Command {
+func (c *cmdClusterRevokeToken) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("revoke-token", i18n.G("[<remote>:]<member>"))
 	cmd.Short = i18n.G("Revoke cluster member join token")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), cmd.Short)
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	return cmd
 }
 
-func (c *cmdClusterRevokeToken) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterRevokeToken) run(cmd *cobra.Command, args []string) error {
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
 		return err
@@ -1053,7 +1053,7 @@ type cmdClusterUpdateCertificate struct {
 	cluster *cmdCluster
 }
 
-func (c *cmdClusterUpdateCertificate) Command() *cobra.Command {
+func (c *cmdClusterUpdateCertificate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("update-certificate", i18n.G("[<remote>:] <cert.crt> <cert.key>"))
 	cmd.Aliases = []string{"update-cert"}
@@ -1061,11 +1061,11 @@ func (c *cmdClusterUpdateCertificate) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"),
 		i18n.G("Update cluster certificate with PEM certificate and key read from input files."))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	return cmd
 }
 
-func (c *cmdClusterUpdateCertificate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterUpdateCertificate) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
@@ -1157,7 +1157,7 @@ type cmdClusterEvacuate struct {
 	action  *cmdClusterEvacuateAction
 }
 
-func (c *cmdClusterEvacuate) Command() *cobra.Command {
+func (c *cmdClusterEvacuate) command() *cobra.Command {
 	cmdAction := cmdClusterEvacuateAction{global: c.global}
 	c.action = &cmdAction
 
@@ -1180,7 +1180,7 @@ type cmdClusterRestore struct {
 	action  *cmdClusterEvacuateAction
 }
 
-func (c *cmdClusterRestore) Command() *cobra.Command {
+func (c *cmdClusterRestore) command() *cobra.Command {
 	cmdAction := cmdClusterEvacuateAction{global: c.global}
 	c.action = &cmdAction
 
@@ -1196,12 +1196,12 @@ func (c *cmdClusterRestore) Command() *cobra.Command {
 
 func (c *cmdClusterEvacuateAction) Command(action string) *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterEvacuateAction) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterEvacuateAction) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1161,7 +1161,7 @@ func (c *cmdClusterEvacuate) command() *cobra.Command {
 	cmdAction := cmdClusterEvacuateAction{global: c.global}
 	c.action = &cmdAction
 
-	cmd := c.action.Command("evacuate")
+	cmd := c.action.command("evacuate")
 	cmd.Aliases = []string{"evac"}
 	cmd.Use = usage("evacuate", i18n.G("[<remote>:]<member>"))
 	cmd.Short = i18n.G("Evacuate cluster member")
@@ -1184,7 +1184,7 @@ func (c *cmdClusterRestore) command() *cobra.Command {
 	cmdAction := cmdClusterEvacuateAction{global: c.global}
 	c.action = &cmdAction
 
-	cmd := c.action.Command("restore")
+	cmd := c.action.command("restore")
 	cmd.Use = usage("restore", i18n.G("[<remote>:]<member>"))
 	cmd.Short = i18n.G("Restore cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Restore cluster member`))
@@ -1194,7 +1194,7 @@ func (c *cmdClusterRestore) command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdClusterEvacuateAction) Command(action string) *cobra.Command {
+func (c *cmdClusterEvacuateAction) command(action string) *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.RunE = c.run
 

--- a/lxc/cluster_group.go
+++ b/lxc/cluster_group.go
@@ -23,7 +23,7 @@ type cmdClusterGroup struct {
 }
 
 // Cluster management including assignment, creation, deletion, editing, listing, removal, renaming, and showing details.
-func (c *cmdClusterGroup) Command() *cobra.Command {
+func (c *cmdClusterGroup) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("group")
 	cmd.Short = i18n.G("Manage cluster groups")
@@ -32,39 +32,39 @@ func (c *cmdClusterGroup) Command() *cobra.Command {
 
 	// Assign
 	clusterGroupAssignCmd := cmdClusterGroupAssign{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupAssignCmd.Command())
+	cmd.AddCommand(clusterGroupAssignCmd.command())
 
 	// Create
 	clusterGroupCreateCmd := cmdClusterGroupCreate{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupCreateCmd.Command())
+	cmd.AddCommand(clusterGroupCreateCmd.command())
 
 	// Delete
 	clusterGroupDeleteCmd := cmdClusterGroupDelete{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupDeleteCmd.Command())
+	cmd.AddCommand(clusterGroupDeleteCmd.command())
 
 	// Edit
 	clusterGroupEditCmd := cmdClusterGroupEdit{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupEditCmd.Command())
+	cmd.AddCommand(clusterGroupEditCmd.command())
 
 	// List
 	clusterGroupListCmd := cmdClusterGroupList{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupListCmd.Command())
+	cmd.AddCommand(clusterGroupListCmd.command())
 
 	// Remove
 	clusterGroupRemoveCmd := cmdClusterGroupRemove{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupRemoveCmd.Command())
+	cmd.AddCommand(clusterGroupRemoveCmd.command())
 
 	// Rename
 	clusterGroupRenameCmd := cmdClusterGroupRename{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupRenameCmd.Command())
+	cmd.AddCommand(clusterGroupRenameCmd.command())
 
 	// Show
 	clusterGroupShowCmd := cmdClusterGroupShow{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupShowCmd.Command())
+	cmd.AddCommand(clusterGroupShowCmd.command())
 
 	// Add
 	clusterGroupAddCmd := cmdClusterGroupAdd{global: c.global, cluster: c.cluster}
-	cmd.AddCommand(clusterGroupAddCmd.Command())
+	cmd.AddCommand(clusterGroupAddCmd.command())
 
 	return cmd
 }
@@ -76,7 +76,7 @@ type cmdClusterGroupAssign struct {
 }
 
 // Setting a groups to cluster members, setting usage, description, examples, and the RunE method.
-func (c *cmdClusterGroupAssign) Command() *cobra.Command {
+func (c *cmdClusterGroupAssign) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("assign", i18n.G("[<remote>:]<member> <group>"))
 	cmd.Aliases = []string{"apply"}
@@ -90,13 +90,13 @@ func (c *cmdClusterGroupAssign) Command() *cobra.Command {
 lxc cluster group assign foo default
     Reset "foo" to only using the "default" cluster group.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Groups assigning to a cluster member, performing checks, parsing arguments, and updating the member's group configuration.
-func (c *cmdClusterGroupAssign) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupAssign) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -150,20 +150,20 @@ type cmdClusterGroupCreate struct {
 }
 
 // Creation of a new cluster group, defining its usage, short and long descriptions, and the RunE method.
-func (c *cmdClusterGroupCreate) Command() *cobra.Command {
+func (c *cmdClusterGroupCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<group>"))
 	cmd.Short = i18n.G("Create a cluster group")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create a cluster group`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // It creates new cluster group after performing checks, parsing arguments, and making the server call for creation.
-func (c *cmdClusterGroupCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -206,7 +206,7 @@ type cmdClusterGroupDelete struct {
 }
 
 // It deletes a cluster group, setting up usage, descriptions, aliases, and the RunE method.
-func (c *cmdClusterGroupDelete) Command() *cobra.Command {
+func (c *cmdClusterGroupDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<group>"))
 	cmd.Aliases = []string{"rm"}
@@ -214,13 +214,13 @@ func (c *cmdClusterGroupDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete a cluster group`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // It's the deletion of a cluster group after argument checks, parsing, and making the server call for deletion.
-func (c *cmdClusterGroupDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -259,20 +259,20 @@ type cmdClusterGroupEdit struct {
 }
 
 // This Command generates the cobra command that enables the editing of a cluster group's attributes.
-func (c *cmdClusterGroupEdit) Command() *cobra.Command {
+func (c *cmdClusterGroupEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<group>"))
 	cmd.Short = i18n.G("Edit a cluster group")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Edit a cluster group`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // The modification of a cluster group's configuration, either through an editor or via the terminal.
-func (c *cmdClusterGroupEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -374,7 +374,7 @@ type cmdClusterGroupList struct {
 }
 
 // Command returns a cobra command to list all the cluster groups in a specified format.
-func (c *cmdClusterGroupList) Command() *cobra.Command {
+func (c *cmdClusterGroupList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -383,13 +383,13 @@ func (c *cmdClusterGroupList) Command() *cobra.Command {
 		`List all the cluster groups`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run executes the command to list all the cluster groups, their descriptions, and number of members.
-func (c *cmdClusterGroupList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -449,20 +449,20 @@ type cmdClusterGroupRemove struct {
 }
 
 // Removal of a specified member from a specific cluster group.
-func (c *cmdClusterGroupRemove) Command() *cobra.Command {
+func (c *cmdClusterGroupRemove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<member> <group>"))
 	cmd.Short = i18n.G("Remove member from group")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove a cluster member from a cluster group`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // The removal process of a cluster member from a specific cluster group, with verbose output unless the 'quiet' flag is set.
-func (c *cmdClusterGroupRemove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupRemove) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -521,7 +521,7 @@ type cmdClusterGroupRename struct {
 }
 
 // Renaming a cluster group, defining usage, aliases, and linking the associated runtime function.
-func (c *cmdClusterGroupRename) Command() *cobra.Command {
+func (c *cmdClusterGroupRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<group> <new-name>"))
 	cmd.Aliases = []string{"mv"}
@@ -529,13 +529,13 @@ func (c *cmdClusterGroupRename) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Rename a cluster group`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Renaming operation of a cluster group after checking arguments and parsing the remote server, and provides appropriate output.
-func (c *cmdClusterGroupRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupRename) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -570,20 +570,20 @@ type cmdClusterGroupShow struct {
 }
 
 // Setting up the 'show' command to display the configurations of a specified cluster group in a remote server.
-func (c *cmdClusterGroupShow) Command() *cobra.Command {
+func (c *cmdClusterGroupShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<group>"))
 	cmd.Short = i18n.G("Show cluster group configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show cluster group configurations`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // This retrieves and prints the configuration details of a specified cluster group from a remote server in YAML format.
-func (c *cmdClusterGroupShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -624,19 +624,19 @@ type cmdClusterGroupAdd struct {
 	cluster *cmdCluster
 }
 
-func (c *cmdClusterGroupAdd) Command() *cobra.Command {
+func (c *cmdClusterGroupAdd) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<member> <group>"))
 	cmd.Short = i18n.G("Add member to group")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Add a cluster member to a cluster group`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdClusterGroupAdd) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterGroupAdd) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {

--- a/lxc/cluster_role.go
+++ b/lxc/cluster_role.go
@@ -16,7 +16,7 @@ type cmdClusterRole struct {
 }
 
 // It uses the cmdGlobal, cmdCluster, and cmdClusterRole structs for context and operation.
-func (c *cmdClusterRole) Command() *cobra.Command {
+func (c *cmdClusterRole) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("role")
 	cmd.Short = i18n.G("Manage cluster roles")
@@ -24,11 +24,11 @@ func (c *cmdClusterRole) Command() *cobra.Command {
 
 	// Add
 	clusterRoleAddCmd := cmdClusterRoleAdd{global: c.global, cluster: c.cluster, clusterRole: c}
-	cmd.AddCommand(clusterRoleAddCmd.Command())
+	cmd.AddCommand(clusterRoleAddCmd.command())
 
 	// Remove
 	clusterRoleRemoveCmd := cmdClusterRoleRemove{global: c.global, cluster: c.cluster, clusterRole: c}
-	cmd.AddCommand(clusterRoleRemoveCmd.Command())
+	cmd.AddCommand(clusterRoleRemoveCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -43,20 +43,20 @@ type cmdClusterRoleAdd struct {
 }
 
 // Setting up the usage, short description, and long description of the command, as well as its RunE method.
-func (c *cmdClusterRoleAdd) Command() *cobra.Command {
+func (c *cmdClusterRoleAdd) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<member> <role[,role...]>"))
 	cmd.Short = i18n.G("Add roles to a cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Add roles to a cluster member`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // It checks and parses input arguments, verifies role assignment, and updates the member's roles.
-func (c *cmdClusterRoleAdd) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterRoleAdd) run(cmd *cobra.Command, args []string) error {
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
 		return err
@@ -99,20 +99,20 @@ type cmdClusterRoleRemove struct {
 }
 
 // Removing the roles from a cluster member, setting up usage, descriptions, and the RunE method.
-func (c *cmdClusterRoleRemove) Command() *cobra.Command {
+func (c *cmdClusterRoleRemove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<member> <role[,role...]>"))
 	cmd.Short = i18n.G("Remove roles from a cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove roles from a cluster member`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run executes the removal of specified roles from a cluster member, checking inputs, validating role assignment, and updating the member's roles.
-func (c *cmdClusterRoleRemove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdClusterRoleRemove) run(cmd *cobra.Command, args []string) error {
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
 		return err

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -25,7 +25,7 @@ type cmdConfig struct {
 
 // Command creates a Cobra command for managing instance and server configurations,
 // including options for device, edit, get, metadata, profile, set, show, template, trust, and unset.
-func (c *cmdConfig) Command() *cobra.Command {
+func (c *cmdConfig) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("config")
 	cmd.Short = i18n.G("Manage instance and server configuration options")
@@ -34,50 +34,50 @@ func (c *cmdConfig) Command() *cobra.Command {
 
 	// Device
 	configDeviceCmd := cmdConfigDevice{global: c.global, config: c}
-	cmd.AddCommand(configDeviceCmd.Command())
+	cmd.AddCommand(configDeviceCmd.command())
 
 	// Edit
 	configEditCmd := cmdConfigEdit{global: c.global, config: c}
-	cmd.AddCommand(configEditCmd.Command())
+	cmd.AddCommand(configEditCmd.command())
 
 	// Get
 	configGetCmd := cmdConfigGet{global: c.global, config: c}
-	cmd.AddCommand(configGetCmd.Command())
+	cmd.AddCommand(configGetCmd.command())
 
 	// Metadata
 	configMetadataCmd := cmdConfigMetadata{global: c.global, config: c}
-	cmd.AddCommand(configMetadataCmd.Command())
+	cmd.AddCommand(configMetadataCmd.command())
 
 	// Profile
 	configProfileCmd := cmdProfile{global: c.global}
-	profileCmd := configProfileCmd.Command()
+	profileCmd := configProfileCmd.command()
 	profileCmd.Hidden = true
 	profileCmd.Deprecated = i18n.G("please use `lxc profile`")
 	cmd.AddCommand(profileCmd)
 
 	// Set
 	configSetCmd := cmdConfigSet{global: c.global, config: c}
-	cmd.AddCommand(configSetCmd.Command())
+	cmd.AddCommand(configSetCmd.command())
 
 	// Show
 	configShowCmd := cmdConfigShow{global: c.global, config: c}
-	cmd.AddCommand(configShowCmd.Command())
+	cmd.AddCommand(configShowCmd.command())
 
 	// Template
 	configTemplateCmd := cmdConfigTemplate{global: c.global, config: c}
-	cmd.AddCommand(configTemplateCmd.Command())
+	cmd.AddCommand(configTemplateCmd.command())
 
 	// Trust
 	configTrustCmd := cmdConfigTrust{global: c.global, config: c}
-	cmd.AddCommand(configTrustCmd.Command())
+	cmd.AddCommand(configTrustCmd.command())
 
 	// Unset
 	configUnsetCmd := cmdConfigUnset{global: c.global, config: c, configSet: &configSetCmd}
-	cmd.AddCommand(configUnsetCmd.Command())
+	cmd.AddCommand(configUnsetCmd.command())
 
 	// Uefi
 	configUefiCmd := cmdConfigUefi{global: c.global, config: c}
-	cmd.AddCommand(configUefiCmd.Command())
+	cmd.AddCommand(configUefiCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -92,7 +92,7 @@ type cmdConfigEdit struct {
 }
 
 // Command creates a Cobra command to edit instance or server configurations using YAML, with optional flags for targeting cluster members.
-func (c *cmdConfigEdit) Command() *cobra.Command {
+func (c *cmdConfigEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:][<instance>[/<snapshot>]]"))
 	cmd.Short = i18n.G("Edit instance or server configurations as YAML")
@@ -103,7 +103,7 @@ func (c *cmdConfigEdit) Command() *cobra.Command {
     Update the instance configuration from config.yaml.`))
 
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -131,7 +131,7 @@ func (c *cmdConfigEdit) helpTemplate() string {
 }
 
 // Run executes the config edit command, allowing users to edit instance or server configurations via an interactive YAML editor.
-func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -377,7 +377,7 @@ type cmdConfigGet struct {
 
 // Command creates a Cobra command to fetch values for given instance or server configuration keys,
 // with optional flags for expanded configuration and cluster targeting.
-func (c *cmdConfigGet) Command() *cobra.Command {
+func (c *cmdConfigGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:][<instance>] <key>"))
 	cmd.Short = i18n.G("Get values for instance or server configuration keys")
@@ -387,13 +387,13 @@ func (c *cmdConfigGet) Command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.flagExpanded, "expanded", "e", false, i18n.G("Access the expanded configuration"))
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as an instance property"))
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run fetches and prints the specified configuration key's value for an instance or server, also handling target and expansion flags.
-func (c *cmdConfigGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
 	if exit {
@@ -510,7 +510,7 @@ type cmdConfigSet struct {
 }
 
 // Command creates a new Cobra command to set instance or server configuration keys and returns it.
-func (c *cmdConfigSet) Command() *cobra.Command {
+func (c *cmdConfigSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:][<instance>] <key>=<value>..."))
 	cmd.Short = i18n.G("Set instance or server configuration keys")
@@ -531,13 +531,13 @@ lxc config set core.trust_password=blah
 
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as an instance property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run executes the "set" command, updating instance or server configuration keys based on provided arguments.
-func (c *cmdConfigSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -727,7 +727,7 @@ type cmdConfigShow struct {
 }
 
 // Command sets up the "show" command, which displays instance or server configurations based on the provided arguments.
-func (c *cmdConfigShow) Command() *cobra.Command {
+func (c *cmdConfigShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:][<instance>[/<snapshot>]]"))
 	cmd.Short = i18n.G("Show instance or server configurations")
@@ -736,13 +736,13 @@ func (c *cmdConfigShow) Command() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&c.flagExpanded, "expanded", "e", false, i18n.G("Show the expanded configuration"))
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run executes the "show" command, displaying the YAML-formatted configuration of a specified server or instance.
-func (c *cmdConfigShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -851,7 +851,7 @@ type cmdConfigUnset struct {
 }
 
 // Command generates a new "unset" command to remove specific configuration keys for an instance or server.
-func (c *cmdConfigUnset) Command() *cobra.Command {
+func (c *cmdConfigUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:][<instance>] <key>"))
 	cmd.Short = i18n.G("Unset instance or server configuration keys")
@@ -860,13 +860,13 @@ func (c *cmdConfigUnset) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as an instance property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run executes the "unset" command, delegating to the "set" command to remove specific configuration keys.
-func (c *cmdConfigUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
 	if exit {
@@ -876,7 +876,7 @@ func (c *cmdConfigUnset) Run(cmd *cobra.Command, args []string) error {
 	c.configSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.configSet.Run(cmd, args)
+	return c.configSet.run(cmd, args)
 }
 
 type cmdConfigUefi struct {
@@ -886,7 +886,7 @@ type cmdConfigUefi struct {
 
 // Command creates a Cobra command for managing virtual machine instance UEFI variables,
 // including options for get, set, unset, show, edit.
-func (c *cmdConfigUefi) Command() *cobra.Command {
+func (c *cmdConfigUefi) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("uefi")
 	cmd.Short = i18n.G("Manage instance UEFI variables")
@@ -895,23 +895,23 @@ func (c *cmdConfigUefi) Command() *cobra.Command {
 
 	// Get
 	configUefiGetCmd := cmdConfigUefiGet{global: c.global, configUefi: c}
-	cmd.AddCommand(configUefiGetCmd.Command())
+	cmd.AddCommand(configUefiGetCmd.command())
 
 	// Set
 	configUefiSetCmd := cmdConfigUefiSet{global: c.global, configUefi: c}
-	cmd.AddCommand(configUefiSetCmd.Command())
+	cmd.AddCommand(configUefiSetCmd.command())
 
 	// Unset
 	configUefiUnsetCmd := cmdConfigUefiUnset{global: c.global, configUefi: c, configSet: &configUefiSetCmd}
-	cmd.AddCommand(configUefiUnsetCmd.Command())
+	cmd.AddCommand(configUefiUnsetCmd.command())
 
 	// Show
 	configUefiShowCmd := cmdConfigUefiShow{global: c.global, configUefi: c}
-	cmd.AddCommand(configUefiShowCmd.Command())
+	cmd.AddCommand(configUefiShowCmd.command())
 
 	// Edit
 	configUefiEditCmd := cmdConfigUefiEdit{global: c.global, configUefi: c}
-	cmd.AddCommand(configUefiEditCmd.Command())
+	cmd.AddCommand(configUefiEditCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -926,20 +926,20 @@ type cmdConfigUefiGet struct {
 }
 
 // Command creates a Cobra command to fetch virtual machine instance UEFI variables.
-func (c *cmdConfigUefiGet) Command() *cobra.Command {
+func (c *cmdConfigUefiGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<instance> <key>"))
 	cmd.Short = i18n.G("Get UEFI variables for instance")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Get UEFI variables for instance`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run fetches and prints the specified UEFI variable's value.
-func (c *cmdConfigUefiGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigUefiGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -981,7 +981,7 @@ type cmdConfigUefiSet struct {
 }
 
 // Command creates a new Cobra command to set virtual machine instance UEFI variables.
-func (c *cmdConfigUefiSet) Command() *cobra.Command {
+func (c *cmdConfigUefiSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<instance> <key>=<value>..."))
 	cmd.Short = i18n.G("Set UEFI variables for instance")
@@ -991,13 +991,13 @@ func (c *cmdConfigUefiSet) Command() *cobra.Command {
 		`lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb
     Set a UEFI variable with name "testvar", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value "aabb" (HEX-encoded) for the instance.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run executes the "set" command, updating virtual machine instance UEFI variables based on provided arguments.
-func (c *cmdConfigUefiSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigUefiSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -1072,20 +1072,20 @@ type cmdConfigUefiUnset struct {
 }
 
 // Command generates a new "unset" command to remove specific virtual machine instance UEFI variable.
-func (c *cmdConfigUefiUnset) Command() *cobra.Command {
+func (c *cmdConfigUefiUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<instance> <key>"))
 	cmd.Short = i18n.G("Unset UEFI variables for instance")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Unset UEFI variables for instance`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run executes the "unset" command, delegating to the "set" command to remove specific UEFI variable.
-func (c *cmdConfigUefiUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigUefiUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1093,7 +1093,7 @@ func (c *cmdConfigUefiUnset) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	args = append(args, "")
-	return c.configSet.Run(cmd, args)
+	return c.configSet.run(cmd, args)
 }
 
 // Show.
@@ -1103,20 +1103,20 @@ type cmdConfigUefiShow struct {
 }
 
 // Command sets up the "show" command, which displays virtual machine instance UEFI variables based on the provided arguments.
-func (c *cmdConfigUefiShow) Command() *cobra.Command {
+func (c *cmdConfigUefiShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<instance>"))
 	cmd.Short = i18n.G("Show instance UEFI variables")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show instance UEFI variables`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run executes the "show" command, displaying the YAML-formatted configuration of a virtual machine instance UEFI variables.
-func (c *cmdConfigUefiShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigUefiShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -1157,7 +1157,7 @@ type cmdConfigUefiEdit struct {
 }
 
 // Command creates a Cobra command to edit virtual machine instance UEFI variables.
-func (c *cmdConfigUefiEdit) Command() *cobra.Command {
+func (c *cmdConfigUefiEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<instance>"))
 	cmd.Short = i18n.G("Edit instance UEFI variables")
@@ -1167,7 +1167,7 @@ func (c *cmdConfigUefiEdit) Command() *cobra.Command {
 		`lxc config uefi edit <instance> < instance_uefi_vars.yaml
     Set the instance UEFI variables from instance_uefi_vars.yaml.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -1208,7 +1208,7 @@ func (c *cmdConfigUefiEdit) helpTemplate() string {
 }
 
 // Run executes the config edit command, allowing users to edit virtual machine instance UEFI variables via an interactive YAML editor.
-func (c *cmdConfigUefiEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigUefiEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {

--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -17,7 +17,7 @@ type cmdConfigDevice struct {
 	profile *cmdProfile
 }
 
-func (c *cmdConfigDevice) Command() *cobra.Command {
+func (c *cmdConfigDevice) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("device")
 	cmd.Short = i18n.G("Manage devices")
@@ -26,37 +26,37 @@ func (c *cmdConfigDevice) Command() *cobra.Command {
 
 	// Add
 	configDeviceAddCmd := cmdConfigDeviceAdd{global: c.global, config: c.config, profile: c.profile, configDevice: c}
-	cmd.AddCommand(configDeviceAddCmd.Command())
+	cmd.AddCommand(configDeviceAddCmd.command())
 
 	// Get
 	configDeviceGetCmd := cmdConfigDeviceGet{global: c.global, config: c.config, profile: c.profile, configDevice: c}
-	cmd.AddCommand(configDeviceGetCmd.Command())
+	cmd.AddCommand(configDeviceGetCmd.command())
 
 	// List
 	configDeviceListCmd := cmdConfigDeviceList{global: c.global, config: c.config, profile: c.profile, configDevice: c}
-	cmd.AddCommand(configDeviceListCmd.Command())
+	cmd.AddCommand(configDeviceListCmd.command())
 
 	// Override
 	if c.config != nil {
 		configDeviceOverrideCmd := cmdConfigDeviceOverride{global: c.global, config: c.config, profile: c.profile, configDevice: c}
-		cmd.AddCommand(configDeviceOverrideCmd.Command())
+		cmd.AddCommand(configDeviceOverrideCmd.command())
 	}
 
 	// Remove
 	configDeviceRemoveCmd := cmdConfigDeviceRemove{global: c.global, config: c.config, profile: c.profile, configDevice: c}
-	cmd.AddCommand(configDeviceRemoveCmd.Command())
+	cmd.AddCommand(configDeviceRemoveCmd.command())
 
 	// Set
 	configDeviceSetCmd := cmdConfigDeviceSet{global: c.global, config: c.config, profile: c.profile, configDevice: c}
-	cmd.AddCommand(configDeviceSetCmd.Command())
+	cmd.AddCommand(configDeviceSetCmd.command())
 
 	// Show
 	configDeviceShowCmd := cmdConfigDeviceShow{global: c.global, config: c.config, profile: c.profile, configDevice: c}
-	cmd.AddCommand(configDeviceShowCmd.Command())
+	cmd.AddCommand(configDeviceShowCmd.command())
 
 	// Unset
 	configDeviceUnsetCmd := cmdConfigDeviceUnset{global: c.global, config: c.config, profile: c.profile, configDevice: c, configDeviceSet: &configDeviceSetCmd}
-	cmd.AddCommand(configDeviceUnsetCmd.Command())
+	cmd.AddCommand(configDeviceUnsetCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -72,7 +72,7 @@ type cmdConfigDeviceAdd struct {
 	profile      *cmdProfile
 }
 
-func (c *cmdConfigDeviceAdd) Command() *cobra.Command {
+func (c *cmdConfigDeviceAdd) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Short = i18n.G("Add instance devices")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
@@ -95,12 +95,12 @@ lxc profile device add [<remote>:]profile1 <device-name> disk pool=some-pool sou
     Will mount the some-volume volume on some-pool onto /opt in the instance.`))
 	}
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigDeviceAdd) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigDeviceAdd) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -196,7 +196,7 @@ type cmdConfigDeviceGet struct {
 	profile      *cmdProfile
 }
 
-func (c *cmdConfigDeviceGet) Command() *cobra.Command {
+func (c *cmdConfigDeviceGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	if c.config != nil {
 		cmd.Use = usage("get", i18n.G("[<remote>:]<instance> <device> <key>"))
@@ -208,12 +208,12 @@ func (c *cmdConfigDeviceGet) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Get values for device configuration keys`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigDeviceGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -278,7 +278,7 @@ type cmdConfigDeviceList struct {
 	profile      *cmdProfile
 }
 
-func (c *cmdConfigDeviceList) Command() *cobra.Command {
+func (c *cmdConfigDeviceList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Aliases = []string{"ls"}
 	cmd.Short = i18n.G("List instance devices")
@@ -290,12 +290,12 @@ func (c *cmdConfigDeviceList) Command() *cobra.Command {
 		cmd.Use = usage("list", i18n.G("[<remote>:]<profile>"))
 	}
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigDeviceList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigDeviceList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -349,19 +349,19 @@ type cmdConfigDeviceOverride struct {
 	profile      *cmdProfile
 }
 
-func (c *cmdConfigDeviceOverride) Command() *cobra.Command {
+func (c *cmdConfigDeviceOverride) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("override", i18n.G("[<remote>:]<instance> <device> [key=value...]"))
 	cmd.Short = i18n.G("Copy profile inherited devices and override configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Copy profile inherited devices and override configuration keys`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigDeviceOverride) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigDeviceOverride) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -437,7 +437,7 @@ type cmdConfigDeviceRemove struct {
 	profile      *cmdProfile
 }
 
-func (c *cmdConfigDeviceRemove) Command() *cobra.Command {
+func (c *cmdConfigDeviceRemove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	if c.config != nil {
 		cmd.Use = usage("remove", i18n.G("[<remote>:]<instance> <name>..."))
@@ -450,12 +450,12 @@ func (c *cmdConfigDeviceRemove) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove instance devices`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigDeviceRemove) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -540,7 +540,7 @@ type cmdConfigDeviceSet struct {
 	profile      *cmdProfile
 }
 
-func (c *cmdConfigDeviceSet) Command() *cobra.Command {
+func (c *cmdConfigDeviceSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Short = i18n.G("Set device configuration keys")
 	if c.config != nil {
@@ -559,12 +559,12 @@ For backward compatibility, a single configuration key may still be set with:
     lxc profile device set [<remote>:]<profile> <device> <key> <value>`))
 	}
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigDeviceSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -656,7 +656,7 @@ type cmdConfigDeviceShow struct {
 	profile      *cmdProfile
 }
 
-func (c *cmdConfigDeviceShow) Command() *cobra.Command {
+func (c *cmdConfigDeviceShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	if c.config != nil {
 		cmd.Use = usage("show", i18n.G("[<remote>:]<instance>"))
@@ -668,12 +668,12 @@ func (c *cmdConfigDeviceShow) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show full device configuration`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigDeviceShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigDeviceShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -729,7 +729,7 @@ type cmdConfigDeviceUnset struct {
 	profile         *cmdProfile
 }
 
-func (c *cmdConfigDeviceUnset) Command() *cobra.Command {
+func (c *cmdConfigDeviceUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	if c.config != nil {
 		cmd.Use = usage("unset", i18n.G("[<remote>:]<instance> <device> <key>"))
@@ -741,12 +741,12 @@ func (c *cmdConfigDeviceUnset) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Unset device configuration keys`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigDeviceUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigDeviceUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -754,5 +754,5 @@ func (c *cmdConfigDeviceUnset) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	args = append(args, "")
-	return c.configDeviceSet.Run(cmd, args)
+	return c.configDeviceSet.run(cmd, args)
 }

--- a/lxc/config_metadata.go
+++ b/lxc/config_metadata.go
@@ -20,7 +20,7 @@ type cmdConfigMetadata struct {
 	config *cmdConfig
 }
 
-func (c *cmdConfigMetadata) Command() *cobra.Command {
+func (c *cmdConfigMetadata) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("metadata")
 	cmd.Short = i18n.G("Manage instance metadata files")
@@ -29,11 +29,11 @@ func (c *cmdConfigMetadata) Command() *cobra.Command {
 
 	// Edit
 	configMetadataEditCmd := cmdConfigMetadataEdit{global: c.global, config: c.config, configMetadata: c}
-	cmd.AddCommand(configMetadataEditCmd.Command())
+	cmd.AddCommand(configMetadataEditCmd.command())
 
 	// Show
 	configMetadataShowCmd := cmdConfigMetadataShow{global: c.global, config: c.config, configMetadata: c}
-	cmd.AddCommand(configMetadataShowCmd.Command())
+	cmd.AddCommand(configMetadataShowCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -48,14 +48,14 @@ type cmdConfigMetadataEdit struct {
 	configMetadata *cmdConfigMetadata
 }
 
-func (c *cmdConfigMetadataEdit) Command() *cobra.Command {
+func (c *cmdConfigMetadataEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<instance>"))
 	cmd.Short = i18n.G("Edit instance metadata files")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Edit instance metadata files`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -84,7 +84,7 @@ func (c *cmdConfigMetadataEdit) helpTemplate() string {
 ###     properties: {}`)
 }
 
-func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigMetadataEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -173,19 +173,19 @@ type cmdConfigMetadataShow struct {
 	configMetadata *cmdConfigMetadata
 }
 
-func (c *cmdConfigMetadataShow) Command() *cobra.Command {
+func (c *cmdConfigMetadataShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<instance>"))
 	cmd.Short = i18n.G("Show instance metadata files")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show instance metadata files`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigMetadataShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigMetadataShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -20,7 +20,7 @@ type cmdConfigTemplate struct {
 	config *cmdConfig
 }
 
-func (c *cmdConfigTemplate) Command() *cobra.Command {
+func (c *cmdConfigTemplate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("template")
 	cmd.Short = i18n.G("Manage instance file templates")
@@ -29,23 +29,23 @@ func (c *cmdConfigTemplate) Command() *cobra.Command {
 
 	// Create
 	configTemplateCreateCmd := cmdConfigTemplateCreate{global: c.global, config: c.config, configTemplate: c}
-	cmd.AddCommand(configTemplateCreateCmd.Command())
+	cmd.AddCommand(configTemplateCreateCmd.command())
 
 	// Delete
 	configTemplateDeleteCmd := cmdConfigTemplateDelete{global: c.global, config: c.config, configTemplate: c}
-	cmd.AddCommand(configTemplateDeleteCmd.Command())
+	cmd.AddCommand(configTemplateDeleteCmd.command())
 
 	// Edit
 	configTemplateEditCmd := cmdConfigTemplateEdit{global: c.global, config: c.config, configTemplate: c}
-	cmd.AddCommand(configTemplateEditCmd.Command())
+	cmd.AddCommand(configTemplateEditCmd.command())
 
 	// List
 	configTemplateListCmd := cmdConfigTemplateList{global: c.global, config: c.config, configTemplate: c}
-	cmd.AddCommand(configTemplateListCmd.Command())
+	cmd.AddCommand(configTemplateListCmd.command())
 
 	// Show
 	configTemplateShowCmd := cmdConfigTemplateShow{global: c.global, config: c.config, configTemplate: c}
-	cmd.AddCommand(configTemplateShowCmd.Command())
+	cmd.AddCommand(configTemplateShowCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -60,19 +60,19 @@ type cmdConfigTemplateCreate struct {
 	configTemplate *cmdConfigTemplate
 }
 
-func (c *cmdConfigTemplateCreate) Command() *cobra.Command {
+func (c *cmdConfigTemplateCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<instance> <template>"))
 	cmd.Short = i18n.G("Create new instance file templates")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create new instance file templates`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTemplateCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTemplateCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -102,7 +102,7 @@ type cmdConfigTemplateDelete struct {
 	configTemplate *cmdConfigTemplate
 }
 
-func (c *cmdConfigTemplateDelete) Command() *cobra.Command {
+func (c *cmdConfigTemplateDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<instance> <template>"))
 	cmd.Aliases = []string{"rm"}
@@ -110,12 +110,12 @@ func (c *cmdConfigTemplateDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete instance file templates`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTemplateDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTemplateDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -145,19 +145,19 @@ type cmdConfigTemplateEdit struct {
 	configTemplate *cmdConfigTemplate
 }
 
-func (c *cmdConfigTemplateEdit) Command() *cobra.Command {
+func (c *cmdConfigTemplateEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<instance> <template>"))
 	cmd.Short = i18n.G("Edit instance file templates")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Edit instance file templates`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTemplateEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -233,7 +233,7 @@ type cmdConfigTemplateList struct {
 	flagFormat string
 }
 
-func (c *cmdConfigTemplateList) Command() *cobra.Command {
+func (c *cmdConfigTemplateList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<instance>"))
 	cmd.Short = i18n.G("List instance file templates")
@@ -241,12 +241,12 @@ func (c *cmdConfigTemplateList) Command() *cobra.Command {
 		`List instance file templates`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTemplateList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTemplateList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -293,19 +293,19 @@ type cmdConfigTemplateShow struct {
 	configTemplate *cmdConfigTemplate
 }
 
-func (c *cmdConfigTemplateShow) Command() *cobra.Command {
+func (c *cmdConfigTemplateShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<instance> <template>"))
 	cmd.Short = i18n.G("Show content of instance file templates")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show content of instance file templates`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTemplateShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTemplateShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -27,7 +27,7 @@ type cmdConfigTrust struct {
 	config *cmdConfig
 }
 
-func (c *cmdConfigTrust) Command() *cobra.Command {
+func (c *cmdConfigTrust) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("trust")
 	cmd.Short = i18n.G("Manage trusted clients")
@@ -36,31 +36,31 @@ func (c *cmdConfigTrust) Command() *cobra.Command {
 
 	// Add
 	configTrustAddCmd := cmdConfigTrustAdd{global: c.global, config: c.config, configTrust: c}
-	cmd.AddCommand(configTrustAddCmd.Command())
+	cmd.AddCommand(configTrustAddCmd.command())
 
 	// Edit
 	configTrustEditCmd := cmdConfigTrustEdit{global: c.global, config: c.config, configTrust: c}
-	cmd.AddCommand(configTrustEditCmd.Command())
+	cmd.AddCommand(configTrustEditCmd.command())
 
 	// List
 	configTrustListCmd := cmdConfigTrustList{global: c.global, config: c.config, configTrust: c}
-	cmd.AddCommand(configTrustListCmd.Command())
+	cmd.AddCommand(configTrustListCmd.command())
 
 	// List tokens
 	configTrustListTokensCmd := cmdConfigTrustListTokens{global: c.global, config: c.config, configTrust: c}
-	cmd.AddCommand(configTrustListTokensCmd.Command())
+	cmd.AddCommand(configTrustListTokensCmd.command())
 
 	// Remove
 	configTrustRemoveCmd := cmdConfigTrustRemove{global: c.global, config: c.config, configTrust: c}
-	cmd.AddCommand(configTrustRemoveCmd.Command())
+	cmd.AddCommand(configTrustRemoveCmd.command())
 
 	// Revoke token
 	configTrustRevokeTokenCmd := cmdConfigTrustRevokeToken{global: c.global, config: c.config, configTrust: c}
-	cmd.AddCommand(configTrustRevokeTokenCmd.Command())
+	cmd.AddCommand(configTrustRevokeTokenCmd.command())
 
 	// Show
 	configTrustShowCmd := cmdConfigTrustShow{global: c.global, config: c.config, configTrust: c}
-	cmd.AddCommand(configTrustShowCmd.Command())
+	cmd.AddCommand(configTrustShowCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -80,7 +80,7 @@ type cmdConfigTrustAdd struct {
 	flagType       string
 }
 
-func (c *cmdConfigTrustAdd) Command() *cobra.Command {
+func (c *cmdConfigTrustAdd) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:] [<cert>]"))
 	cmd.Short = i18n.G("Add new trusted client")
@@ -102,12 +102,12 @@ restricted to one or more projects.
 	cmd.Flags().StringVar(&c.flagName, "name", "", i18n.G("Alternative certificate name")+"``")
 	cmd.Flags().StringVar(&c.flagType, "type", "client", i18n.G("Type of certificate")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTrustAdd) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTrustAdd) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 2)
 	if exit {
@@ -229,14 +229,14 @@ type cmdConfigTrustEdit struct {
 	configTrust *cmdConfigTrust
 }
 
-func (c *cmdConfigTrustEdit) Command() *cobra.Command {
+func (c *cmdConfigTrustEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<fingerprint>"))
 	cmd.Short = i18n.G("Edit trust configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Edit trust configurations as YAML`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -249,7 +249,7 @@ func (c *cmdConfigTrustEdit) helpTemplate() string {
 ### Note that the fingerprint is shown but cannot be changed`)
 }
 
-func (c *cmdConfigTrustEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTrustEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -342,7 +342,7 @@ type cmdConfigTrustList struct {
 	flagFormat string
 }
 
-func (c *cmdConfigTrustList) Command() *cobra.Command {
+func (c *cmdConfigTrustList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -351,12 +351,12 @@ func (c *cmdConfigTrustList) Command() *cobra.Command {
 		`List trusted clients`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTrustList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTrustList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -425,7 +425,7 @@ type cmdConfigTrustListTokens struct {
 	flagFormat string
 }
 
-func (c *cmdConfigTrustListTokens) Command() *cobra.Command {
+func (c *cmdConfigTrustListTokens) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list-tokens", i18n.G("[<remote>:]"))
 	cmd.Short = i18n.G("List all active certificate add tokens")
@@ -433,12 +433,12 @@ func (c *cmdConfigTrustListTokens) Command() *cobra.Command {
 		`List all active certificate add tokens`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTrustListTokens) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTrustListTokens) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -526,7 +526,7 @@ type cmdConfigTrustRemove struct {
 	configTrust *cmdConfigTrust
 }
 
-func (c *cmdConfigTrustRemove) Command() *cobra.Command {
+func (c *cmdConfigTrustRemove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<fingerprint>"))
 	cmd.Aliases = []string{"rm"}
@@ -534,12 +534,12 @@ func (c *cmdConfigTrustRemove) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove trusted client`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTrustRemove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTrustRemove) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
 	if exit {
@@ -573,19 +573,19 @@ type cmdConfigTrustRevokeToken struct {
 	configTrust *cmdConfigTrust
 }
 
-func (c *cmdConfigTrustRevokeToken) Command() *cobra.Command {
+func (c *cmdConfigTrustRevokeToken) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("revoke-token", i18n.G("[<remote>:] <name>"))
 	cmd.Short = i18n.G("Revoke certificate add token")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Revoke certificate add token`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTrustRevokeToken) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTrustRevokeToken) run(cmd *cobra.Command, args []string) error {
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
 		return err
@@ -644,19 +644,19 @@ type cmdConfigTrustShow struct {
 	configTrust *cmdConfigTrust
 }
 
-func (c *cmdConfigTrustShow) Command() *cobra.Command {
+func (c *cmdConfigTrustShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<fingerprint>"))
 	cmd.Short = i18n.G("Show trust configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show trust configurations`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdConfigTrustShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConfigTrustShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {

--- a/lxc/console.go
+++ b/lxc/console.go
@@ -29,7 +29,7 @@ type cmdConsole struct {
 	flagType    string
 }
 
-func (c *cmdConsole) Command() *cobra.Command {
+func (c *cmdConsole) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("console", i18n.G("[<remote>:]<instance>"))
 	cmd.Short = i18n.G("Attach to instance consoles")
@@ -39,7 +39,7 @@ func (c *cmdConsole) Command() *cobra.Command {
 This command allows you to interact with the boot console of an instance
 as well as retrieve past log entries from it.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagShowLog, "show-log", false, i18n.G("Retrieve the instance's console log"))
 	cmd.Flags().StringVarP(&c.flagType, "type", "t", "console", i18n.G("Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output")+"``")
 
@@ -94,7 +94,7 @@ func (er stdinMirror) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdConsole) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/console.go
+++ b/lxc/console.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -288,7 +289,11 @@ func (c *cmdConsole) vga(d lxd.InstanceServer, name string) error {
 			return err
 		}
 
-		addr := listener.Addr().(*net.TCPAddr)
+		addr, ok := listener.Addr().(*net.TCPAddr)
+		if !ok {
+			return errors.New("Failed to get TCP listen address")
+		}
+
 		socket = fmt.Sprintf("spice://127.0.0.1:%d", addr.Port)
 	}
 

--- a/lxc/console.go
+++ b/lxc/console.go
@@ -140,10 +140,10 @@ func (c *cmdConsole) run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return c.Console(d, name)
+	return c.runConsole(d, name)
 }
 
-func (c *cmdConsole) Console(d lxd.InstanceServer, name string) error {
+func (c *cmdConsole) runConsole(d lxd.InstanceServer, name string) error {
 	if c.flagType == "" {
 		c.flagType = "console"
 	}

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -33,7 +33,7 @@ type cmdCopy struct {
 	flagAllowInconsistent bool
 }
 
-func (c *cmdCopy) Command() *cobra.Command {
+func (c *cmdCopy) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("copy", i18n.G("[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"))
 	cmd.Aliases = []string{"cp"}
@@ -49,7 +49,7 @@ Transfer modes (--mode):
 The pull transfer mode is the default as it is compatible with all LXD versions.
 `))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringArrayVarP(&c.flagConfig, "config", "c", nil, i18n.G("Config key/value to apply to the new instance")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagDevice, "device", "d", nil, i18n.G("New key/value to apply to a specific device")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagProfile, "profile", "p", nil, i18n.G("Profile to apply to the new instance")+"``")
@@ -450,7 +450,7 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 	return nil
 }
 
-func (c *cmdCopy) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdCopy) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -23,7 +23,7 @@ type cmdDelete struct {
 	flagInteractive    bool
 }
 
-func (c *cmdDelete) Command() *cobra.Command {
+func (c *cmdDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"))
 	cmd.Aliases = []string{"rm"}
@@ -31,7 +31,7 @@ func (c *cmdDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete instances and snapshots`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force the removal of running instances"))
 	cmd.Flags().BoolVarP(&c.flagInteractive, "interactive", "i", false, i18n.G("Require user confirmation"))
 
@@ -71,7 +71,7 @@ func (c *cmdDelete) doDelete(d lxd.InstanceServer, name string) error {
 	return op.Wait()
 }
 
-func (c *cmdDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -34,7 +34,7 @@ type cmdExec struct {
 	interactive bool
 }
 
-func (c *cmdExec) Command() *cobra.Command {
+func (c *cmdExec) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("exec", i18n.G("[<remote>:]<instance> [flags] [--] <command line>"))
 	cmd.Short = i18n.G("Execute commands in instances")
@@ -50,7 +50,7 @@ executable, passing the shell commands as arguments, for example:
 
 Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored).`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringArrayVar(&c.flagEnvironment, "env", nil, i18n.G("Environment variable to set (e.g. HOME=/home/foo)")+"``")
 	cmd.Flags().StringVar(&c.flagMode, "mode", "auto", i18n.G("Override the terminal mode (auto, interactive or non-interactive)")+"``")
 	cmd.Flags().BoolVarP(&c.flagForceInteractive, "force-interactive", "t", false, i18n.G("Force pseudo-terminal allocation"))
@@ -80,7 +80,7 @@ func (c *cmdExec) sendTermSize(control *websocket.Conn) error {
 	return control.WriteJSON(msg)
 }
 
-func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdExec) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -25,7 +25,7 @@ type cmdExport struct {
 	flagCompressionAlgorithm string
 }
 
-func (c *cmdExport) Command() *cobra.Command {
+func (c *cmdExport) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("export", i18n.G("[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"))
 	cmd.Short = i18n.G("Export instance backups")
@@ -35,7 +35,7 @@ func (c *cmdExport) Command() *cobra.Command {
 		`lxc export u1 backup0.tar.gz
     Download a backup tarball of the u1 instance.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagInstanceOnly, "instance-only", false,
 		i18n.G("Whether or not to only backup the instance (without snapshots)"))
 	cmd.Flags().BoolVar(&c.flagOptimizedStorage, "optimized-storage", false,
@@ -45,7 +45,7 @@ func (c *cmdExport) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdExport) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -43,10 +43,14 @@ type cmdFile struct {
 	flagRecursive bool
 }
 
-func fileGetWrapper(server lxd.InstanceServer, inst string, path string) (buf io.ReadCloser, resp *lxd.InstanceFileResponse, err error) {
+func fileGetWrapper(server lxd.InstanceServer, inst string, path string) (io.ReadCloser, *lxd.InstanceFileResponse, error) {
 	// Signal handling
 	chSignal := make(chan os.Signal, 1)
 	signal.Notify(chSignal, os.Interrupt)
+
+	var buf io.ReadCloser
+	var resp *lxd.InstanceFileResponse
+	var err error
 
 	// Operation handling
 	chDone := make(chan bool)

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -668,6 +668,9 @@ func (c *cmdFilePush) run(cmd *cobra.Command, args []string) error {
 				}
 
 				fMode, fUID, fGID := shared.GetOwnerMode(finfo)
+				if err != nil {
+					return err
+				}
 
 				if c.file.flagMode == "" {
 					mode = fMode

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -863,7 +863,11 @@ func (c *cmdImageImport) run(cmd *cobra.Command, args []string) error {
 	opAPI := op.Get()
 
 	// Get the fingerprint
-	fingerprint := opAPI.Metadata["fingerprint"].(string)
+	fingerprint, ok := opAPI.Metadata["fingerprint"].(string)
+	if !ok {
+		return fmt.Errorf(`Invalid type %T for "fingerprint" key in operation metadata`, fingerprint)
+	}
+
 	progress.Done(fmt.Sprintf(i18n.G("Image imported with fingerprint: %s"), fingerprint))
 
 	// Add the aliases
@@ -1406,7 +1410,10 @@ func (c *cmdImageRefresh) run(cmd *cobra.Command, args []string) error {
 		refreshed := false
 		flag, ok := opAPI.Metadata["refreshed"]
 		if ok {
-			refreshed = flag.(bool)
+			refreshed, ok = flag.(bool)
+			if !ok {
+				return fmt.Errorf(`Invalid type %T for "refreshed" key in operation metadata`, flag)
+			}
 		}
 
 		if refreshed {

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1088,11 +1088,11 @@ func (c *cmdImageList) parseColumns() ([]imageColumn, error) {
 
 		for _, columnRune := range columnEntry {
 			column, ok := columnsShorthandMap[columnRune]
-			if ok {
-				columns = append(columns, column)
-			} else {
+			if !ok {
 				return nil, fmt.Errorf(i18n.G("Unknown column shorthand char '%c' in '%s'"), columnRune, columnEntry)
 			}
+
+			columns = append(columns, column)
 		}
 	}
 

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1207,14 +1207,14 @@ func (c *cmdImageList) imageShouldShow(filters []string, state *api.Image) bool 
 				list := cmdList{}
 				list.global = c.global
 				if list.dotPrefixMatch(key, configKey) {
-					//try to test filter value as a regexp
+					// Try to test filter value as a regexp.
 					regexpValue := value
 					if !(strings.Contains(value, "^") || strings.Contains(value, "$")) {
 						regexpValue = "^" + regexpValue + "$"
 					}
 
 					r, err := regexp.Compile(regexpValue)
-					//if not regexp compatible use original value
+					// If not regexp compatible use original value.
 					if err != nil {
 						if value == configValue {
 							found = true

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -30,7 +30,7 @@ type cmdImage struct {
 	global *cmdGlobal
 }
 
-func (c *cmdImage) Command() *cobra.Command {
+func (c *cmdImage) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("image")
 	cmd.Short = i18n.G("Manage images")
@@ -53,55 +53,55 @@ hash or alias name (if one is set).`))
 
 	// Alias
 	imageAliasCmd := cmdImageAlias{global: c.global, image: c}
-	cmd.AddCommand(imageAliasCmd.Command())
+	cmd.AddCommand(imageAliasCmd.command())
 
 	// Copy
 	imageCopyCmd := cmdImageCopy{global: c.global, image: c}
-	cmd.AddCommand(imageCopyCmd.Command())
+	cmd.AddCommand(imageCopyCmd.command())
 
 	// Delete
 	imageDeleteCmd := cmdImageDelete{global: c.global, image: c}
-	cmd.AddCommand(imageDeleteCmd.Command())
+	cmd.AddCommand(imageDeleteCmd.command())
 
 	// Edit
 	imageEditCmd := cmdImageEdit{global: c.global, image: c}
-	cmd.AddCommand(imageEditCmd.Command())
+	cmd.AddCommand(imageEditCmd.command())
 
 	// Export
 	imageExportCmd := cmdImageExport{global: c.global, image: c}
-	cmd.AddCommand(imageExportCmd.Command())
+	cmd.AddCommand(imageExportCmd.command())
 
 	// Import
 	imageImportCmd := cmdImageImport{global: c.global, image: c}
-	cmd.AddCommand(imageImportCmd.Command())
+	cmd.AddCommand(imageImportCmd.command())
 
 	// Info
 	imageInfoCmd := cmdImageInfo{global: c.global, image: c}
-	cmd.AddCommand(imageInfoCmd.Command())
+	cmd.AddCommand(imageInfoCmd.command())
 
 	// List
 	imageListCmd := cmdImageList{global: c.global, image: c}
-	cmd.AddCommand(imageListCmd.Command())
+	cmd.AddCommand(imageListCmd.command())
 
 	// Refresh
 	imageRefreshCmd := cmdImageRefresh{global: c.global, image: c}
-	cmd.AddCommand(imageRefreshCmd.Command())
+	cmd.AddCommand(imageRefreshCmd.command())
 
 	// Show
 	imageShowCmd := cmdImageShow{global: c.global, image: c}
-	cmd.AddCommand(imageShowCmd.Command())
+	cmd.AddCommand(imageShowCmd.command())
 
 	// Get-property
 	imageGetPropCmd := cmdImageGetProp{global: c.global, image: c}
-	cmd.AddCommand(imageGetPropCmd.Command())
+	cmd.AddCommand(imageGetPropCmd.command())
 
 	// Set-property
 	imageSetPropCmd := cmdImageSetProp{global: c.global, image: c}
-	cmd.AddCommand(imageSetPropCmd.Command())
+	cmd.AddCommand(imageSetPropCmd.command())
 
 	// Unset-property
 	imageUnsetPropCmd := cmdImageUnsetProp{global: c.global, image: c, imageSetProp: &imageSetPropCmd}
-	cmd.AddCommand(imageUnsetPropCmd.Command())
+	cmd.AddCommand(imageUnsetPropCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -150,7 +150,7 @@ type cmdImageCopy struct {
 	flagProfile       []string
 }
 
-func (c *cmdImageCopy) Command() *cobra.Command {
+func (c *cmdImageCopy) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("copy", i18n.G("[<remote>:]<image> <remote>:"))
 	cmd.Aliases = []string{"cp"}
@@ -169,12 +169,12 @@ It requires the source to be an alias and for it to be public.`))
 	cmd.Flags().StringVar(&c.flagMode, "mode", "pull", i18n.G("Transfer mode. One of pull (default), push or relay")+"``")
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagProfile, "profile", "p", nil, i18n.G("Profile to apply to the new image")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageCopy) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageCopy) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -316,7 +316,7 @@ type cmdImageDelete struct {
 	image  *cmdImage
 }
 
-func (c *cmdImageDelete) Command() *cobra.Command {
+func (c *cmdImageDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<image> [[<remote>:]<image>...]"))
 	cmd.Aliases = []string{"rm"}
@@ -324,12 +324,12 @@ func (c *cmdImageDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete images`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -372,7 +372,7 @@ type cmdImageEdit struct {
 	image  *cmdImage
 }
 
-func (c *cmdImageEdit) Command() *cobra.Command {
+func (c *cmdImageEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<image>"))
 	cmd.Short = i18n.G("Edit image properties")
@@ -385,7 +385,7 @@ func (c *cmdImageEdit) Command() *cobra.Command {
 lxc image edit <image> < image.yaml
     Load the image properties from a YAML file`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -400,7 +400,7 @@ func (c *cmdImageEdit) helpTemplate() string {
 ###  description: My custom image`)
 }
 
-func (c *cmdImageEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -493,7 +493,7 @@ type cmdImageExport struct {
 	flagVM bool
 }
 
-func (c *cmdImageExport) Command() *cobra.Command {
+func (c *cmdImageExport) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("export", i18n.G("[<remote>:]<image> [<target>]"))
 	cmd.Short = i18n.G("Export and download images")
@@ -503,12 +503,12 @@ func (c *cmdImageExport) Command() *cobra.Command {
 The output target is optional and defaults to the working directory.`))
 
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Query virtual machine images"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageExport) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageExport) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
 	if exit {
@@ -657,7 +657,7 @@ type cmdImageImport struct {
 	flagAliases []string
 }
 
-func (c *cmdImageImport) Command() *cobra.Command {
+func (c *cmdImageImport) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("import", i18n.G("<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"))
 	cmd.Short = i18n.G("Import images into the image store")
@@ -668,7 +668,7 @@ Directory import is only available on Linux and must be performed as root.`))
 
 	cmd.Flags().BoolVar(&c.flagPublic, "public", false, i18n.G("Make image public"))
 	cmd.Flags().StringArrayVar(&c.flagAliases, "alias", nil, i18n.G("New aliases to add to the image")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -697,7 +697,7 @@ func (c *cmdImageImport) packImageDir(path string) (string, error) {
 	return outFileName, outFile.Close()
 }
 
-func (c *cmdImageImport) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageImport) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -890,7 +890,7 @@ type cmdImageInfo struct {
 	flagVM bool
 }
 
-func (c *cmdImageInfo) Command() *cobra.Command {
+func (c *cmdImageInfo) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:]<image>"))
 	cmd.Short = i18n.G("Show useful information about images")
@@ -898,12 +898,12 @@ func (c *cmdImageInfo) Command() *cobra.Command {
 		`Show useful information about images`))
 
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Query virtual machine images"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageInfo) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageInfo) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -1023,7 +1023,7 @@ type cmdImageList struct {
 	flagColumns string
 }
 
-func (c *cmdImageList) Command() *cobra.Command {
+func (c *cmdImageList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:] [<filter>...]"))
 	cmd.Aliases = []string{"ls"}
@@ -1055,7 +1055,7 @@ Column shorthand chars:
 
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", "lfpdatsu", i18n.G("Columns")+"``")
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -1247,7 +1247,7 @@ func (c *cmdImageList) imageShouldShow(filters []string, state *api.Image) bool 
 	return true
 }
 
-func (c *cmdImageList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, -1)
 	if exit {
@@ -1343,19 +1343,19 @@ type cmdImageRefresh struct {
 	image  *cmdImage
 }
 
-func (c *cmdImageRefresh) Command() *cobra.Command {
+func (c *cmdImageRefresh) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("refresh", i18n.G("[<remote>:]<image> [[<remote>:]<image>...]"))
 	cmd.Short = i18n.G("Refresh images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Refresh images`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageRefresh) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageRefresh) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -1427,7 +1427,7 @@ type cmdImageShow struct {
 	flagVM bool
 }
 
-func (c *cmdImageShow) Command() *cobra.Command {
+func (c *cmdImageShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<image>"))
 	cmd.Short = i18n.G("Show image properties")
@@ -1435,12 +1435,12 @@ func (c *cmdImageShow) Command() *cobra.Command {
 		`Show image properties`))
 
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Query virtual machine images"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -1485,19 +1485,19 @@ type cmdImageGetProp struct {
 	image  *cmdImage
 }
 
-func (c *cmdImageGetProp) Command() *cobra.Command {
+func (c *cmdImageGetProp) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get-property", i18n.G("[<remote>:]<image> <key>"))
 	cmd.Short = i18n.G("Get image properties")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Get image properties`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageGetProp) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageGetProp) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1536,19 +1536,19 @@ type cmdImageSetProp struct {
 	image  *cmdImage
 }
 
-func (c *cmdImageSetProp) Command() *cobra.Command {
+func (c *cmdImageSetProp) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set-property", i18n.G("[<remote>:]<image> <key> <value>"))
 	cmd.Short = i18n.G("Set image properties")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Set image properties`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageSetProp) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageSetProp) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -1591,19 +1591,19 @@ type cmdImageUnsetProp struct {
 	imageSetProp *cmdImageSetProp
 }
 
-func (c *cmdImageUnsetProp) Command() *cobra.Command {
+func (c *cmdImageUnsetProp) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset-property", i18n.G("[<remote>:]<image> <key>"))
 	cmd.Short = i18n.G("Unset image properties")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Unset image properties`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageUnsetProp) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageUnsetProp) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1611,7 +1611,7 @@ func (c *cmdImageUnsetProp) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	args = append(args, "")
-	return c.imageSetProp.Run(cmd, args)
+	return c.imageSetProp.run(cmd, args)
 }
 
 func structToMap(data any) map[string]any {

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -17,7 +17,7 @@ type cmdImageAlias struct {
 	image  *cmdImage
 }
 
-func (c *cmdImageAlias) Command() *cobra.Command {
+func (c *cmdImageAlias) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("alias")
 	cmd.Short = i18n.G("Manage image aliases")
@@ -26,19 +26,19 @@ func (c *cmdImageAlias) Command() *cobra.Command {
 
 	// Create
 	imageAliasCreateCmd := cmdImageAliasCreate{global: c.global, image: c.image, imageAlias: c}
-	cmd.AddCommand(imageAliasCreateCmd.Command())
+	cmd.AddCommand(imageAliasCreateCmd.command())
 
 	// Delete
 	imageAliasDeleteCmd := cmdImageAliasDelete{global: c.global, image: c.image, imageAlias: c}
-	cmd.AddCommand(imageAliasDeleteCmd.Command())
+	cmd.AddCommand(imageAliasDeleteCmd.command())
 
 	// List
 	imageAliasListCmd := cmdImageAliasList{global: c.global, image: c.image, imageAlias: c}
-	cmd.AddCommand(imageAliasListCmd.Command())
+	cmd.AddCommand(imageAliasListCmd.command())
 
 	// Rename
 	imageAliasRenameCmd := cmdImageAliasRename{global: c.global, image: c.image, imageAlias: c}
-	cmd.AddCommand(imageAliasRenameCmd.Command())
+	cmd.AddCommand(imageAliasRenameCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -53,19 +53,19 @@ type cmdImageAliasCreate struct {
 	imageAlias *cmdImageAlias
 }
 
-func (c *cmdImageAliasCreate) Command() *cobra.Command {
+func (c *cmdImageAliasCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<alias> <fingerprint>"))
 	cmd.Short = i18n.G("Create aliases for existing images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create aliases for existing images`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageAliasCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageAliasCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -99,7 +99,7 @@ type cmdImageAliasDelete struct {
 	imageAlias *cmdImageAlias
 }
 
-func (c *cmdImageAliasDelete) Command() *cobra.Command {
+func (c *cmdImageAliasDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<alias>"))
 	cmd.Aliases = []string{"rm"}
@@ -107,12 +107,12 @@ func (c *cmdImageAliasDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete image aliases`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageAliasDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageAliasDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -144,7 +144,7 @@ type cmdImageAliasList struct {
 	flagFormat string
 }
 
-func (c *cmdImageAliasList) Command() *cobra.Command {
+func (c *cmdImageAliasList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:] [<filters>...]"))
 	cmd.Aliases = []string{"ls"}
@@ -156,7 +156,7 @@ Filters may be part of the image hash or part of the image alias name.
 `))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -175,7 +175,7 @@ func (c *cmdImageAliasList) aliasShouldShow(filters []string, state *api.ImageAl
 	return false
 }
 
-func (c *cmdImageAliasList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageAliasList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, -1)
 	if exit {
@@ -247,7 +247,7 @@ type cmdImageAliasRename struct {
 	imageAlias *cmdImageAlias
 }
 
-func (c *cmdImageAliasRename) Command() *cobra.Command {
+func (c *cmdImageAliasRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<alias> <new-name>"))
 	cmd.Aliases = []string{"mv"}
@@ -255,12 +255,12 @@ func (c *cmdImageAliasRename) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Rename aliases`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdImageAliasRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImageAliasRename) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {

--- a/lxc/import.go
+++ b/lxc/import.go
@@ -22,7 +22,7 @@ type cmdImport struct {
 	flagDevice  []string
 }
 
-func (c *cmdImport) Command() *cobra.Command {
+func (c *cmdImport) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("import", i18n.G("[<remote>:] <backup file> [<instance name>]"))
 	cmd.Short = i18n.G("Import instance backups")
@@ -32,14 +32,14 @@ func (c *cmdImport) Command() *cobra.Command {
 		`lxc import backup0.tar.gz
     Create a new instance using backup0.tar.gz as the source.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagStorage, "storage", "s", "", i18n.G("Storage pool name")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagDevice, "device", "d", nil, i18n.G("New key/value to apply to a specific device")+"``")
 
 	return cmd
 }
 
-func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdImport) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 3)
 	if exit {

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -25,8 +25,7 @@ type cmdInfo struct {
 	flagTarget    string
 }
 
-// Command show instance or server information.
-func (c *cmdInfo) Command() *cobra.Command {
+func (c *cmdInfo) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:][<instance>]"))
 	cmd.Short = i18n.G("Show instance or server information")
@@ -39,7 +38,7 @@ func (c *cmdInfo) Command() *cobra.Command {
 lxc info [<remote>:] [--resources]
     For LXD server information.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagShowLog, "show-log", false, i18n.G("Show the instance's last 100 log lines?"))
 	cmd.Flags().BoolVar(&c.flagResources, "resources", false, i18n.G("Show the resources available to the server"))
 	cmd.Flags().StringVar(&c.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
@@ -47,8 +46,7 @@ lxc info [<remote>:] [--resources]
 	return cmd
 }
 
-// Run executes the info command.
-func (c *cmdInfo) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdInfo) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -36,7 +36,7 @@ type cmdInit struct {
 	flagVM         bool
 }
 
-func (c *cmdInit) Command() *cobra.Command {
+func (c *cmdInit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("init", i18n.G("[<remote>:]<image> [<remote>:][<name>]"))
 	cmd.Short = i18n.G("Create instances from images")
@@ -53,7 +53,7 @@ lxc init ubuntu:24.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB
 lxc init ubuntu:24.04 v1 --vm -c limits.cpu=2 -c limits.memory=8GiB -d root,size=32GiB
     Create a virtual machine with 2 vCPUs, 8GiB of RAM and a root disk of 32GiB`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringArrayVarP(&c.flagConfig, "config", "c", nil, i18n.G("Config key/value to apply to the new instance")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagProfile, "profile", "p", nil, i18n.G("Profile to apply to the new instance")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagDevice, "device", "d", nil, i18n.G("New key/value to apply to a specific device")+"``")
@@ -69,7 +69,7 @@ lxc init ubuntu:24.04 v1 --vm -c limits.cpu=2 -c limits.memory=8GiB -d root,size
 	return cmd
 }
 
-func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdInit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 2)
 	if exit {

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -17,8 +17,8 @@ type cmdLaunch struct {
 	flagConsole string
 }
 
-func (c *cmdLaunch) Command() *cobra.Command {
-	cmd := c.init.Command()
+func (c *cmdLaunch) command() *cobra.Command {
+	cmd := c.init.command()
 	cmd.Use = usage("launch", i18n.G("[<remote>:]<image> [<remote>:][<name>]"))
 	cmd.Short = i18n.G("Create and start instances from images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
@@ -40,7 +40,7 @@ lxc launch ubuntu:24.04 v1 --vm -c limits.cpu=2 -c limits.memory=8GiB -d root,si
 
 	cmd.Hidden = false
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.flagConsole, "console", "", i18n.G("Immediately attach to the console")+"``")
 	cmd.Flags().Lookup("console").NoOptDefVal = "console"
@@ -48,7 +48,7 @@ lxc launch ubuntu:24.04 v1 --vm -c limits.cpu=2 -c limits.memory=8GiB -d root,si
 	return cmd
 }
 
-func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdLaunch) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -121,7 +121,7 @@ func (c *cmdLaunch) run(cmd *cobra.Command, args []string) error {
 		console := cmdConsole{}
 		console.global = c.global
 		console.flagType = c.flagConsole
-		return console.Console(d, name)
+		return console.runConsole(d, name)
 	}
 
 	return nil

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -548,8 +548,8 @@ func (c *cmdList) run(cmd *cobra.Command, args []string) error {
 
 func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 	columnsShorthandMap := map[rune]column{
-		'4': {i18n.G("IPV4"), c.IP4ColumnData, true, false},
-		'6': {i18n.G("IPV6"), c.IP6ColumnData, true, false},
+		'4': {i18n.G("IPV4"), c.ipv4ColumnData, true, false},
+		'6': {i18n.G("IPV6"), c.ipv6ColumnData, true, false},
 		'a': {i18n.G("ARCHITECTURE"), c.architectureColumnData, false, false},
 		'b': {i18n.G("STORAGE POOL"), c.storagePoolColumnData, false, false},
 		'c': {i18n.G("CREATED AT"), c.createdColumnData, false, false},
@@ -563,7 +563,7 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 		'M': {i18n.G("MEMORY USAGE%"), c.memoryUsagePercentColumnData, true, false},
 		'n': {i18n.G("NAME"), c.nameColumnData, false, false},
 		'N': {i18n.G("PROCESSES"), c.numberOfProcessesColumnData, true, false},
-		'p': {i18n.G("PID"), c.PIDColumnData, true, false},
+		'p': {i18n.G("PID"), c.pidColumnData, true, false},
 		'P': {i18n.G("PROFILES"), c.profilesColumnData, false, false},
 		'S': {i18n.G("SNAPSHOTS"), c.numberSnapshotsColumnData, false, true},
 		's': {i18n.G("STATE"), c.statusColumnData, false, false},
@@ -755,7 +755,7 @@ func (c *cmdList) statusColumnData(cInfo api.InstanceFull) string {
 	return strings.ToUpper(cInfo.Status)
 }
 
-func (c *cmdList) IP4ColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) ipv4ColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil && cInfo.State.Network != nil {
 		ipv4s := []string{}
 		for netName, net := range cInfo.State.Network {
@@ -781,7 +781,7 @@ func (c *cmdList) IP4ColumnData(cInfo api.InstanceFull) string {
 	return ""
 }
 
-func (c *cmdList) IP6ColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) ipv6ColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil && cInfo.State.Network != nil {
 		ipv6s := []string{}
 		for netName, net := range cInfo.State.Network {
@@ -876,7 +876,7 @@ func (c *cmdList) numberSnapshotsColumnData(cInfo api.InstanceFull) string {
 	return "0"
 }
 
-func (c *cmdList) PIDColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) pidColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil {
 		return fmt.Sprintf("%d", cInfo.State.Pid)
 	}

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -40,8 +40,7 @@ type cmdList struct {
 	shorthandFilters map[string]func(*api.Instance, *api.InstanceState, string) bool
 }
 
-// Command list instances.
-func (c *cmdList) Command() *cobra.Command {
+func (c *cmdList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:] [<filter>...]"))
 	cmd.Aliases = []string{"ls"}
@@ -128,7 +127,7 @@ Custom columns are defined with "[config:|devices:]key[:name][:maxWidth]":
 lxc list -c ns,user.comment:comment
   List instances with their running state and user comment.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultColumns, i18n.G("Columns")+"``")
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 	cmd.Flags().BoolVar(&c.flagFast, "fast", false, i18n.G("Fast mode (same as --columns=nsacPt)"))
@@ -446,8 +445,7 @@ func (c *cmdList) showInstances(instances []api.InstanceFull, filters []string, 
 	return cli.RenderTable(c.flagFormat, headers, data, instancesFiltered)
 }
 
-// Run executes the list command.
-func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdList) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -112,147 +112,147 @@ For help with any of those, simply call them with --help.`))
 
 	// alias sub-command
 	aliasCmd := cmdAlias{global: &globalCmd}
-	app.AddCommand(aliasCmd.Command())
+	app.AddCommand(aliasCmd.command())
 
 	// cluster sub-command
 	clusterCmd := cmdCluster{global: &globalCmd}
-	app.AddCommand(clusterCmd.Command())
+	app.AddCommand(clusterCmd.command())
 
 	// config sub-command
 	configCmd := cmdConfig{global: &globalCmd}
-	app.AddCommand(configCmd.Command())
+	app.AddCommand(configCmd.command())
 
 	// console sub-command
 	consoleCmd := cmdConsole{global: &globalCmd}
-	app.AddCommand(consoleCmd.Command())
+	app.AddCommand(consoleCmd.command())
 
 	// copy sub-command
 	copyCmd := cmdCopy{global: &globalCmd}
-	app.AddCommand(copyCmd.Command())
+	app.AddCommand(copyCmd.command())
 
 	// delete sub-command
 	deleteCmd := cmdDelete{global: &globalCmd}
-	app.AddCommand(deleteCmd.Command())
+	app.AddCommand(deleteCmd.command())
 
 	// exec sub-command
 	execCmd := cmdExec{global: &globalCmd}
-	app.AddCommand(execCmd.Command())
+	app.AddCommand(execCmd.command())
 
 	// export sub-command
 	exportCmd := cmdExport{global: &globalCmd}
-	app.AddCommand(exportCmd.Command())
+	app.AddCommand(exportCmd.command())
 
 	// file sub-command
 	fileCmd := cmdFile{global: &globalCmd}
-	app.AddCommand(fileCmd.Command())
+	app.AddCommand(fileCmd.command())
 
 	// import sub-command
 	importCmd := cmdImport{global: &globalCmd}
-	app.AddCommand(importCmd.Command())
+	app.AddCommand(importCmd.command())
 
 	// info sub-command
 	infoCmd := cmdInfo{global: &globalCmd}
-	app.AddCommand(infoCmd.Command())
+	app.AddCommand(infoCmd.command())
 
 	// image sub-command
 	imageCmd := cmdImage{global: &globalCmd}
-	app.AddCommand(imageCmd.Command())
+	app.AddCommand(imageCmd.command())
 
 	// init sub-command
 	initCmd := cmdInit{global: &globalCmd}
-	app.AddCommand(initCmd.Command())
+	app.AddCommand(initCmd.command())
 
 	// launch sub-command
 	launchCmd := cmdLaunch{global: &globalCmd, init: &initCmd}
-	app.AddCommand(launchCmd.Command())
+	app.AddCommand(launchCmd.command())
 
 	// list sub-command
 	listCmd := cmdList{global: &globalCmd}
-	app.AddCommand(listCmd.Command())
+	app.AddCommand(listCmd.command())
 
 	// manpage sub-command
 	manpageCmd := cmdManpage{global: &globalCmd}
-	app.AddCommand(manpageCmd.Command())
+	app.AddCommand(manpageCmd.command())
 
 	// monitor sub-command
 	monitorCmd := cmdMonitor{global: &globalCmd}
-	app.AddCommand(monitorCmd.Command())
+	app.AddCommand(monitorCmd.command())
 
 	// move sub-command
 	moveCmd := cmdMove{global: &globalCmd}
-	app.AddCommand(moveCmd.Command())
+	app.AddCommand(moveCmd.command())
 
 	// network sub-command
 	networkCmd := cmdNetwork{global: &globalCmd}
-	app.AddCommand(networkCmd.Command())
+	app.AddCommand(networkCmd.command())
 
 	// operation sub-command
 	operationCmd := cmdOperation{global: &globalCmd}
-	app.AddCommand(operationCmd.Command())
+	app.AddCommand(operationCmd.command())
 
 	// pause sub-command
 	pauseCmd := cmdPause{global: &globalCmd}
-	app.AddCommand(pauseCmd.Command())
+	app.AddCommand(pauseCmd.command())
 
 	// publish sub-command
 	publishCmd := cmdPublish{global: &globalCmd}
-	app.AddCommand(publishCmd.Command())
+	app.AddCommand(publishCmd.command())
 
 	// profile sub-command
 	profileCmd := cmdProfile{global: &globalCmd}
-	app.AddCommand(profileCmd.Command())
+	app.AddCommand(profileCmd.command())
 
 	// project sub-command
 	projectCmd := cmdProject{global: &globalCmd}
-	app.AddCommand(projectCmd.Command())
+	app.AddCommand(projectCmd.command())
 
 	// query sub-command
 	queryCmd := cmdQuery{global: &globalCmd}
-	app.AddCommand(queryCmd.Command())
+	app.AddCommand(queryCmd.command())
 
 	// rebuild sub-command
 	rebuildCmd := cmdRebuild{global: &globalCmd}
-	app.AddCommand(rebuildCmd.Command())
+	app.AddCommand(rebuildCmd.command())
 
 	// rename sub-command
 	renameCmd := cmdRename{global: &globalCmd}
-	app.AddCommand(renameCmd.Command())
+	app.AddCommand(renameCmd.command())
 
 	// restart sub-command
 	restartCmd := cmdRestart{global: &globalCmd}
-	app.AddCommand(restartCmd.Command())
+	app.AddCommand(restartCmd.command())
 
 	// remote sub-command
 	remoteCmd := cmdRemote{global: &globalCmd}
-	app.AddCommand(remoteCmd.Command())
+	app.AddCommand(remoteCmd.command())
 
 	// restore sub-command
 	restoreCmd := cmdRestore{global: &globalCmd}
-	app.AddCommand(restoreCmd.Command())
+	app.AddCommand(restoreCmd.command())
 
 	// snapshot sub-command
 	snapshotCmd := cmdSnapshot{global: &globalCmd}
-	app.AddCommand(snapshotCmd.Command())
+	app.AddCommand(snapshotCmd.command())
 
 	// storage sub-command
 	storageCmd := cmdStorage{global: &globalCmd}
-	app.AddCommand(storageCmd.Command())
+	app.AddCommand(storageCmd.command())
 
 	// start sub-command
 	startCmd := cmdStart{global: &globalCmd}
-	app.AddCommand(startCmd.Command())
+	app.AddCommand(startCmd.command())
 
 	// stop sub-command
 	stopCmd := cmdStop{global: &globalCmd}
-	app.AddCommand(stopCmd.Command())
+	app.AddCommand(stopCmd.command())
 
 	// version sub-command
 	versionCmd := cmdVersion{global: &globalCmd}
-	app.AddCommand(versionCmd.Command())
+	app.AddCommand(versionCmd.command())
 
 	// warning sub-command
 	warningCmd := cmdWarning{global: &globalCmd}
-	app.AddCommand(warningCmd.Command())
+	app.AddCommand(warningCmd.command())
 
 	authCmd := cmdAuth{global: &globalCmd}
 	app.AddCommand(authCmd.command())

--- a/lxc/manpage.go
+++ b/lxc/manpage.go
@@ -15,7 +15,7 @@ type cmdManpage struct {
 	flagFormat string
 }
 
-func (c *cmdManpage) Command() *cobra.Command {
+func (c *cmdManpage) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("manpage", i18n.G("<target>"))
 	cmd.Short = i18n.G("Generate manpages for all commands")
@@ -24,12 +24,12 @@ func (c *cmdManpage) Command() *cobra.Command {
 	cmd.Hidden = true
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "man", i18n.G("Format (man|md|rest|yaml)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdManpage) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdManpage) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -26,7 +26,7 @@ type cmdMonitor struct {
 	flagFormat      string
 }
 
-func (c *cmdMonitor) Command() *cobra.Command {
+func (c *cmdMonitor) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("monitor", i18n.G("[<remote>:]"))
 	cmd.Short = i18n.G("Monitor a local or remote LXD server")
@@ -44,7 +44,7 @@ lxc monitor --pretty --type=logging --loglevel=info
 lxc monitor --type=lifecycle
     Only show lifecycle events.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagPretty, "pretty", false, i18n.G("Pretty rendering (short for --format=pretty)"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Show events from all projects"))
 	cmd.Flags().StringArrayVar(&c.flagType, "type", nil, i18n.G("Event type to listen for")+"``")
@@ -54,7 +54,7 @@ lxc monitor --type=lifecycle
 	return cmd
 }
 
-func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdMonitor) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	var err error

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -29,7 +29,7 @@ type cmdMove struct {
 	flagAllowInconsistent bool
 }
 
-func (c *cmdMove) Command() *cobra.Command {
+func (c *cmdMove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("move", i18n.G("[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"))
 	cmd.Aliases = []string{"mv"}
@@ -54,7 +54,7 @@ lxc move <old name> <new name> [--instance-only]
 lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>
     Rename a snapshot.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringArrayVarP(&c.flagConfig, "config", "c", nil, i18n.G("Config key/value to apply to the target instance")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagDevice, "device", "d", nil, i18n.G("New key/value to apply to a specific device")+"``")
 	cmd.Flags().StringArrayVarP(&c.flagProfile, "profile", "p", nil, i18n.G("Profile to apply to the target instance")+"``")
@@ -70,7 +70,7 @@ lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>
 	return cmd
 }
 
-func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdMove) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -253,7 +253,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 	del := cmdDelete{global: c.global}
 	del.flagForce = true
 	del.flagForceProtected = true
-	err = del.Run(cmd, args[:1])
+	err = del.run(cmd, args[:1])
 	if err != nil {
 		return fmt.Errorf("Failed to delete original instance after copying it: %w", err)
 	}

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -25,7 +25,7 @@ type cmdNetwork struct {
 	flagType   string
 }
 
-func (c *cmdNetwork) Command() *cobra.Command {
+func (c *cmdNetwork) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("network")
 	cmd.Short = i18n.G("Manage and attach instances to networks")
@@ -34,87 +34,87 @@ func (c *cmdNetwork) Command() *cobra.Command {
 
 	// Attach
 	networkAttachCmd := cmdNetworkAttach{global: c.global, network: c}
-	cmd.AddCommand(networkAttachCmd.Command())
+	cmd.AddCommand(networkAttachCmd.command())
 
 	// Attach profile
 	networkAttachProfileCmd := cmdNetworkAttachProfile{global: c.global, network: c}
-	cmd.AddCommand(networkAttachProfileCmd.Command())
+	cmd.AddCommand(networkAttachProfileCmd.command())
 
 	// Create
 	networkCreateCmd := cmdNetworkCreate{global: c.global, network: c}
-	cmd.AddCommand(networkCreateCmd.Command())
+	cmd.AddCommand(networkCreateCmd.command())
 
 	// Delete
 	networkDeleteCmd := cmdNetworkDelete{global: c.global, network: c}
-	cmd.AddCommand(networkDeleteCmd.Command())
+	cmd.AddCommand(networkDeleteCmd.command())
 
 	// Detach
 	networkDetachCmd := cmdNetworkDetach{global: c.global, network: c}
-	cmd.AddCommand(networkDetachCmd.Command())
+	cmd.AddCommand(networkDetachCmd.command())
 
 	// Detach profile
 	networkDetachProfileCmd := cmdNetworkDetachProfile{global: c.global, network: c}
-	cmd.AddCommand(networkDetachProfileCmd.Command())
+	cmd.AddCommand(networkDetachProfileCmd.command())
 
 	// Edit
 	networkEditCmd := cmdNetworkEdit{global: c.global, network: c}
-	cmd.AddCommand(networkEditCmd.Command())
+	cmd.AddCommand(networkEditCmd.command())
 
 	// Get
 	networkGetCmd := cmdNetworkGet{global: c.global, network: c}
-	cmd.AddCommand(networkGetCmd.Command())
+	cmd.AddCommand(networkGetCmd.command())
 
 	// Info
 	networkInfoCmd := cmdNetworkInfo{global: c.global, network: c}
-	cmd.AddCommand(networkInfoCmd.Command())
+	cmd.AddCommand(networkInfoCmd.command())
 
 	// List
 	networkListCmd := cmdNetworkList{global: c.global, network: c}
-	cmd.AddCommand(networkListCmd.Command())
+	cmd.AddCommand(networkListCmd.command())
 
 	// List allocations
 	networkListAllocationsCmd := cmdNetworkListAllocations{global: c.global, network: c}
-	cmd.AddCommand(networkListAllocationsCmd.Command())
+	cmd.AddCommand(networkListAllocationsCmd.command())
 
 	// List leases
 	networkListLeasesCmd := cmdNetworkListLeases{global: c.global, network: c}
-	cmd.AddCommand(networkListLeasesCmd.Command())
+	cmd.AddCommand(networkListLeasesCmd.command())
 
 	// Rename
 	networkRenameCmd := cmdNetworkRename{global: c.global, network: c}
-	cmd.AddCommand(networkRenameCmd.Command())
+	cmd.AddCommand(networkRenameCmd.command())
 
 	// Set
 	networkSetCmd := cmdNetworkSet{global: c.global, network: c}
-	cmd.AddCommand(networkSetCmd.Command())
+	cmd.AddCommand(networkSetCmd.command())
 
 	// Show
 	networkShowCmd := cmdNetworkShow{global: c.global, network: c}
-	cmd.AddCommand(networkShowCmd.Command())
+	cmd.AddCommand(networkShowCmd.command())
 
 	// Unset
 	networkUnsetCmd := cmdNetworkUnset{global: c.global, network: c, networkSet: &networkSetCmd}
-	cmd.AddCommand(networkUnsetCmd.Command())
+	cmd.AddCommand(networkUnsetCmd.command())
 
 	// ACL
 	networkACLCmd := cmdNetworkACL{global: c.global}
-	cmd.AddCommand(networkACLCmd.Command())
+	cmd.AddCommand(networkACLCmd.command())
 
 	// Forward
 	networkForwardCmd := cmdNetworkForward{global: c.global}
-	cmd.AddCommand(networkForwardCmd.Command())
+	cmd.AddCommand(networkForwardCmd.command())
 
 	// Load Balancer
 	networkLoadBalancerCmd := cmdNetworkLoadBalancer{global: c.global}
-	cmd.AddCommand(networkLoadBalancerCmd.Command())
+	cmd.AddCommand(networkLoadBalancerCmd.command())
 
 	// Peer
 	networkPeerCmd := cmdNetworkPeer{global: c.global}
-	cmd.AddCommand(networkPeerCmd.Command())
+	cmd.AddCommand(networkPeerCmd.command())
 
 	// Zone
 	networkZoneCmd := cmdNetworkZone{global: c.global}
-	cmd.AddCommand(networkZoneCmd.Command())
+	cmd.AddCommand(networkZoneCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -128,19 +128,19 @@ type cmdNetworkAttach struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkAttach) Command() *cobra.Command {
+func (c *cmdNetworkAttach) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("attach", i18n.G("[<remote>:]<network> <instance> [<device name>] [<interface name>]"))
 	cmd.Short = i18n.G("Attach network interfaces to instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Attach new network interfaces to instances`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkAttach) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkAttach) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 4)
 	if exit {
@@ -213,19 +213,19 @@ type cmdNetworkAttachProfile struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkAttachProfile) Command() *cobra.Command {
+func (c *cmdNetworkAttachProfile) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("attach-profile", i18n.G("[<remote>:]<network> <profile> [<device name>] [<interface name>]"))
 	cmd.Short = i18n.G("Attach network interfaces to profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Attach network interfaces to profiles`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkAttachProfile) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkAttachProfile) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 4)
 	if exit {
@@ -286,7 +286,7 @@ type cmdNetworkCreate struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkCreate) Command() *cobra.Command {
+func (c *cmdNetworkCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> [key=value...]"))
 	cmd.Short = i18n.G("Create new networks")
@@ -300,12 +300,12 @@ lxc network create bar network=baz --type ovn
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVarP(&c.network.flagType, "type", "t", "", i18n.G("Network type")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -364,7 +364,7 @@ type cmdNetworkDelete struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkDelete) Command() *cobra.Command {
+func (c *cmdNetworkDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network>"))
 	cmd.Aliases = []string{"rm"}
@@ -372,12 +372,12 @@ func (c *cmdNetworkDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete networks`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -415,19 +415,19 @@ type cmdNetworkDetach struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkDetach) Command() *cobra.Command {
+func (c *cmdNetworkDetach) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("detach", i18n.G("[<remote>:]<network> <instance> [<device name>]"))
 	cmd.Short = i18n.G("Detach network interfaces from instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Detach network interfaces from instances`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkDetach) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkDetach) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
 	if exit {
@@ -500,19 +500,19 @@ type cmdNetworkDetachProfile struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkDetachProfile) Command() *cobra.Command {
+func (c *cmdNetworkDetachProfile) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("detach-profile", i18n.G("[<remote>:]<network> <profile> [<device name>]"))
 	cmd.Short = i18n.G("Detach network interfaces from profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Detach network interfaces from profiles`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkDetachProfile) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkDetachProfile) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
 	if exit {
@@ -585,14 +585,14 @@ type cmdNetworkEdit struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkEdit) Command() *cobra.Command {
+func (c *cmdNetworkEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<network>"))
 	cmd.Short = i18n.G("Edit network configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Edit network configurations as YAML`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -617,7 +617,7 @@ func (c *cmdNetworkEdit) helpTemplate() string {
 ### Note that only the configuration can be changed.`)
 }
 
-func (c *cmdNetworkEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -713,7 +713,7 @@ type cmdNetworkGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkGet) Command() *cobra.Command {
+func (c *cmdNetworkGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<network> <key>"))
 	cmd.Short = i18n.G("Get values for network configuration keys")
@@ -722,12 +722,12 @@ func (c *cmdNetworkGet) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -782,7 +782,7 @@ type cmdNetworkInfo struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkInfo) Command() *cobra.Command {
+func (c *cmdNetworkInfo) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:]<network>"))
 	cmd.Short = i18n.G("Get runtime information on networks")
@@ -790,12 +790,12 @@ func (c *cmdNetworkInfo) Command() *cobra.Command {
 		`Get runtime information on networks`))
 
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkInfo) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkInfo) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -904,7 +904,7 @@ type cmdNetworkList struct {
 	flagFormat string
 }
 
-func (c *cmdNetworkList) Command() *cobra.Command {
+func (c *cmdNetworkList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -912,13 +912,13 @@ func (c *cmdNetworkList) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`List available networks`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -998,7 +998,7 @@ type cmdNetworkListLeases struct {
 	flagFormat string
 }
 
-func (c *cmdNetworkListLeases) Command() *cobra.Command {
+func (c *cmdNetworkListLeases) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list-leases", i18n.G("[<remote>:]<network>"))
 	cmd.Short = i18n.G("List DHCP leases")
@@ -1006,12 +1006,12 @@ func (c *cmdNetworkListLeases) Command() *cobra.Command {
 		`List DHCP leases`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkListLeases) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkListLeases) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -1068,7 +1068,7 @@ type cmdNetworkRename struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkRename) Command() *cobra.Command {
+func (c *cmdNetworkRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<network> <new-name>"))
 	cmd.Aliases = []string{"mv"}
@@ -1076,12 +1076,12 @@ func (c *cmdNetworkRename) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Rename networks`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkRename) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1121,7 +1121,7 @@ type cmdNetworkSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkSet) Command() *cobra.Command {
+func (c *cmdNetworkSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<network> <key>=<value>..."))
 	cmd.Short = i18n.G("Set network configuration keys")
@@ -1133,12 +1133,12 @@ For backward compatibility, a single configuration key may still be set with:
 
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -1209,7 +1209,7 @@ type cmdNetworkShow struct {
 	network *cmdNetwork
 }
 
-func (c *cmdNetworkShow) Command() *cobra.Command {
+func (c *cmdNetworkShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<network>"))
 	cmd.Short = i18n.G("Show network configurations")
@@ -1217,12 +1217,12 @@ func (c *cmdNetworkShow) Command() *cobra.Command {
 		`Show network configurations`))
 
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -1273,7 +1273,7 @@ type cmdNetworkUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkUnset) Command() *cobra.Command {
+func (c *cmdNetworkUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<network> <key>"))
 	cmd.Short = i18n.G("Unset network configuration keys")
@@ -1282,12 +1282,12 @@ func (c *cmdNetworkUnset) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1297,5 +1297,5 @@ func (c *cmdNetworkUnset) Run(cmd *cobra.Command, args []string) error {
 	c.networkSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.networkSet.Run(cmd, args)
+	return c.networkSet.run(cmd, args)
 }

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -22,7 +22,7 @@ type cmdNetworkACL struct {
 	global *cmdGlobal
 }
 
-func (c *cmdNetworkACL) Command() *cobra.Command {
+func (c *cmdNetworkACL) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("acl")
 	cmd.Short = i18n.G("Manage network ACLs")
@@ -30,47 +30,47 @@ func (c *cmdNetworkACL) Command() *cobra.Command {
 
 	// List.
 	networkACLListCmd := cmdNetworkACLList{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLListCmd.Command())
+	cmd.AddCommand(networkACLListCmd.command())
 
 	// Show.
 	networkACLShowCmd := cmdNetworkACLShow{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLShowCmd.Command())
+	cmd.AddCommand(networkACLShowCmd.command())
 
 	// Show log.
 	networkACLShowLogCmd := cmdNetworkACLShowLog{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLShowLogCmd.Command())
+	cmd.AddCommand(networkACLShowLogCmd.command())
 
 	// Get.
 	networkACLGetCmd := cmdNetworkACLGet{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLGetCmd.Command())
+	cmd.AddCommand(networkACLGetCmd.command())
 
 	// Create.
 	networkACLCreateCmd := cmdNetworkACLCreate{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLCreateCmd.Command())
+	cmd.AddCommand(networkACLCreateCmd.command())
 
 	// Set.
 	networkACLSetCmd := cmdNetworkACLSet{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLSetCmd.Command())
+	cmd.AddCommand(networkACLSetCmd.command())
 
 	// Unset.
 	networkACLUnsetCmd := cmdNetworkACLUnset{global: c.global, networkACL: c, networkACLSet: &networkACLSetCmd}
-	cmd.AddCommand(networkACLUnsetCmd.Command())
+	cmd.AddCommand(networkACLUnsetCmd.command())
 
 	// Edit.
 	networkACLEditCmd := cmdNetworkACLEdit{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLEditCmd.Command())
+	cmd.AddCommand(networkACLEditCmd.command())
 
 	// Rename.
 	networkACLRenameCmd := cmdNetworkACLRename{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLRenameCmd.Command())
+	cmd.AddCommand(networkACLRenameCmd.command())
 
 	// Delete.
 	networkACLDeleteCmd := cmdNetworkACLDelete{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLDeleteCmd.Command())
+	cmd.AddCommand(networkACLDeleteCmd.command())
 
 	// Rule.
 	networkACLRuleCmd := cmdNetworkACLRule{global: c.global, networkACL: c}
-	cmd.AddCommand(networkACLRuleCmd.Command())
+	cmd.AddCommand(networkACLRuleCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -86,20 +86,20 @@ type cmdNetworkACLList struct {
 	flagFormat string
 }
 
-func (c *cmdNetworkACLList) Command() *cobra.Command {
+func (c *cmdNetworkACLList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
 	cmd.Short = i18n.G("List available network ACLS")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("List available network ACL"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkACLList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -158,17 +158,17 @@ type cmdNetworkACLShow struct {
 	networkACL *cmdNetworkACL
 }
 
-func (c *cmdNetworkACLShow) Command() *cobra.Command {
+func (c *cmdNetworkACLShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<ACL>"))
 	cmd.Short = i18n.G("Show network ACL configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Show network ACL configurations"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkACLShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -211,17 +211,17 @@ type cmdNetworkACLShowLog struct {
 	networkACL *cmdNetworkACL
 }
 
-func (c *cmdNetworkACLShowLog) Command() *cobra.Command {
+func (c *cmdNetworkACLShowLog) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show-log", i18n.G("[<remote>:]<ACL>"))
 	cmd.Short = i18n.G("Show network ACL log")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Show network ACL log"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkACLShowLog) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLShowLog) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -259,19 +259,19 @@ type cmdNetworkACLGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkACLGet) Command() *cobra.Command {
+func (c *cmdNetworkACLGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<ACL> <key>"))
 	cmd.Short = i18n.G("Get values for network ACL configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Get values for network ACL configuration keys"))
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network ACL property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkACLGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -320,18 +320,18 @@ type cmdNetworkACLCreate struct {
 	networkACL *cmdNetworkACL
 }
 
-func (c *cmdNetworkACLCreate) Command() *cobra.Command {
+func (c *cmdNetworkACLCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<ACL> [key=value...]"))
 	cmd.Short = i18n.G("Create new network ACLs")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network ACLs"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkACLCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -405,7 +405,7 @@ type cmdNetworkACLSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkACLSet) Command() *cobra.Command {
+func (c *cmdNetworkACLSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<ACL> <key>=<value>..."))
 	cmd.Short = i18n.G("Set network ACL configuration keys")
@@ -416,12 +416,12 @@ For backward compatibility, a single configuration key may still be set with:
     lxc network set [<remote>:]<ACL> <key> <value>`))
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network ACL property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkACLSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -485,18 +485,18 @@ type cmdNetworkACLUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkACLUnset) Command() *cobra.Command {
+func (c *cmdNetworkACLUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<ACL> <key>"))
 	cmd.Short = i18n.G("Unset network ACL configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Unset network ACL configuration keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network ACL property"))
 	return cmd
 }
 
-func (c *cmdNetworkACLUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -506,7 +506,7 @@ func (c *cmdNetworkACLUnset) Run(cmd *cobra.Command, args []string) error {
 	c.networkACLSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.networkACLSet.Run(cmd, args)
+	return c.networkACLSet.run(cmd, args)
 }
 
 // Edit.
@@ -515,13 +515,13 @@ type cmdNetworkACLEdit struct {
 	networkACL *cmdNetworkACL
 }
 
-func (c *cmdNetworkACLEdit) Command() *cobra.Command {
+func (c *cmdNetworkACLEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<ACL>"))
 	cmd.Short = i18n.G("Edit network ACL configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Edit network ACL configurations as YAML"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -553,7 +553,7 @@ func (c *cmdNetworkACLEdit) helpTemplate() string {
 ### Note that only the ingress and egress rules, description and configuration keys can be changed.`)
 }
 
-func (c *cmdNetworkACLEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -645,18 +645,18 @@ type cmdNetworkACLRename struct {
 	networkACL *cmdNetworkACL
 }
 
-func (c *cmdNetworkACLRename) Command() *cobra.Command {
+func (c *cmdNetworkACLRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<ACL> <new-name>"))
 	cmd.Aliases = []string{"mv"}
 	cmd.Short = i18n.G("Rename network ACLs")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Rename network ACLs"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkACLRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLRename) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -694,18 +694,18 @@ type cmdNetworkACLDelete struct {
 	networkACL *cmdNetworkACL
 }
 
-func (c *cmdNetworkACLDelete) Command() *cobra.Command {
+func (c *cmdNetworkACLDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<ACL>"))
 	cmd.Aliases = []string{"rm"}
 	cmd.Short = i18n.G("Delete network ACLs")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network ACLs"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkACLDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -744,7 +744,7 @@ type cmdNetworkACLRule struct {
 	flagRemoveForce bool
 }
 
-func (c *cmdNetworkACLRule) Command() *cobra.Command {
+func (c *cmdNetworkACLRule) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rule")
 	cmd.Short = i18n.G("Manage network ACL rules")

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -751,20 +751,20 @@ func (c *cmdNetworkACLRule) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Manage network ACL rules"))
 
 	// Rule Add.
-	cmd.AddCommand(c.CommandAdd())
+	cmd.AddCommand(c.commandAdd())
 
 	// Rule Remove.
-	cmd.AddCommand(c.CommandRemove())
+	cmd.AddCommand(c.commandRemove())
 
 	return cmd
 }
 
-func (c *cmdNetworkACLRule) CommandAdd() *cobra.Command {
+func (c *cmdNetworkACLRule) commandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<ACL> <direction> <key>=<value>..."))
 	cmd.Short = i18n.G("Add rules to an ACL")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add rules to an ACL"))
-	cmd.RunE = c.RunAdd
+	cmd.RunE = c.runAdd
 
 	return cmd
 }
@@ -825,7 +825,7 @@ func (c *cmdNetworkACLRule) parseConfigToRule(config map[string]string) (*api.Ne
 	return &rule, nil
 }
 
-func (c *cmdNetworkACLRule) RunAdd(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLRule) runAdd(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -880,19 +880,19 @@ func (c *cmdNetworkACLRule) RunAdd(cmd *cobra.Command, args []string) error {
 	return resource.server.UpdateNetworkACL(resource.name, netACL.Writable(), etag)
 }
 
-func (c *cmdNetworkACLRule) CommandRemove() *cobra.Command {
+func (c *cmdNetworkACLRule) commandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<ACL> <direction> <key>=<value>..."))
 	cmd.Short = i18n.G("Remove rules from an ACL")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove rules from an ACL"))
 	cmd.Flags().BoolVar(&c.flagRemoveForce, "force", false, i18n.G("Remove all rules that match"))
 
-	cmd.RunE = c.RunRemove
+	cmd.RunE = c.runRemove
 
 	return cmd
 }
 
-func (c *cmdNetworkACLRule) RunRemove(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkACLRule) runRemove(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {

--- a/lxc/network_allocations.go
+++ b/lxc/network_allocations.go
@@ -44,7 +44,7 @@ func (c *cmdNetworkListAllocations) pretty(allocs []api.NetworkAllocations) erro
 	return cli.RenderTable(c.flagFormat, header, data, allocs)
 }
 
-func (c *cmdNetworkListAllocations) Command() *cobra.Command {
+func (c *cmdNetworkListAllocations) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list-allocations")
 	cmd.Short = i18n.G("List network allocations in use")
@@ -52,7 +52,7 @@ func (c *cmdNetworkListAllocations) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.MaximumNArgs(1)
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 	cmd.Flags().StringVarP(&c.flagProject, "project", "p", "default", i18n.G("Run again a specific project"))
@@ -60,7 +60,7 @@ func (c *cmdNetworkListAllocations) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdNetworkListAllocations) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkListAllocations) run(cmd *cobra.Command, args []string) error {
 	remote := ""
 	if len(args) > 0 {
 		remote = args[0]

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -765,27 +765,27 @@ func (c *cmdNetworkForwardPort) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Manage network forward ports"))
 
 	// Port Add.
-	cmd.AddCommand(c.CommandAdd())
+	cmd.AddCommand(c.commandAdd())
 
 	// Port Remove.
-	cmd.AddCommand(c.CommandRemove())
+	cmd.AddCommand(c.commandRemove())
 
 	return cmd
 }
 
-func (c *cmdNetworkForwardPort) CommandAdd() *cobra.Command {
+func (c *cmdNetworkForwardPort) commandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"))
 	cmd.Short = i18n.G("Add ports to a forward")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add ports to a forward"))
-	cmd.RunE = c.RunAdd
+	cmd.RunE = c.runAdd
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkForwardPort) RunAdd(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardPort) runAdd(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 5, 6)
 	if exit {
@@ -838,20 +838,20 @@ func (c *cmdNetworkForwardPort) RunAdd(cmd *cobra.Command, args []string) error 
 	return client.UpdateNetworkForward(resource.name, forward.ListenAddress, forward.Writable(), etag)
 }
 
-func (c *cmdNetworkForwardPort) CommandRemove() *cobra.Command {
+func (c *cmdNetworkForwardPort) commandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"))
 	cmd.Short = i18n.G("Remove ports from a forward")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove ports from a forward"))
 	cmd.Flags().BoolVar(&c.flagRemoveForce, "force", false, i18n.G("Remove all ports that match"))
-	cmd.RunE = c.RunRemove
+	cmd.RunE = c.runRemove
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkForwardPort) RunRemove(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardPort) runRemove(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 4)
 	if exit {

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -24,7 +24,7 @@ type cmdNetworkForward struct {
 	flagTarget string
 }
 
-func (c *cmdNetworkForward) Command() *cobra.Command {
+func (c *cmdNetworkForward) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("forward")
 	cmd.Short = i18n.G("Manage network forwards")
@@ -32,39 +32,39 @@ func (c *cmdNetworkForward) Command() *cobra.Command {
 
 	// List.
 	networkForwardListCmd := cmdNetworkForwardList{global: c.global, networkForward: c}
-	cmd.AddCommand(networkForwardListCmd.Command())
+	cmd.AddCommand(networkForwardListCmd.command())
 
 	// Show.
 	networkForwardShowCmd := cmdNetworkForwardShow{global: c.global, networkForward: c}
-	cmd.AddCommand(networkForwardShowCmd.Command())
+	cmd.AddCommand(networkForwardShowCmd.command())
 
 	// Create.
 	networkForwardCreateCmd := cmdNetworkForwardCreate{global: c.global, networkForward: c}
-	cmd.AddCommand(networkForwardCreateCmd.Command())
+	cmd.AddCommand(networkForwardCreateCmd.command())
 
 	// Get.
 	networkForwardGetCmd := cmdNetworkForwardGet{global: c.global, networkForward: c}
-	cmd.AddCommand(networkForwardGetCmd.Command())
+	cmd.AddCommand(networkForwardGetCmd.command())
 
 	// Set.
 	networkForwardSetCmd := cmdNetworkForwardSet{global: c.global, networkForward: c}
-	cmd.AddCommand(networkForwardSetCmd.Command())
+	cmd.AddCommand(networkForwardSetCmd.command())
 
 	// Unset.
 	networkForwardUnsetCmd := cmdNetworkForwardUnset{global: c.global, networkForward: c, networkForwardSet: &networkForwardSetCmd}
-	cmd.AddCommand(networkForwardUnsetCmd.Command())
+	cmd.AddCommand(networkForwardUnsetCmd.command())
 
 	// Edit.
 	networkForwardEditCmd := cmdNetworkForwardEdit{global: c.global, networkForward: c}
-	cmd.AddCommand(networkForwardEditCmd.Command())
+	cmd.AddCommand(networkForwardEditCmd.command())
 
 	// Delete.
 	networkForwardDeleteCmd := cmdNetworkForwardDelete{global: c.global, networkForward: c}
-	cmd.AddCommand(networkForwardDeleteCmd.Command())
+	cmd.AddCommand(networkForwardDeleteCmd.command())
 
 	// Port.
 	networkForwardPortCmd := cmdNetworkForwardPort{global: c.global, networkForward: c}
-	cmd.AddCommand(networkForwardPortCmd.Command())
+	cmd.AddCommand(networkForwardPortCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -80,20 +80,20 @@ type cmdNetworkForwardList struct {
 	flagFormat string
 }
 
-func (c *cmdNetworkForwardList) Command() *cobra.Command {
+func (c *cmdNetworkForwardList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<network>"))
 	cmd.Aliases = []string{"ls"}
 	cmd.Short = i18n.G("List available network forwards")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("List available network forwards"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkForwardList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -162,19 +162,19 @@ type cmdNetworkForwardShow struct {
 	networkForward *cmdNetworkForward
 }
 
-func (c *cmdNetworkForwardShow) Command() *cobra.Command {
+func (c *cmdNetworkForwardShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<network> <listen_address>"))
 	cmd.Short = i18n.G("Show network forward configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Show network forward configurations"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkForwardShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -227,12 +227,12 @@ type cmdNetworkForwardCreate struct {
 	flagAllocate   string
 }
 
-func (c *cmdNetworkForwardCreate) Command() *cobra.Command {
+func (c *cmdNetworkForwardCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> [<listen_address>] [key=value...]"))
 	cmd.Short = i18n.G("Create new network forwards")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network forwards"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagAllocate, "allocate", "", i18n.G("Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'.")+"``")
@@ -240,7 +240,7 @@ func (c *cmdNetworkForwardCreate) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdNetworkForwardCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -357,19 +357,19 @@ type cmdNetworkForwardGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkForwardGet) Command() *cobra.Command {
+func (c *cmdNetworkForwardGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<network> <listen_address> <key>"))
 	cmd.Short = i18n.G("Get values for network forward configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Get values for network forward configuration keys"))
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network forward property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkForwardGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -426,7 +426,7 @@ type cmdNetworkForwardSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkForwardSet) Command() *cobra.Command {
+func (c *cmdNetworkForwardSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<network> <listen_address> <key>=<value>..."))
 	cmd.Short = i18n.G("Set network forward keys")
@@ -435,7 +435,7 @@ func (c *cmdNetworkForwardSet) Command() *cobra.Command {
 
 For backward compatibility, a single configuration key may still be set with:
     lxc network set [<remote>:]<network> <listen_address> <key> <value>`))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network forward property"))
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
@@ -443,7 +443,7 @@ For backward compatibility, a single configuration key may still be set with:
 	return cmd
 }
 
-func (c *cmdNetworkForwardSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -524,18 +524,18 @@ type cmdNetworkForwardUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkForwardUnset) Command() *cobra.Command {
+func (c *cmdNetworkForwardUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<network> <listen_address> <key>"))
 	cmd.Short = i18n.G("Unset network forward configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Unset network forward keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network forward property"))
 	return cmd
 }
 
-func (c *cmdNetworkForwardUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -545,7 +545,7 @@ func (c *cmdNetworkForwardUnset) Run(cmd *cobra.Command, args []string) error {
 	c.networkForwardSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.networkForwardSet.Run(cmd, args)
+	return c.networkForwardSet.run(cmd, args)
 }
 
 // Edit.
@@ -554,12 +554,12 @@ type cmdNetworkForwardEdit struct {
 	networkForward *cmdNetworkForward
 }
 
-func (c *cmdNetworkForwardEdit) Command() *cobra.Command {
+func (c *cmdNetworkForwardEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<network> <listen_address>"))
 	cmd.Short = i18n.G("Edit network forward configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Edit network forward configurations as YAML"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
@@ -589,7 +589,7 @@ func (c *cmdNetworkForwardEdit) helpTemplate() string {
 ### Note that the listen_address and location cannot be changed.`)
 }
 
-func (c *cmdNetworkForwardEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -695,20 +695,20 @@ type cmdNetworkForwardDelete struct {
 	networkForward *cmdNetworkForward
 }
 
-func (c *cmdNetworkForwardDelete) Command() *cobra.Command {
+func (c *cmdNetworkForwardDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network> <listen_address>"))
 	cmd.Aliases = []string{"rm"}
 	cmd.Short = i18n.G("Delete network forwards")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network forwards"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkForwardDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkForwardDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -758,7 +758,7 @@ type cmdNetworkForwardPort struct {
 	flagRemoveForce bool
 }
 
-func (c *cmdNetworkForwardPort) Command() *cobra.Command {
+func (c *cmdNetworkForwardPort) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("port")
 	cmd.Short = i18n.G("Manage network forward ports")

--- a/lxc/network_load_balancer.go
+++ b/lxc/network_load_balancer.go
@@ -24,7 +24,7 @@ type cmdNetworkLoadBalancer struct {
 	flagTarget string
 }
 
-func (c *cmdNetworkLoadBalancer) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancer) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("load-balancer")
 	cmd.Short = i18n.G("Manage network load balancers")
@@ -32,43 +32,43 @@ func (c *cmdNetworkLoadBalancer) Command() *cobra.Command {
 
 	// List.
 	networkLoadBalancerListCmd := cmdNetworkLoadBalancerList{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerListCmd.Command())
+	cmd.AddCommand(networkLoadBalancerListCmd.command())
 
 	// Show.
 	networkLoadBalancerShowCmd := cmdNetworkLoadBalancerShow{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerShowCmd.Command())
+	cmd.AddCommand(networkLoadBalancerShowCmd.command())
 
 	// Create.
 	networkLoadBalancerCreateCmd := cmdNetworkLoadBalancerCreate{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerCreateCmd.Command())
+	cmd.AddCommand(networkLoadBalancerCreateCmd.command())
 
 	// Get.
 	networkLoadBalancerGetCmd := cmdNetworkLoadBalancerGet{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerGetCmd.Command())
+	cmd.AddCommand(networkLoadBalancerGetCmd.command())
 
 	// Set.
 	networkLoadBalancerSetCmd := cmdNetworkLoadBalancerSet{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerSetCmd.Command())
+	cmd.AddCommand(networkLoadBalancerSetCmd.command())
 
 	// Unset.
 	networkLoadBalancerUnsetCmd := cmdNetworkLoadBalancerUnset{global: c.global, networkLoadBalancer: c, networkLoadBalancerSet: &networkLoadBalancerSetCmd}
-	cmd.AddCommand(networkLoadBalancerUnsetCmd.Command())
+	cmd.AddCommand(networkLoadBalancerUnsetCmd.command())
 
 	// Edit.
 	networkLoadBalancerEditCmd := cmdNetworkLoadBalancerEdit{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerEditCmd.Command())
+	cmd.AddCommand(networkLoadBalancerEditCmd.command())
 
 	// Delete.
 	networkLoadBalancerDeleteCmd := cmdNetworkLoadBalancerDelete{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerDeleteCmd.Command())
+	cmd.AddCommand(networkLoadBalancerDeleteCmd.command())
 
 	// Backend.
 	networkLoadBalancerBackendCmd := cmdNetworkLoadBalancerBackend{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerBackendCmd.Command())
+	cmd.AddCommand(networkLoadBalancerBackendCmd.command())
 
 	// Port.
 	networkLoadBalancerPortCmd := cmdNetworkLoadBalancerPort{global: c.global, networkLoadBalancer: c}
-	cmd.AddCommand(networkLoadBalancerPortCmd.Command())
+	cmd.AddCommand(networkLoadBalancerPortCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -84,20 +84,20 @@ type cmdNetworkLoadBalancerList struct {
 	flagFormat string
 }
 
-func (c *cmdNetworkLoadBalancerList) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<network>"))
 	cmd.Aliases = []string{"ls"}
 	cmd.Short = i18n.G("List available network load balancers")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("List available network load balancers"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -164,19 +164,19 @@ type cmdNetworkLoadBalancerShow struct {
 	networkLoadBalancer *cmdNetworkLoadBalancer
 }
 
-func (c *cmdNetworkLoadBalancerShow) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<network> <listen_address>"))
 	cmd.Short = i18n.G("Show network load balancer configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Show network load balancer configurations"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -229,12 +229,12 @@ type cmdNetworkLoadBalancerCreate struct {
 	flagAllocate        string
 }
 
-func (c *cmdNetworkLoadBalancerCreate) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> [<listen_address>] [key=value...]"))
 	cmd.Short = i18n.G("Create new network load balancers")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network load balancers"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagAllocate, "allocate", "", i18n.G("Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'.")+"``")
@@ -242,7 +242,7 @@ func (c *cmdNetworkLoadBalancerCreate) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -361,18 +361,18 @@ type cmdNetworkLoadBalancerGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkLoadBalancerGet) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<network> <listen_address> <key>"))
 	cmd.Short = i18n.G("Get values for network load balancer configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Get values for network load balancer configuration keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network load balancer property"))
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -429,7 +429,7 @@ type cmdNetworkLoadBalancerSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkLoadBalancerSet) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<network> <listen_address> <key>=<value>..."))
 	cmd.Short = i18n.G("Set network load balancer keys")
@@ -438,7 +438,7 @@ func (c *cmdNetworkLoadBalancerSet) Command() *cobra.Command {
 
 For backward compatibility, a single configuration key may still be set with:
     lxc network set [<remote>:]<network> <listen_address> <key> <value>`))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network load balancer property"))
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
@@ -446,7 +446,7 @@ For backward compatibility, a single configuration key may still be set with:
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -527,18 +527,18 @@ type cmdNetworkLoadBalancerUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkLoadBalancerUnset) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<network> <listen_address> <key>"))
 	cmd.Short = i18n.G("Unset network load balancer configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Unset network load balancer keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network load balancer property"))
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -548,7 +548,7 @@ func (c *cmdNetworkLoadBalancerUnset) Run(cmd *cobra.Command, args []string) err
 	c.networkLoadBalancerSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.networkLoadBalancerSet.Run(cmd, args)
+	return c.networkLoadBalancerSet.run(cmd, args)
 }
 
 // Edit.
@@ -557,12 +557,12 @@ type cmdNetworkLoadBalancerEdit struct {
 	networkLoadBalancer *cmdNetworkLoadBalancer
 }
 
-func (c *cmdNetworkLoadBalancerEdit) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<network> <listen_address>"))
 	cmd.Short = i18n.G("Edit network load balancer configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Edit network load balancer configurations as YAML"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
@@ -592,7 +592,7 @@ func (c *cmdNetworkLoadBalancerEdit) helpTemplate() string {
 ### Note that the listen_address and location cannot be changed.`)
 }
 
-func (c *cmdNetworkLoadBalancerEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -699,20 +699,20 @@ type cmdNetworkLoadBalancerDelete struct {
 	networkLoadBalancer *cmdNetworkLoadBalancer
 }
 
-func (c *cmdNetworkLoadBalancerDelete) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network> <listen_address>"))
 	cmd.Aliases = []string{"rm"}
 	cmd.Short = i18n.G("Delete network load balancers")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network load balancers"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -761,7 +761,7 @@ type cmdNetworkLoadBalancerBackend struct {
 	networkLoadBalancer *cmdNetworkLoadBalancer
 }
 
-func (c *cmdNetworkLoadBalancerBackend) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerBackend) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("backend")
 	cmd.Short = i18n.G("Manage network load balancer backends")
@@ -926,7 +926,7 @@ type cmdNetworkLoadBalancerPort struct {
 	flagRemoveForce     bool
 }
 
-func (c *cmdNetworkLoadBalancerPort) Command() *cobra.Command {
+func (c *cmdNetworkLoadBalancerPort) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("port")
 	cmd.Short = i18n.G("Manage network load balancer ports")

--- a/lxc/network_load_balancer.go
+++ b/lxc/network_load_balancer.go
@@ -768,27 +768,27 @@ func (c *cmdNetworkLoadBalancerBackend) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Manage network load balancer backends"))
 
 	// Backend Add.
-	cmd.AddCommand(c.CommandAdd())
+	cmd.AddCommand(c.commandAdd())
 
 	// Backend Remove.
-	cmd.AddCommand(c.CommandRemove())
+	cmd.AddCommand(c.commandRemove())
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerBackend) CommandAdd() *cobra.Command {
+func (c *cmdNetworkLoadBalancerBackend) commandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"))
 	cmd.Short = i18n.G("Add backends to a load balancer")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add backend to a load balancer"))
-	cmd.RunE = c.RunAdd
+	cmd.RunE = c.runAdd
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerBackend) RunAdd(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerBackend) runAdd(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 4, 5)
 	if exit {
@@ -840,19 +840,19 @@ func (c *cmdNetworkLoadBalancerBackend) RunAdd(cmd *cobra.Command, args []string
 	return client.UpdateNetworkLoadBalancer(resource.name, loadBalancer.ListenAddress, loadBalancer.Writable(), etag)
 }
 
-func (c *cmdNetworkLoadBalancerBackend) CommandRemove() *cobra.Command {
+func (c *cmdNetworkLoadBalancerBackend) commandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<network> <listen_address> <backend_name>"))
 	cmd.Short = i18n.G("Remove backends from a load balancer")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove backend from a load balancer"))
-	cmd.RunE = c.RunRemove
+	cmd.RunE = c.runRemove
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerBackend) RunRemove(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerBackend) runRemove(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -933,27 +933,27 @@ func (c *cmdNetworkLoadBalancerPort) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Manage network load balancer ports"))
 
 	// Port Add.
-	cmd.AddCommand(c.CommandAdd())
+	cmd.AddCommand(c.commandAdd())
 
 	// Port Remove.
-	cmd.AddCommand(c.CommandRemove())
+	cmd.AddCommand(c.commandRemove())
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerPort) CommandAdd() *cobra.Command {
+func (c *cmdNetworkLoadBalancerPort) commandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"))
 	cmd.Short = i18n.G("Add ports to a load balancer")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add ports to a load balancer"))
-	cmd.RunE = c.RunAdd
+	cmd.RunE = c.runAdd
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerPort) RunAdd(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerPort) runAdd(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 5, 5)
 	if exit {
@@ -1002,20 +1002,20 @@ func (c *cmdNetworkLoadBalancerPort) RunAdd(cmd *cobra.Command, args []string) e
 	return client.UpdateNetworkLoadBalancer(resource.name, loadBalancer.ListenAddress, loadBalancer.Writable(), etag)
 }
 
-func (c *cmdNetworkLoadBalancerPort) CommandRemove() *cobra.Command {
+func (c *cmdNetworkLoadBalancerPort) commandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"))
 	cmd.Short = i18n.G("Remove ports from a load balancer")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove ports from a load balancer"))
 	cmd.Flags().BoolVar(&c.flagRemoveForce, "force", false, i18n.G("Remove all ports that match"))
-	cmd.RunE = c.RunRemove
+	cmd.RunE = c.runRemove
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkLoadBalancerPort) RunRemove(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkLoadBalancerPort) runRemove(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 4)
 	if exit {

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -21,7 +21,7 @@ type cmdNetworkPeer struct {
 	global *cmdGlobal
 }
 
-func (c *cmdNetworkPeer) Command() *cobra.Command {
+func (c *cmdNetworkPeer) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("peer")
 	cmd.Short = i18n.G("Manage network peerings")
@@ -29,35 +29,35 @@ func (c *cmdNetworkPeer) Command() *cobra.Command {
 
 	// List.
 	networkPeerListCmd := cmdNetworkPeerList{global: c.global, networkPeer: c}
-	cmd.AddCommand(networkPeerListCmd.Command())
+	cmd.AddCommand(networkPeerListCmd.command())
 
 	// Show.
 	networkPeerShowCmd := cmdNetworkPeerShow{global: c.global, networkPeer: c}
-	cmd.AddCommand(networkPeerShowCmd.Command())
+	cmd.AddCommand(networkPeerShowCmd.command())
 
 	// Create.
 	networkPeerCreateCmd := cmdNetworkPeerCreate{global: c.global, networkPeer: c}
-	cmd.AddCommand(networkPeerCreateCmd.Command())
+	cmd.AddCommand(networkPeerCreateCmd.command())
 
 	// Get,
 	networkPeerGetCmd := cmdNetworkPeerGet{global: c.global, networkPeer: c}
-	cmd.AddCommand(networkPeerGetCmd.Command())
+	cmd.AddCommand(networkPeerGetCmd.command())
 
 	// Set.
 	networkPeerSetCmd := cmdNetworkPeerSet{global: c.global, networkPeer: c}
-	cmd.AddCommand(networkPeerSetCmd.Command())
+	cmd.AddCommand(networkPeerSetCmd.command())
 
 	// Unset.
 	networkPeerUnsetCmd := cmdNetworkPeerUnset{global: c.global, networkPeer: c, networkPeerSet: &networkPeerSetCmd}
-	cmd.AddCommand(networkPeerUnsetCmd.Command())
+	cmd.AddCommand(networkPeerUnsetCmd.command())
 
 	// Edit.
 	networkPeerEditCmd := cmdNetworkPeerEdit{global: c.global, networkPeer: c}
-	cmd.AddCommand(networkPeerEditCmd.Command())
+	cmd.AddCommand(networkPeerEditCmd.command())
 
 	// Delete.
 	networkPeerDeleteCmd := cmdNetworkPeerDelete{global: c.global, networkPeer: c}
-	cmd.AddCommand(networkPeerDeleteCmd.Command())
+	cmd.AddCommand(networkPeerDeleteCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -73,20 +73,20 @@ type cmdNetworkPeerList struct {
 	flagFormat string
 }
 
-func (c *cmdNetworkPeerList) Command() *cobra.Command {
+func (c *cmdNetworkPeerList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<network>"))
 	cmd.Aliases = []string{"ls"}
 	cmd.Short = i18n.G("List available network peers")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("List available network peers"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkPeerList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkPeerList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -151,17 +151,17 @@ type cmdNetworkPeerShow struct {
 	networkPeer *cmdNetworkPeer
 }
 
-func (c *cmdNetworkPeerShow) Command() *cobra.Command {
+func (c *cmdNetworkPeerShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<network> <peer name>"))
 	cmd.Short = i18n.G("Show network peer configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Show network peer configurations"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkPeerShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkPeerShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -208,17 +208,17 @@ type cmdNetworkPeerCreate struct {
 	networkPeer *cmdNetworkPeer
 }
 
-func (c *cmdNetworkPeerCreate) Command() *cobra.Command {
+func (c *cmdNetworkPeerCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> <peer_name> <[target project/]target_network> [key=value...]"))
 	cmd.Short = i18n.G("Create new network peering")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network peering"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkPeerCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkPeerCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -324,18 +324,18 @@ type cmdNetworkPeerGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkPeerGet) Command() *cobra.Command {
+func (c *cmdNetworkPeerGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<network> <peer_name> <key>"))
 	cmd.Short = i18n.G("Get values for network peer configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Get values for network peer configuration keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network peer property"))
 	return cmd
 }
 
-func (c *cmdNetworkPeerGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkPeerGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -392,7 +392,7 @@ type cmdNetworkPeerSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkPeerSet) Command() *cobra.Command {
+func (c *cmdNetworkPeerSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<network> <peer_name> <key>=<value>..."))
 	cmd.Short = i18n.G("Set network peer keys")
@@ -401,13 +401,13 @@ func (c *cmdNetworkPeerSet) Command() *cobra.Command {
 
 For backward compatibility, a single configuration key may still be set with:
     lxc network set [<remote>:]<network> <peer_name> <key> <value>`))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network peer property"))
 	return cmd
 }
 
-func (c *cmdNetworkPeerSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkPeerSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -481,18 +481,18 @@ type cmdNetworkPeerUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkPeerUnset) Command() *cobra.Command {
+func (c *cmdNetworkPeerUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<network> <peer_name> <key>"))
 	cmd.Short = i18n.G("Unset network peer configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Unset network peer keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network peer property"))
 	return cmd
 }
 
-func (c *cmdNetworkPeerUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkPeerUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -502,7 +502,7 @@ func (c *cmdNetworkPeerUnset) Run(cmd *cobra.Command, args []string) error {
 	c.networkPeerSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.networkPeerSet.Run(cmd, args)
+	return c.networkPeerSet.run(cmd, args)
 }
 
 // Edit.
@@ -511,12 +511,12 @@ type cmdNetworkPeerEdit struct {
 	networkPeer *cmdNetworkPeer
 }
 
-func (c *cmdNetworkPeerEdit) Command() *cobra.Command {
+func (c *cmdNetworkPeerEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<network> <peer_name>"))
 	cmd.Short = i18n.G("Edit network peer configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Edit network peer configurations as YAML"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -537,7 +537,7 @@ func (c *cmdNetworkPeerEdit) helpTemplate() string {
 ### Note that the name, target_project, target_network and status fields cannot be changed.`)
 }
 
-func (c *cmdNetworkPeerEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkPeerEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -635,18 +635,18 @@ type cmdNetworkPeerDelete struct {
 	networkPeer *cmdNetworkPeer
 }
 
-func (c *cmdNetworkPeerDelete) Command() *cobra.Command {
+func (c *cmdNetworkPeerDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network> <peer_name>"))
 	cmd.Aliases = []string{"rm"}
 	cmd.Short = i18n.G("Delete network peerings")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network peerings"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkPeerDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkPeerDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -1225,26 +1225,26 @@ func (c *cmdNetworkZoneRecordEntry) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Manage network zone record entries"))
 
 	// Rule Add.
-	cmd.AddCommand(c.CommandAdd())
+	cmd.AddCommand(c.commandAdd())
 
 	// Rule Remove.
-	cmd.AddCommand(c.CommandRemove())
+	cmd.AddCommand(c.commandRemove())
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordEntry) CommandAdd() *cobra.Command {
+func (c *cmdNetworkZoneRecordEntry) commandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<zone> <record> <type> <value>"))
 	cmd.Short = i18n.G("Add a network zone record entry")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add entries to a network zone record"))
-	cmd.RunE = c.RunAdd
+	cmd.RunE = c.runAdd
 	cmd.Flags().Uint64Var(&c.flagTTL, "ttl", 0, i18n.G("Entry TTL")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordEntry) RunAdd(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordEntry) runAdd(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 4, 4)
 	if exit {
@@ -1279,17 +1279,17 @@ func (c *cmdNetworkZoneRecordEntry) RunAdd(cmd *cobra.Command, args []string) er
 	return resource.server.UpdateNetworkZoneRecord(resource.name, args[1], netRecord.Writable(), etag)
 }
 
-func (c *cmdNetworkZoneRecordEntry) CommandRemove() *cobra.Command {
+func (c *cmdNetworkZoneRecordEntry) commandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<zone> <record> <type> <value>"))
 	cmd.Short = i18n.G("Remove a network zone record entry")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove entries from a network zone record"))
-	cmd.RunE = c.RunRemove
+	cmd.RunE = c.runRemove
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordEntry) RunRemove(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordEntry) runRemove(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 4, 4)
 	if exit {

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -21,7 +21,7 @@ type cmdNetworkZone struct {
 	global *cmdGlobal
 }
 
-func (c *cmdNetworkZone) Command() *cobra.Command {
+func (c *cmdNetworkZone) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("zone")
 	cmd.Short = i18n.G("Manage network zones")
@@ -29,39 +29,39 @@ func (c *cmdNetworkZone) Command() *cobra.Command {
 
 	// List.
 	networkZoneListCmd := cmdNetworkZoneList{global: c.global, networkZone: c}
-	cmd.AddCommand(networkZoneListCmd.Command())
+	cmd.AddCommand(networkZoneListCmd.command())
 
 	// Show.
 	networkZoneShowCmd := cmdNetworkZoneShow{global: c.global, networkZone: c}
-	cmd.AddCommand(networkZoneShowCmd.Command())
+	cmd.AddCommand(networkZoneShowCmd.command())
 
 	// Get.
 	networkZoneGetCmd := cmdNetworkZoneGet{global: c.global, networkZone: c}
-	cmd.AddCommand(networkZoneGetCmd.Command())
+	cmd.AddCommand(networkZoneGetCmd.command())
 
 	// Create.
 	networkZoneCreateCmd := cmdNetworkZoneCreate{global: c.global, networkZone: c}
-	cmd.AddCommand(networkZoneCreateCmd.Command())
+	cmd.AddCommand(networkZoneCreateCmd.command())
 
 	// Set.
 	networkZoneSetCmd := cmdNetworkZoneSet{global: c.global, networkZone: c}
-	cmd.AddCommand(networkZoneSetCmd.Command())
+	cmd.AddCommand(networkZoneSetCmd.command())
 
 	// Unset.
 	networkZoneUnsetCmd := cmdNetworkZoneUnset{global: c.global, networkZone: c, networkZoneSet: &networkZoneSetCmd}
-	cmd.AddCommand(networkZoneUnsetCmd.Command())
+	cmd.AddCommand(networkZoneUnsetCmd.command())
 
 	// Edit.
 	networkZoneEditCmd := cmdNetworkZoneEdit{global: c.global, networkZone: c}
-	cmd.AddCommand(networkZoneEditCmd.Command())
+	cmd.AddCommand(networkZoneEditCmd.command())
 
 	// Delete.
 	networkZoneDeleteCmd := cmdNetworkZoneDelete{global: c.global, networkZone: c}
-	cmd.AddCommand(networkZoneDeleteCmd.Command())
+	cmd.AddCommand(networkZoneDeleteCmd.command())
 
 	// Record.
 	networkZoneRecordCmd := cmdNetworkZoneRecord{global: c.global, networkZone: c}
-	cmd.AddCommand(networkZoneRecordCmd.Command())
+	cmd.AddCommand(networkZoneRecordCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -77,20 +77,20 @@ type cmdNetworkZoneList struct {
 	flagFormat string
 }
 
-func (c *cmdNetworkZoneList) Command() *cobra.Command {
+func (c *cmdNetworkZoneList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
 	cmd.Short = i18n.G("List available network zoneS")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("List available network zone"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -149,17 +149,17 @@ type cmdNetworkZoneShow struct {
 	networkZone *cmdNetworkZone
 }
 
-func (c *cmdNetworkZoneShow) Command() *cobra.Command {
+func (c *cmdNetworkZoneShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<Zone>"))
 	cmd.Short = i18n.G("Show network zone configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Show network zone configurations"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -204,18 +204,18 @@ type cmdNetworkZoneGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkZoneGet) Command() *cobra.Command {
+func (c *cmdNetworkZoneGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<Zone> <key>"))
 	cmd.Short = i18n.G("Get values for network zone configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Get values for network zone configuration keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network zone property"))
 	return cmd
 }
 
-func (c *cmdNetworkZoneGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -264,18 +264,18 @@ type cmdNetworkZoneCreate struct {
 	networkZone *cmdNetworkZone
 }
 
-func (c *cmdNetworkZoneCreate) Command() *cobra.Command {
+func (c *cmdNetworkZoneCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<Zone> [key=value...]"))
 	cmd.Short = i18n.G("Create new network zones")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network zones"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -347,7 +347,7 @@ type cmdNetworkZoneSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkZoneSet) Command() *cobra.Command {
+func (c *cmdNetworkZoneSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<Zone> <key>=<value>..."))
 	cmd.Short = i18n.G("Set network zone configuration keys")
@@ -357,13 +357,13 @@ func (c *cmdNetworkZoneSet) Command() *cobra.Command {
 For backward compatibility, a single configuration key may still be set with:
     lxc network set [<remote>:]<Zone> <key> <value>`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network zone property"))
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -427,19 +427,19 @@ type cmdNetworkZoneUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkZoneUnset) Command() *cobra.Command {
+func (c *cmdNetworkZoneUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<Zone> <key>"))
 	cmd.Short = i18n.G("Unset network zone configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Unset network zone configuration keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network zone property"))
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -449,7 +449,7 @@ func (c *cmdNetworkZoneUnset) Run(cmd *cobra.Command, args []string) error {
 	c.networkZoneSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.networkZoneSet.Run(cmd, args)
+	return c.networkZoneSet.run(cmd, args)
 }
 
 // Edit.
@@ -458,13 +458,13 @@ type cmdNetworkZoneEdit struct {
 	networkZone *cmdNetworkZone
 }
 
-func (c *cmdNetworkZoneEdit) Command() *cobra.Command {
+func (c *cmdNetworkZoneEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<Zone>"))
 	cmd.Short = i18n.G("Edit network zone configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Edit network zone configurations as YAML"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -484,7 +484,7 @@ func (c *cmdNetworkZoneEdit) helpTemplate() string {
 `)
 }
 
-func (c *cmdNetworkZoneEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -576,18 +576,18 @@ type cmdNetworkZoneDelete struct {
 	networkZone *cmdNetworkZone
 }
 
-func (c *cmdNetworkZoneDelete) Command() *cobra.Command {
+func (c *cmdNetworkZoneDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<Zone>"))
 	cmd.Aliases = []string{"rm"}
 	cmd.Short = i18n.G("Delete network zones")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network zones"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -625,7 +625,7 @@ type cmdNetworkZoneRecord struct {
 	networkZone *cmdNetworkZone
 }
 
-func (c *cmdNetworkZoneRecord) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecord) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("record")
 	cmd.Short = i18n.G("Manage network zone records")
@@ -633,39 +633,39 @@ func (c *cmdNetworkZoneRecord) Command() *cobra.Command {
 
 	// List.
 	networkZoneRecordListCmd := cmdNetworkZoneRecordList{global: c.global, networkZoneRecord: c}
-	cmd.AddCommand(networkZoneRecordListCmd.Command())
+	cmd.AddCommand(networkZoneRecordListCmd.command())
 
 	// Show.
 	networkZoneRecordShowCmd := cmdNetworkZoneRecordShow{global: c.global, networkZoneRecord: c}
-	cmd.AddCommand(networkZoneRecordShowCmd.Command())
+	cmd.AddCommand(networkZoneRecordShowCmd.command())
 
 	// Get.
 	networkZoneRecordGetCmd := cmdNetworkZoneRecordGet{global: c.global, networkZoneRecord: c}
-	cmd.AddCommand(networkZoneRecordGetCmd.Command())
+	cmd.AddCommand(networkZoneRecordGetCmd.command())
 
 	// Create.
 	networkZoneRecordCreateCmd := cmdNetworkZoneRecordCreate{global: c.global, networkZoneRecord: c}
-	cmd.AddCommand(networkZoneRecordCreateCmd.Command())
+	cmd.AddCommand(networkZoneRecordCreateCmd.command())
 
 	// Set.
 	networkZoneRecordSetCmd := cmdNetworkZoneRecordSet{global: c.global, networkZoneRecord: c}
-	cmd.AddCommand(networkZoneRecordSetCmd.Command())
+	cmd.AddCommand(networkZoneRecordSetCmd.command())
 
 	// Unset.
 	networkZoneRecordUnsetCmd := cmdNetworkZoneRecordUnset{global: c.global, networkZoneRecord: c, networkZoneRecordSet: &networkZoneRecordSetCmd}
-	cmd.AddCommand(networkZoneRecordUnsetCmd.Command())
+	cmd.AddCommand(networkZoneRecordUnsetCmd.command())
 
 	// Edit.
 	networkZoneRecordEditCmd := cmdNetworkZoneRecordEdit{global: c.global, networkZoneRecord: c}
-	cmd.AddCommand(networkZoneRecordEditCmd.Command())
+	cmd.AddCommand(networkZoneRecordEditCmd.command())
 
 	// Delete.
 	networkZoneRecordDeleteCmd := cmdNetworkZoneRecordDelete{global: c.global, networkZoneRecord: c}
-	cmd.AddCommand(networkZoneRecordDeleteCmd.Command())
+	cmd.AddCommand(networkZoneRecordDeleteCmd.command())
 
 	// Entry.
 	networkZoneRecordEntryCmd := cmdNetworkZoneRecordEntry{global: c.global, networkZoneRecord: c}
-	cmd.AddCommand(networkZoneRecordEntryCmd.Command())
+	cmd.AddCommand(networkZoneRecordEntryCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -681,20 +681,20 @@ type cmdNetworkZoneRecordList struct {
 	flagFormat string
 }
 
-func (c *cmdNetworkZoneRecordList) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<zone>"))
 	cmd.Aliases = []string{"ls"}
 	cmd.Short = i18n.G("List available network zone records")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("List available network zone records"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -752,17 +752,17 @@ type cmdNetworkZoneRecordShow struct {
 	networkZoneRecord *cmdNetworkZoneRecord
 }
 
-func (c *cmdNetworkZoneRecordShow) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<zone> <record>"))
 	cmd.Short = i18n.G("Show network zone record configuration")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Show network zone record configurations"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -804,18 +804,18 @@ type cmdNetworkZoneRecordGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkZoneRecordGet) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<zone> <record> <key>"))
 	cmd.Short = i18n.G("Get values for network zone record configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Get values for network zone record configuration keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network zone record property"))
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -863,18 +863,18 @@ type cmdNetworkZoneRecordCreate struct {
 	networkZoneRecord *cmdNetworkZoneRecord
 }
 
-func (c *cmdNetworkZoneRecordCreate) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<zone> <record> [key=value...]"))
 	cmd.Short = i18n.G("Create new network zone record")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network zone record"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -945,20 +945,20 @@ type cmdNetworkZoneRecordSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkZoneRecordSet) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<zone> <record> <key>=<value>..."))
 	cmd.Short = i18n.G("Set network zone record configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Set network zone record configuration keys`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network zone record property"))
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -1021,18 +1021,18 @@ type cmdNetworkZoneRecordUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdNetworkZoneRecordUnset) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<zone> <record> <key>"))
 	cmd.Short = i18n.G("Unset network zone record configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Unset network zone record configuration keys"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network zone record property"))
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -1042,7 +1042,7 @@ func (c *cmdNetworkZoneRecordUnset) Run(cmd *cobra.Command, args []string) error
 	c.networkZoneRecordSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.networkZoneRecordSet.Run(cmd, args)
+	return c.networkZoneRecordSet.run(cmd, args)
 }
 
 // Edit.
@@ -1051,13 +1051,13 @@ type cmdNetworkZoneRecordEdit struct {
 	networkZoneRecord *cmdNetworkZoneRecord
 }
 
-func (c *cmdNetworkZoneRecordEdit) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<zone> <record>"))
 	cmd.Short = i18n.G("Edit network zone record configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Edit network zone record configurations as YAML"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -1077,7 +1077,7 @@ func (c *cmdNetworkZoneRecordEdit) helpTemplate() string {
 `)
 }
 
-func (c *cmdNetworkZoneRecordEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1168,18 +1168,18 @@ type cmdNetworkZoneRecordDelete struct {
 	networkZoneRecord *cmdNetworkZoneRecord
 }
 
-func (c *cmdNetworkZoneRecordDelete) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<zone> <record>"))
 	cmd.Aliases = []string{"rm"}
 	cmd.Short = i18n.G("Delete network zone record")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network zone record"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdNetworkZoneRecordDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdNetworkZoneRecordDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1218,7 +1218,7 @@ type cmdNetworkZoneRecordEntry struct {
 	flagTTL uint64
 }
 
-func (c *cmdNetworkZoneRecordEntry) Command() *cobra.Command {
+func (c *cmdNetworkZoneRecordEntry) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("entry")
 	cmd.Short = i18n.G("Manage network zone record entries")

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -17,7 +17,7 @@ type cmdOperation struct {
 	global *cmdGlobal
 }
 
-func (c *cmdOperation) Command() *cobra.Command {
+func (c *cmdOperation) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("operation")
 	cmd.Short = i18n.G("List, show and delete background operations")
@@ -26,15 +26,15 @@ func (c *cmdOperation) Command() *cobra.Command {
 
 	// Delete
 	operationDeleteCmd := cmdOperationDelete{global: c.global, operation: c}
-	cmd.AddCommand(operationDeleteCmd.Command())
+	cmd.AddCommand(operationDeleteCmd.command())
 
 	// List
 	operationListCmd := cmdOperationList{global: c.global, operation: c}
-	cmd.AddCommand(operationListCmd.Command())
+	cmd.AddCommand(operationListCmd.command())
 
 	// Show
 	operationShowCmd := cmdOperationShow{global: c.global, operation: c}
-	cmd.AddCommand(operationShowCmd.Command())
+	cmd.AddCommand(operationShowCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -48,7 +48,7 @@ type cmdOperationDelete struct {
 	operation *cmdOperation
 }
 
-func (c *cmdOperationDelete) Command() *cobra.Command {
+func (c *cmdOperationDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<operation>"))
 	cmd.Aliases = []string{"cancel", "rm"}
@@ -56,12 +56,12 @@ func (c *cmdOperationDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete a background operation (will attempt to cancel)`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdOperationDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdOperationDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -98,7 +98,7 @@ type cmdOperationList struct {
 	flagAllProjects bool
 }
 
-func (c *cmdOperationList) Command() *cobra.Command {
+func (c *cmdOperationList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -108,12 +108,12 @@ func (c *cmdOperationList) Command() *cobra.Command {
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("List operations from all projects")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdOperationList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -186,7 +186,7 @@ type cmdOperationShow struct {
 	operation *cmdOperation
 }
 
-func (c *cmdOperationShow) Command() *cobra.Command {
+func (c *cmdOperationShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<operation>"))
 	cmd.Short = i18n.G("Show details on a background operation")
@@ -196,12 +196,12 @@ func (c *cmdOperationShow) Command() *cobra.Command {
 		`lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a
     Show details on that operation UUID`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdOperationShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdOperationShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -22,7 +22,7 @@ type cmdProfile struct {
 	global *cmdGlobal
 }
 
-func (c *cmdProfile) Command() *cobra.Command {
+func (c *cmdProfile) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("profile")
 	cmd.Short = i18n.G("Manage profiles")
@@ -31,59 +31,59 @@ func (c *cmdProfile) Command() *cobra.Command {
 
 	// Add
 	profileAddCmd := cmdProfileAdd{global: c.global, profile: c}
-	cmd.AddCommand(profileAddCmd.Command())
+	cmd.AddCommand(profileAddCmd.command())
 
 	// Assign
 	profileAssignCmd := cmdProfileAssign{global: c.global, profile: c}
-	cmd.AddCommand(profileAssignCmd.Command())
+	cmd.AddCommand(profileAssignCmd.command())
 
 	// Copy
 	profileCopyCmd := cmdProfileCopy{global: c.global, profile: c}
-	cmd.AddCommand(profileCopyCmd.Command())
+	cmd.AddCommand(profileCopyCmd.command())
 
 	// Create
 	profileCreateCmd := cmdProfileCreate{global: c.global, profile: c}
-	cmd.AddCommand(profileCreateCmd.Command())
+	cmd.AddCommand(profileCreateCmd.command())
 
 	// Delete
 	profileDeleteCmd := cmdProfileDelete{global: c.global, profile: c}
-	cmd.AddCommand(profileDeleteCmd.Command())
+	cmd.AddCommand(profileDeleteCmd.command())
 
 	// Device
 	profileDeviceCmd := cmdConfigDevice{global: c.global, profile: c}
-	cmd.AddCommand(profileDeviceCmd.Command())
+	cmd.AddCommand(profileDeviceCmd.command())
 
 	// Edit
 	profileEditCmd := cmdProfileEdit{global: c.global, profile: c}
-	cmd.AddCommand(profileEditCmd.Command())
+	cmd.AddCommand(profileEditCmd.command())
 
 	// Get
 	profileGetCmd := cmdProfileGet{global: c.global, profile: c}
-	cmd.AddCommand(profileGetCmd.Command())
+	cmd.AddCommand(profileGetCmd.command())
 
 	// List
 	profileListCmd := cmdProfileList{global: c.global, profile: c}
-	cmd.AddCommand(profileListCmd.Command())
+	cmd.AddCommand(profileListCmd.command())
 
 	// Remove
 	profileRemoveCmd := cmdProfileRemove{global: c.global, profile: c}
-	cmd.AddCommand(profileRemoveCmd.Command())
+	cmd.AddCommand(profileRemoveCmd.command())
 
 	// Rename
 	profileRenameCmd := cmdProfileRename{global: c.global, profile: c}
-	cmd.AddCommand(profileRenameCmd.Command())
+	cmd.AddCommand(profileRenameCmd.command())
 
 	// Set
 	profileSetCmd := cmdProfileSet{global: c.global, profile: c}
-	cmd.AddCommand(profileSetCmd.Command())
+	cmd.AddCommand(profileSetCmd.command())
 
 	// Show
 	profileShowCmd := cmdProfileShow{global: c.global, profile: c}
-	cmd.AddCommand(profileShowCmd.Command())
+	cmd.AddCommand(profileShowCmd.command())
 
 	// Unset
 	profileUnsetCmd := cmdProfileUnset{global: c.global, profile: c, profileSet: &profileSetCmd}
-	cmd.AddCommand(profileUnsetCmd.Command())
+	cmd.AddCommand(profileUnsetCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -97,19 +97,19 @@ type cmdProfileAdd struct {
 	profile *cmdProfile
 }
 
-func (c *cmdProfileAdd) Command() *cobra.Command {
+func (c *cmdProfileAdd) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<instance> <profile>"))
 	cmd.Short = i18n.G("Add profiles to instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Add profiles to instances`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProfileAdd) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileAdd) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -159,7 +159,7 @@ type cmdProfileAssign struct {
 	profile *cmdProfile
 }
 
-func (c *cmdProfileAssign) Command() *cobra.Command {
+func (c *cmdProfileAssign) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("assign", i18n.G("[<remote>:]<instance> <profiles>"))
 	cmd.Aliases = []string{"apply"}
@@ -176,12 +176,12 @@ lxc profile assign foo default
 lxc profile assign foo ''
     Remove all profile from "foo"`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProfileAssign) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileAssign) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -242,7 +242,7 @@ type cmdProfileCopy struct {
 	flagRefresh       bool
 }
 
-func (c *cmdProfileCopy) Command() *cobra.Command {
+func (c *cmdProfileCopy) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("copy", i18n.G("[<remote>:]<profile> [<remote>:]<profile>"))
 	cmd.Aliases = []string{"cp"}
@@ -252,12 +252,12 @@ func (c *cmdProfileCopy) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
 	cmd.Flags().BoolVar(&c.flagRefresh, "refresh", false, i18n.G("Update the target profile from the source if it already exists"))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProfileCopy) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileCopy) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -313,19 +313,19 @@ type cmdProfileCreate struct {
 	profile *cmdProfile
 }
 
-func (c *cmdProfileCreate) Command() *cobra.Command {
+func (c *cmdProfileCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<profile>"))
 	cmd.Short = i18n.G("Create profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create profiles`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProfileCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -366,7 +366,7 @@ type cmdProfileDelete struct {
 	profile *cmdProfile
 }
 
-func (c *cmdProfileDelete) Command() *cobra.Command {
+func (c *cmdProfileDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<profile>"))
 	cmd.Aliases = []string{"rm"}
@@ -374,12 +374,12 @@ func (c *cmdProfileDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete profiles`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProfileDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -417,7 +417,7 @@ type cmdProfileEdit struct {
 	profile *cmdProfile
 }
 
-func (c *cmdProfileEdit) Command() *cobra.Command {
+func (c *cmdProfileEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<profile>"))
 	cmd.Short = i18n.G("Edit profile configurations as YAML")
@@ -427,7 +427,7 @@ func (c *cmdProfileEdit) Command() *cobra.Command {
 		`lxc profile edit <profile> < profile.yaml
     Update a profile using the content of profile.yaml`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -453,7 +453,7 @@ func (c *cmdProfileEdit) helpTemplate() string {
 ### Note that the name is shown but cannot be changed`)
 }
 
-func (c *cmdProfileEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -545,20 +545,20 @@ type cmdProfileGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdProfileGet) Command() *cobra.Command {
+func (c *cmdProfileGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<profile> <key>"))
 	cmd.Short = i18n.G("Get values for profile configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Get values for profile configuration keys`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a profile property"))
 	return cmd
 }
 
-func (c *cmdProfileGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -605,7 +605,7 @@ type cmdProfileList struct {
 	flagFormat string
 }
 
-func (c *cmdProfileList) Command() *cobra.Command {
+func (c *cmdProfileList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -613,13 +613,13 @@ func (c *cmdProfileList) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`List profiles`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
-func (c *cmdProfileList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -667,19 +667,19 @@ type cmdProfileRemove struct {
 	profile *cmdProfile
 }
 
-func (c *cmdProfileRemove) Command() *cobra.Command {
+func (c *cmdProfileRemove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<instance> <profile>"))
 	cmd.Short = i18n.G("Remove profiles from instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove profiles from instances`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProfileRemove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileRemove) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -742,7 +742,7 @@ type cmdProfileRename struct {
 	profile *cmdProfile
 }
 
-func (c *cmdProfileRename) Command() *cobra.Command {
+func (c *cmdProfileRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<profile> <new-name>"))
 	cmd.Aliases = []string{"mv"}
@@ -750,12 +750,12 @@ func (c *cmdProfileRename) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Rename profiles`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProfileRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileRename) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -795,7 +795,7 @@ type cmdProfileSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdProfileSet) Command() *cobra.Command {
+func (c *cmdProfileSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<profile> <key><value>..."))
 	cmd.Short = i18n.G("Set profile configuration keys")
@@ -805,12 +805,12 @@ func (c *cmdProfileSet) Command() *cobra.Command {
 For backward compatibility, a single configuration key may still be set with:
     lxc profile set [<remote>:]<profile> <key> <value>`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a profile property"))
 	return cmd
 }
 
-func (c *cmdProfileSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -871,19 +871,19 @@ type cmdProfileShow struct {
 	profile *cmdProfile
 }
 
-func (c *cmdProfileShow) Command() *cobra.Command {
+func (c *cmdProfileShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<profile>"))
 	cmd.Short = i18n.G("Show profile configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show profile configurations`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProfileShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -927,20 +927,20 @@ type cmdProfileUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdProfileUnset) Command() *cobra.Command {
+func (c *cmdProfileUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<profile> <key>"))
 	cmd.Short = i18n.G("Unset profile configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Unset profile configuration keys`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a profile property"))
 
 	return cmd
 }
 
-func (c *cmdProfileUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProfileUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -950,5 +950,5 @@ func (c *cmdProfileUnset) Run(cmd *cobra.Command, args []string) error {
 	c.profileSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.profileSet.Run(cmd, args)
+	return c.profileSet.run(cmd, args)
 }

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -22,7 +22,7 @@ type cmdProject struct {
 	global *cmdGlobal
 }
 
-func (c *cmdProject) Command() *cobra.Command {
+func (c *cmdProject) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("project")
 	cmd.Short = i18n.G("Manage projects")
@@ -31,47 +31,47 @@ func (c *cmdProject) Command() *cobra.Command {
 
 	// Create
 	projectCreateCmd := cmdProjectCreate{global: c.global, project: c}
-	cmd.AddCommand(projectCreateCmd.Command())
+	cmd.AddCommand(projectCreateCmd.command())
 
 	// Delete
 	projectDeleteCmd := cmdProjectDelete{global: c.global, project: c}
-	cmd.AddCommand(projectDeleteCmd.Command())
+	cmd.AddCommand(projectDeleteCmd.command())
 
 	// Edit
 	projectEditCmd := cmdProjectEdit{global: c.global, project: c}
-	cmd.AddCommand(projectEditCmd.Command())
+	cmd.AddCommand(projectEditCmd.command())
 
 	// Get
 	projectGetCmd := cmdProjectGet{global: c.global, project: c}
-	cmd.AddCommand(projectGetCmd.Command())
+	cmd.AddCommand(projectGetCmd.command())
 
 	// List
 	projectListCmd := cmdProjectList{global: c.global, project: c}
-	cmd.AddCommand(projectListCmd.Command())
+	cmd.AddCommand(projectListCmd.command())
 
 	// Rename
 	projectRenameCmd := cmdProjectRename{global: c.global, project: c}
-	cmd.AddCommand(projectRenameCmd.Command())
+	cmd.AddCommand(projectRenameCmd.command())
 
 	// Set
 	projectSetCmd := cmdProjectSet{global: c.global, project: c}
-	cmd.AddCommand(projectSetCmd.Command())
+	cmd.AddCommand(projectSetCmd.command())
 
 	// Unset
 	projectUnsetCmd := cmdProjectUnset{global: c.global, project: c, projectSet: &projectSetCmd}
-	cmd.AddCommand(projectUnsetCmd.Command())
+	cmd.AddCommand(projectUnsetCmd.command())
 
 	// Show
 	projectShowCmd := cmdProjectShow{global: c.global, project: c}
-	cmd.AddCommand(projectShowCmd.Command())
+	cmd.AddCommand(projectShowCmd.command())
 
 	// Info
 	projectGetInfo := cmdProjectInfo{global: c.global, project: c}
-	cmd.AddCommand(projectGetInfo.Command())
+	cmd.AddCommand(projectGetInfo.command())
 
 	// Set default
 	projectSwitchCmd := cmdProjectSwitch{global: c.global, project: c}
-	cmd.AddCommand(projectSwitchCmd.Command())
+	cmd.AddCommand(projectSwitchCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -86,7 +86,7 @@ type cmdProjectCreate struct {
 	flagConfig []string
 }
 
-func (c *cmdProjectCreate) Command() *cobra.Command {
+func (c *cmdProjectCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<project>"))
 	cmd.Short = i18n.G("Create projects")
@@ -94,12 +94,12 @@ func (c *cmdProjectCreate) Command() *cobra.Command {
 		`Create projects`))
 	cmd.Flags().StringArrayVarP(&c.flagConfig, "config", "c", nil, i18n.G("Config key/value to apply to the new project")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProjectCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -150,7 +150,7 @@ type cmdProjectDelete struct {
 	project *cmdProject
 }
 
-func (c *cmdProjectDelete) Command() *cobra.Command {
+func (c *cmdProjectDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<project>"))
 	cmd.Aliases = []string{"rm"}
@@ -158,12 +158,12 @@ func (c *cmdProjectDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete projects`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProjectDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -214,7 +214,7 @@ type cmdProjectEdit struct {
 	project *cmdProject
 }
 
-func (c *cmdProjectEdit) Command() *cobra.Command {
+func (c *cmdProjectEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<project>"))
 	cmd.Short = i18n.G("Edit project configurations as YAML")
@@ -224,7 +224,7 @@ func (c *cmdProjectEdit) Command() *cobra.Command {
 		`lxc project edit <project> < project.yaml
     Update a project using the content of project.yaml`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -250,7 +250,7 @@ func (c *cmdProjectEdit) helpTemplate() string {
 ### Note that the name is shown but cannot be changed`)
 }
 
-func (c *cmdProjectEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -342,19 +342,19 @@ type cmdProjectGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdProjectGet) Command() *cobra.Command {
+func (c *cmdProjectGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<project> <key>"))
 	cmd.Short = i18n.G("Get values for project configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Get values for project configuration keys`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a project property"))
 	return cmd
 }
 
-func (c *cmdProjectGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -402,7 +402,7 @@ type cmdProjectList struct {
 	flagFormat string
 }
 
-func (c *cmdProjectList) Command() *cobra.Command {
+func (c *cmdProjectList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -411,12 +411,12 @@ func (c *cmdProjectList) Command() *cobra.Command {
 		`List projects`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectList) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -515,7 +515,7 @@ type cmdProjectRename struct {
 	project *cmdProject
 }
 
-func (c *cmdProjectRename) Command() *cobra.Command {
+func (c *cmdProjectRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<project> <new-name>"))
 	cmd.Aliases = []string{"mv"}
@@ -523,12 +523,12 @@ func (c *cmdProjectRename) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Rename projects`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProjectRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectRename) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -573,7 +573,7 @@ type cmdProjectSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdProjectSet) Command() *cobra.Command {
+func (c *cmdProjectSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<project> <key>=<value>..."))
 	cmd.Short = i18n.G("Set project configuration keys")
@@ -583,12 +583,12 @@ func (c *cmdProjectSet) Command() *cobra.Command {
 For backward compatibility, a single configuration key may still be set with:
     lxc project set [<remote>:]<project> <key> <value>`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a project property"))
 	return cmd
 }
 
-func (c *cmdProjectSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -652,19 +652,19 @@ type cmdProjectUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdProjectUnset) Command() *cobra.Command {
+func (c *cmdProjectUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<project> <key>"))
 	cmd.Short = i18n.G("Unset project configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Unset project configuration keys`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a project property"))
 	return cmd
 }
 
-func (c *cmdProjectUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -674,7 +674,7 @@ func (c *cmdProjectUnset) Run(cmd *cobra.Command, args []string) error {
 	c.projectSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.projectSet.Run(cmd, args)
+	return c.projectSet.run(cmd, args)
 }
 
 // Show.
@@ -683,19 +683,19 @@ type cmdProjectShow struct {
 	project *cmdProject
 }
 
-func (c *cmdProjectShow) Command() *cobra.Command {
+func (c *cmdProjectShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<project>"))
 	cmd.Short = i18n.G("Show project options")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show project options`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProjectShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -736,19 +736,19 @@ type cmdProjectSwitch struct {
 	project *cmdProject
 }
 
-func (c *cmdProjectSwitch) Command() *cobra.Command {
+func (c *cmdProjectSwitch) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("switch", i18n.G("[<remote>:]<project>"))
 	cmd.Short = i18n.G("Switch the current project")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Switch the current project`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProjectSwitch) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectSwitch) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -795,7 +795,7 @@ type cmdProjectInfo struct {
 	flagFormat string
 }
 
-func (c *cmdProjectInfo) Command() *cobra.Command {
+func (c *cmdProjectInfo) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:]<project> <key>"))
 	cmd.Short = i18n.G("Get a summary of resource allocations")
@@ -803,12 +803,12 @@ func (c *cmdProjectInfo) Command() *cobra.Command {
 		`Get a summary of resource allocations`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdProjectInfo) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdProjectInfo) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -272,7 +272,10 @@ func (c *cmdPublish) run(cmd *cobra.Command, args []string) error {
 	opAPI := op.Get()
 
 	// Grab the fingerprint
-	fingerprint := opAPI.Metadata["fingerprint"].(string)
+	fingerprint, ok := opAPI.Metadata["fingerprint"].(string)
+	if !ok {
+		return fmt.Errorf(`Invalid type %T for "fingerprint" key in operation metadata`, fingerprint)
+	}
 
 	// For remote publish, copy to target now
 	if cRemote != iRemote {

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -306,7 +306,7 @@ func (c *cmdPublish) run(cmd *cobra.Command, args []string) error {
 
 	// Delete images if necessary
 	if c.flagReuse && len(existingAliases) > 0 {
-		visitedImages := make(map[string]interface{})
+		visitedImages := make(map[string]any)
 		for _, alias := range existingAliases {
 			image, _, _ := d.GetImage(alias.Target)
 

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -26,14 +26,14 @@ type cmdPublish struct {
 	flagReuse                bool
 }
 
-func (c *cmdPublish) Command() *cobra.Command {
+func (c *cmdPublish) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("publish", i18n.G("[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"))
 	cmd.Short = i18n.G("Publish instances as images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Publish instances as images`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagMakePublic, "public", false, i18n.G("Make the image public"))
 	cmd.Flags().StringArrayVar(&c.flagAliases, "alias", nil, i18n.G("New alias to define at target")+"``")
 	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Stop the instance if currently running"))
@@ -44,7 +44,7 @@ func (c *cmdPublish) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdPublish) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	iName := ""

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -27,7 +27,7 @@ type cmdQuery struct {
 	flagData     string
 }
 
-func (c *cmdQuery) Command() *cobra.Command {
+func (c *cmdQuery) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("query", i18n.G("[<remote>:]<API path>"))
 	cmd.Short = i18n.G("Send a raw query to LXD")
@@ -37,7 +37,7 @@ func (c *cmdQuery) Command() *cobra.Command {
 		`lxc query -X DELETE --wait /1.0/instances/c1
     Delete local instance "c1".`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagRespWait, "wait", false, i18n.G("Wait for the operation to complete"))
 	cmd.Flags().BoolVar(&c.flagRespRaw, "raw", false, i18n.G("Print the raw response"))
 	cmd.Flags().StringVarP(&c.flagAction, "request", "X", "GET", i18n.G("Action (defaults to GET)")+"``")
@@ -59,7 +59,7 @@ func (c *cmdQuery) pretty(input any) string {
 	return pretty.String()
 }
 
-func (c *cmdQuery) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -38,31 +38,30 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 	var name, image, remote, iremote string
 	var err error
 
-	if len(args) > 0 {
-		if len(args) == 1 {
-			remote, name, err = conf.ParseRemote(args[0])
-			if err != nil {
-				return err
-			}
-		} else if len(args) == 2 {
-			iremote, image, err = conf.ParseRemote(args[0])
-			if err != nil {
-				return err
-			}
-
-			remote, name, err = conf.ParseRemote(args[1])
-			if err != nil {
-				return err
-			}
+	switch len(args) {
+	case 1:
+		remote, name, err = conf.ParseRemote(args[0])
+		if err != nil {
+			return err
 		}
-	} else {
+
+	case 2:
+		iremote, image, err = conf.ParseRemote(args[0])
+		if err != nil {
+			return err
+		}
+
+		remote, name, err = conf.ParseRemote(args[1])
+		if err != nil {
+			return err
+		}
+
+	default:
 		return fmt.Errorf(i18n.G("Missing instance name"))
 	}
 
-	if c.flagEmpty {
-		if len(args) > 1 {
-			return fmt.Errorf(i18n.G("--empty cannot be combined with an image name"))
-		}
+	if c.flagEmpty && len(args) > 1 {
+		return fmt.Errorf(i18n.G("--empty cannot be combined with an image name"))
 	}
 
 	d, err := conf.GetInstanceServer(remote)

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -20,14 +20,14 @@ type cmdRebuild struct {
 	flagForce bool
 }
 
-func (c *cmdRebuild) Command() *cobra.Command {
+func (c *cmdRebuild) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rebuild", i18n.G("[<remote>:]<image> [<remote>:]<instance>"))
 	cmd.Short = i18n.G("Rebuild instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagEmpty, "empty", false, i18n.G("Rebuild as an empty instance"))
 	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("If an instance is running, stop it and then rebuild it"))
 
@@ -205,7 +205,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 	return nil
 }
 
-func (c *cmdRebuild) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRebuild) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 	if len(args) == 0 {
 		_ = cmd.Usage()

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -27,7 +27,7 @@ type cmdRemote struct {
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
-func (c *cmdRemote) Command() *cobra.Command {
+func (c *cmdRemote) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remote")
 	cmd.Short = i18n.G("Manage the list of remote servers")
@@ -36,31 +36,31 @@ func (c *cmdRemote) Command() *cobra.Command {
 
 	// Add
 	remoteAddCmd := cmdRemoteAdd{global: c.global, remote: c}
-	cmd.AddCommand(remoteAddCmd.Command())
+	cmd.AddCommand(remoteAddCmd.command())
 
 	// Get default
 	remoteGetDefaultCmd := cmdRemoteGetDefault{global: c.global, remote: c}
-	cmd.AddCommand(remoteGetDefaultCmd.Command())
+	cmd.AddCommand(remoteGetDefaultCmd.command())
 
 	// List
 	remoteListCmd := cmdRemoteList{global: c.global, remote: c}
-	cmd.AddCommand(remoteListCmd.Command())
+	cmd.AddCommand(remoteListCmd.command())
 
 	// Rename
 	remoteRenameCmd := cmdRemoteRename{global: c.global, remote: c}
-	cmd.AddCommand(remoteRenameCmd.Command())
+	cmd.AddCommand(remoteRenameCmd.command())
 
 	// Remove
 	remoteRemoveCmd := cmdRemoteRemove{global: c.global, remote: c}
-	cmd.AddCommand(remoteRemoveCmd.Command())
+	cmd.AddCommand(remoteRemoveCmd.command())
 
 	// Set default
 	remoteSwitchCmd := cmdRemoteSwitch{global: c.global, remote: c}
-	cmd.AddCommand(remoteSwitchCmd.Command())
+	cmd.AddCommand(remoteSwitchCmd.command())
 
 	// Set URL
 	remoteSetURLCmd := cmdRemoteSetURL{global: c.global, remote: c}
-	cmd.AddCommand(remoteSetURLCmd.Command())
+	cmd.AddCommand(remoteSetURLCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -82,7 +82,7 @@ type cmdRemoteAdd struct {
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
-func (c *cmdRemoteAdd) Command() *cobra.Command {
+func (c *cmdRemoteAdd) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>] <IP|FQDN|URL|token>"))
 	cmd.Short = i18n.G("Add new remote servers")
@@ -95,7 +95,7 @@ Basic authentication can be used when combined with the "simplestreams" protocol
   lxc remote add some-name https://LOGIN:PASSWORD@example.com/some/path --protocol=simplestreams
 `))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagAcceptCert, "accept-certificate", false, i18n.G("Accept certificate"))
 	cmd.Flags().StringVar(&c.flagPassword, "password", "", i18n.G("Remote admin password")+"``")
 	cmd.Flags().StringVar(&c.flagProtocol, "protocol", "", i18n.G("Server protocol (lxd or simplestreams)")+"``")
@@ -268,7 +268,7 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 }
 
 // Run is used in the RunE field of the cobra.Command returned by Command.
-func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -617,20 +617,20 @@ type cmdRemoteGetDefault struct {
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
-func (c *cmdRemoteGetDefault) Command() *cobra.Command {
+func (c *cmdRemoteGetDefault) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get-default")
 	cmd.Short = i18n.G("Show the default remote")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show the default remote`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is used in the RunE field of the cobra.Command returned by Command.
-func (c *cmdRemoteGetDefault) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRemoteGetDefault) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -654,7 +654,7 @@ type cmdRemoteList struct {
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
-func (c *cmdRemoteList) Command() *cobra.Command {
+func (c *cmdRemoteList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list")
 	cmd.Aliases = []string{"ls"}
@@ -662,14 +662,14 @@ func (c *cmdRemoteList) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`List the available remotes`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	return cmd
 }
 
 // Run is used in the RunE field of the cobra.Command returned by Command.
-func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRemoteList) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -740,7 +740,7 @@ type cmdRemoteRename struct {
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
-func (c *cmdRemoteRename) Command() *cobra.Command {
+func (c *cmdRemoteRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("<remote> <new-name>"))
 	cmd.Aliases = []string{"mv"}
@@ -748,13 +748,13 @@ func (c *cmdRemoteRename) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Rename remotes`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is used in the RunE field of the cobra.Command returned by Command.
-func (c *cmdRemoteRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRemoteRename) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -813,7 +813,7 @@ type cmdRemoteRemove struct {
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
-func (c *cmdRemoteRemove) Command() *cobra.Command {
+func (c *cmdRemoteRemove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("<remote>"))
 	cmd.Aliases = []string{"rm"}
@@ -821,13 +821,13 @@ func (c *cmdRemoteRemove) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove remotes`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is used in the RunE field of the cobra.Command returned by Command.
-func (c *cmdRemoteRemove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRemoteRemove) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -869,7 +869,7 @@ type cmdRemoteSwitch struct {
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
-func (c *cmdRemoteSwitch) Command() *cobra.Command {
+func (c *cmdRemoteSwitch) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Aliases = []string{"set-default"}
 	cmd.Use = usage("switch", i18n.G("<remote>"))
@@ -877,13 +877,13 @@ func (c *cmdRemoteSwitch) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Switch the default remote`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is used in the RunE field of the cobra.Command returned by Command.
-func (c *cmdRemoteSwitch) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRemoteSwitch) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -910,20 +910,20 @@ type cmdRemoteSetURL struct {
 }
 
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
-func (c *cmdRemoteSetURL) Command() *cobra.Command {
+func (c *cmdRemoteSetURL) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set-url", i18n.G("<remote> <URL>"))
 	cmd.Short = i18n.G("Set the URL for the remote")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Set the URL for the remote`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
 // Run is used in the RunE field of the cobra.Command returned by Command.
-func (c *cmdRemoteSetURL) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRemoteSetURL) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/rename.go
+++ b/lxc/rename.go
@@ -14,18 +14,18 @@ type cmdRename struct {
 	global *cmdGlobal
 }
 
-func (c *cmdRename) Command() *cobra.Command {
+func (c *cmdRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"))
 	cmd.Short = i18n.G("Rename instances and snapshots")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Rename instances and snapshots`))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRename) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -57,5 +57,5 @@ func (c *cmdRename) Run(cmd *cobra.Command, args []string) error {
 
 	// Call move
 	move := cmdMove{global: c.global}
-	return move.Run(cmd, args)
+	return move.run(cmd, args)
 }

--- a/lxc/restore.go
+++ b/lxc/restore.go
@@ -17,7 +17,7 @@ type cmdRestore struct {
 	flagStateful bool
 }
 
-func (c *cmdRestore) Command() *cobra.Command {
+func (c *cmdRestore) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("restore", i18n.G("[<remote>:]<instance> <snapshot>"))
 	cmd.Short = i18n.G("Restore instances from snapshots")
@@ -32,13 +32,13 @@ If --stateful is passed, then the running state will be restored too.`))
 lxc restore u1 snap0
     Restore the snapshot.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagStateful, "stateful", false, i18n.G("Whether or not to restore the instance's running state from snapshot (if available)"))
 
 	return cmd
 }
 
-func (c *cmdRestore) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdRestore) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/snapshot.go
+++ b/lxc/snapshot.go
@@ -64,13 +64,13 @@ func (c *cmdSnapshot) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if shared.IsSnapshot(name) {
-		if snapname == "" {
-			fields := strings.SplitN(name, shared.SnapshotDelimiter, 2)
-			name = fields[0]
-			snapname = fields[1]
-		} else {
+		if snapname != "" {
 			return fmt.Errorf(i18n.G("Invalid instance name: %s"), name)
 		}
+
+		fields := strings.SplitN(name, shared.SnapshotDelimiter, 2)
+		name = fields[0]
+		snapname = fields[1]
 	}
 
 	d, err := conf.GetInstanceServer(remote)

--- a/lxc/snapshot.go
+++ b/lxc/snapshot.go
@@ -21,7 +21,7 @@ type cmdSnapshot struct {
 	flagReuse    bool
 }
 
-func (c *cmdSnapshot) Command() *cobra.Command {
+func (c *cmdSnapshot) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("snapshot", i18n.G("[<remote>:]<instance> [<snapshot name>]"))
 	cmd.Short = i18n.G("Create instance snapshots")
@@ -34,7 +34,7 @@ running state, including process memory state, TCP connections, ...`))
 		`lxc snapshot u1 snap0
     Create a snapshot of "u1" called "snap0".`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagStateful, "stateful", false, i18n.G("Whether or not to snapshot the instance's running state"))
 	cmd.Flags().BoolVar(&c.flagNoExpiry, "no-expiry", false, i18n.G("Ignore any configured auto-expiry for the instance"))
 	cmd.Flags().BoolVar(&c.flagReuse, "reuse", false, i18n.G("If the snapshot name already exists, delete and create a new one"))
@@ -42,7 +42,7 @@ running state, including process memory state, TCP connections, ...`))
 	return cmd
 }
 
-func (c *cmdSnapshot) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdSnapshot) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -26,7 +26,7 @@ type cmdStorage struct {
 	flagTarget string
 }
 
-func (c *cmdStorage) Command() *cobra.Command {
+func (c *cmdStorage) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("storage")
 	cmd.Short = i18n.G("Manage storage pools and volumes")
@@ -35,47 +35,47 @@ func (c *cmdStorage) Command() *cobra.Command {
 
 	// Create
 	storageCreateCmd := cmdStorageCreate{global: c.global, storage: c}
-	cmd.AddCommand(storageCreateCmd.Command())
+	cmd.AddCommand(storageCreateCmd.command())
 
 	// Delete
 	storageDeleteCmd := cmdStorageDelete{global: c.global, storage: c}
-	cmd.AddCommand(storageDeleteCmd.Command())
+	cmd.AddCommand(storageDeleteCmd.command())
 
 	// Edit
 	storageEditCmd := cmdStorageEdit{global: c.global, storage: c}
-	cmd.AddCommand(storageEditCmd.Command())
+	cmd.AddCommand(storageEditCmd.command())
 
 	// Get
 	storageGetCmd := cmdStorageGet{global: c.global, storage: c}
-	cmd.AddCommand(storageGetCmd.Command())
+	cmd.AddCommand(storageGetCmd.command())
 
 	// Info
 	storageInfoCmd := cmdStorageInfo{global: c.global, storage: c}
-	cmd.AddCommand(storageInfoCmd.Command())
+	cmd.AddCommand(storageInfoCmd.command())
 
 	// List
 	storageListCmd := cmdStorageList{global: c.global, storage: c}
-	cmd.AddCommand(storageListCmd.Command())
+	cmd.AddCommand(storageListCmd.command())
 
 	// Set
 	storageSetCmd := cmdStorageSet{global: c.global, storage: c}
-	cmd.AddCommand(storageSetCmd.Command())
+	cmd.AddCommand(storageSetCmd.command())
 
 	// Show
 	storageShowCmd := cmdStorageShow{global: c.global, storage: c}
-	cmd.AddCommand(storageShowCmd.Command())
+	cmd.AddCommand(storageShowCmd.command())
 
 	// Unset
 	storageUnsetCmd := cmdStorageUnset{global: c.global, storage: c, storageSet: &storageSetCmd}
-	cmd.AddCommand(storageUnsetCmd.Command())
+	cmd.AddCommand(storageUnsetCmd.command())
 
 	// Bucket
 	storageBucketCmd := cmdStorageBucket{global: c.global}
-	cmd.AddCommand(storageBucketCmd.Command())
+	cmd.AddCommand(storageBucketCmd.command())
 
 	// Volume
 	storageVolumeCmd := cmdStorageVolume{global: c.global, storage: c}
-	cmd.AddCommand(storageVolumeCmd.Command())
+	cmd.AddCommand(storageVolumeCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -89,7 +89,7 @@ type cmdStorageCreate struct {
 	storage *cmdStorage
 }
 
-func (c *cmdStorageCreate) Command() *cobra.Command {
+func (c *cmdStorageCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <driver> [key=value...]"))
 	cmd.Short = i18n.G("Create storage pools")
@@ -97,12 +97,12 @@ func (c *cmdStorageCreate) Command() *cobra.Command {
 		`Create storage pools`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -162,7 +162,7 @@ type cmdStorageDelete struct {
 	storage *cmdStorage
 }
 
-func (c *cmdStorageDelete) Command() *cobra.Command {
+func (c *cmdStorageDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool>"))
 	cmd.Aliases = []string{"rm"}
@@ -170,12 +170,12 @@ func (c *cmdStorageDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete storage pools`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -213,7 +213,7 @@ type cmdStorageEdit struct {
 	storage *cmdStorage
 }
 
-func (c *cmdStorageEdit) Command() *cobra.Command {
+func (c *cmdStorageEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<pool>"))
 	cmd.Short = i18n.G("Edit storage pool configurations as YAML")
@@ -223,7 +223,7 @@ func (c *cmdStorageEdit) Command() *cobra.Command {
 		`lxc storage edit [<remote>:]<pool> < pool.yaml
     Update a storage pool using the content of pool.yaml.`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -245,7 +245,7 @@ func (c *cmdStorageEdit) helpTemplate() string {
 ###   zfs.pool_name: default`)
 }
 
-func (c *cmdStorageEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -337,7 +337,7 @@ type cmdStorageGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageGet) Command() *cobra.Command {
+func (c *cmdStorageGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<pool> <key>"))
 	cmd.Short = i18n.G("Get values for storage pool configuration keys")
@@ -346,12 +346,12 @@ func (c *cmdStorageGet) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a storage property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -407,7 +407,7 @@ type cmdStorageInfo struct {
 	flagBytes bool
 }
 
-func (c *cmdStorageInfo) Command() *cobra.Command {
+func (c *cmdStorageInfo) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:]<pool>"))
 	cmd.Short = i18n.G("Show useful information about storage pools")
@@ -416,12 +416,12 @@ func (c *cmdStorageInfo) Command() *cobra.Command {
 
 	cmd.Flags().BoolVar(&c.flagBytes, "bytes", false, i18n.G("Show the used and free space in bytes"))
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageInfo) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageInfo) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -578,7 +578,7 @@ type cmdStorageList struct {
 	flagFormat string
 }
 
-func (c *cmdStorageList) Command() *cobra.Command {
+func (c *cmdStorageList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -587,12 +587,12 @@ func (c *cmdStorageList) Command() *cobra.Command {
 		`List available storage pools`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
@@ -658,7 +658,7 @@ type cmdStorageSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageSet) Command() *cobra.Command {
+func (c *cmdStorageSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<pool> <key> <value>"))
 	cmd.Short = i18n.G("Set storage pool configuration keys")
@@ -670,12 +670,12 @@ For backward compatibility, a single configuration key may still be set with:
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a storage property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -754,7 +754,7 @@ type cmdStorageShow struct {
 	flagResources bool
 }
 
-func (c *cmdStorageShow) Command() *cobra.Command {
+func (c *cmdStorageShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<pool>"))
 	cmd.Short = i18n.G("Show storage pool configurations and resources")
@@ -763,12 +763,12 @@ func (c *cmdStorageShow) Command() *cobra.Command {
 
 	cmd.Flags().BoolVar(&c.flagResources, "resources", false, i18n.G("Show the resources available to the storage pool"))
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -840,7 +840,7 @@ type cmdStorageUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageUnset) Command() *cobra.Command {
+func (c *cmdStorageUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<pool> <key>"))
 	cmd.Short = i18n.G("Unset storage pool configuration keys")
@@ -849,12 +849,12 @@ func (c *cmdStorageUnset) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a storage property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -864,5 +864,5 @@ func (c *cmdStorageUnset) Run(cmd *cobra.Command, args []string) error {
 	c.storageSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.storageSet.Run(cmd, args)
+	return c.storageSet.run(cmd, args)
 }

--- a/lxc/storage_bucket.go
+++ b/lxc/storage_bucket.go
@@ -22,7 +22,7 @@ type cmdStorageBucket struct {
 	flagTarget string
 }
 
-func (c *cmdStorageBucket) Command() *cobra.Command {
+func (c *cmdStorageBucket) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("bucket")
 	cmd.Short = i18n.G("Manage storage buckets")
@@ -30,39 +30,39 @@ func (c *cmdStorageBucket) Command() *cobra.Command {
 
 	// Create.
 	storageBucketCreateCmd := cmdStorageBucketCreate{global: c.global, storageBucket: c}
-	cmd.AddCommand(storageBucketCreateCmd.Command())
+	cmd.AddCommand(storageBucketCreateCmd.command())
 
 	// Delete.
 	storageBucketDeleteCmd := cmdStorageBucketDelete{global: c.global, storageBucket: c}
-	cmd.AddCommand(storageBucketDeleteCmd.Command())
+	cmd.AddCommand(storageBucketDeleteCmd.command())
 
 	// Edit.
 	storageBucketEditCmd := cmdStorageBucketEdit{global: c.global, storageBucket: c}
-	cmd.AddCommand(storageBucketEditCmd.Command())
+	cmd.AddCommand(storageBucketEditCmd.command())
 
 	// Get.
 	storageBucketGetCmd := cmdStorageBucketGet{global: c.global, storageBucket: c}
-	cmd.AddCommand(storageBucketGetCmd.Command())
+	cmd.AddCommand(storageBucketGetCmd.command())
 
 	// List.
 	storageBucketListCmd := cmdStorageBucketList{global: c.global, storageBucket: c}
-	cmd.AddCommand(storageBucketListCmd.Command())
+	cmd.AddCommand(storageBucketListCmd.command())
 
 	// Set.
 	storageBucketSetCmd := cmdStorageBucketSet{global: c.global, storageBucket: c}
-	cmd.AddCommand(storageBucketSetCmd.Command())
+	cmd.AddCommand(storageBucketSetCmd.command())
 
 	// Show.
 	storageBucketShowCmd := cmdStorageBucketShow{global: c.global, storageBucket: c}
-	cmd.AddCommand(storageBucketShowCmd.Command())
+	cmd.AddCommand(storageBucketShowCmd.command())
 
 	// Unset.
 	storageBucketUnsetCmd := cmdStorageBucketUnset{global: c.global, storageBucket: c, storageBucketSet: &storageBucketSetCmd}
-	cmd.AddCommand(storageBucketUnsetCmd.Command())
+	cmd.AddCommand(storageBucketUnsetCmd.command())
 
 	// Key.
 	storageBucketKeyCmd := cmdStorageBucketKey{global: c.global, storageBucket: c}
-	cmd.AddCommand(storageBucketKeyCmd.Command())
+	cmd.AddCommand(storageBucketKeyCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -76,19 +76,19 @@ type cmdStorageBucketCreate struct {
 	storageBucket *cmdStorageBucket
 }
 
-func (c *cmdStorageBucketCreate) Command() *cobra.Command {
+func (c *cmdStorageBucketCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <bucket> [key=value...]"))
 	cmd.Short = i18n.G("Create new custom storage buckets")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Create new custom storage buckets`))
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -175,7 +175,7 @@ type cmdStorageBucketDelete struct {
 	storageBucket *cmdStorageBucket
 }
 
-func (c *cmdStorageBucketDelete) Command() *cobra.Command {
+func (c *cmdStorageBucketDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <bucket>"))
 	cmd.Aliases = []string{"rm"}
@@ -183,12 +183,12 @@ func (c *cmdStorageBucketDelete) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Delete storage buckets`))
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -237,7 +237,7 @@ type cmdStorageBucketEdit struct {
 	storageBucket *cmdStorageBucket
 }
 
-func (c *cmdStorageBucketEdit) Command() *cobra.Command {
+func (c *cmdStorageBucketEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<pool> <bucket>"))
 	cmd.Short = i18n.G("Edit storage bucket configurations as YAML")
@@ -246,7 +246,7 @@ func (c *cmdStorageBucketEdit) Command() *cobra.Command {
     Update a storage bucket using the content of bucket.yaml.`))
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -264,7 +264,7 @@ func (c *cmdStorageBucketEdit) helpTemplate() string {
 ###   size: "61203283968"`)
 }
 
-func (c *cmdStorageBucketEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -370,7 +370,7 @@ type cmdStorageBucketGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageBucketGet) Command() *cobra.Command {
+func (c *cmdStorageBucketGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<pool> <bucket> <key>"))
 	cmd.Short = i18n.G("Get values for storage bucket configuration keys")
@@ -378,12 +378,12 @@ func (c *cmdStorageBucketGet) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a storage bucket property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -444,7 +444,7 @@ type cmdStorageBucketList struct {
 	flagFormat    string
 }
 
-func (c *cmdStorageBucketList) Command() *cobra.Command {
+func (c *cmdStorageBucketList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<pool>"))
 	cmd.Aliases = []string{"ls"}
@@ -453,12 +453,12 @@ func (c *cmdStorageBucketList) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`List storage buckets`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
 	if exit {
@@ -523,7 +523,7 @@ type cmdStorageBucketSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageBucketSet) Command() *cobra.Command {
+func (c *cmdStorageBucketSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<pool> <bucket> <key>=<value>..."))
 	cmd.Short = i18n.G("Set storage bucket configuration keys")
@@ -535,12 +535,12 @@ For backward compatibility, a single configuration key may still be set with:
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a storage bucket property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -617,7 +617,7 @@ type cmdStorageBucketShow struct {
 	storageBucket *cmdStorageBucket
 }
 
-func (c *cmdStorageBucketShow) Command() *cobra.Command {
+func (c *cmdStorageBucketShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<pool> <bucket>"))
 	cmd.Short = i18n.G("Show storage bucket configurations")
@@ -627,12 +627,12 @@ func (c *cmdStorageBucketShow) Command() *cobra.Command {
     Will show the properties of a bucket called "data" in the "default" pool.`))
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -686,7 +686,7 @@ type cmdStorageBucketUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageBucketUnset) Command() *cobra.Command {
+func (c *cmdStorageBucketUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<pool> <bucket> <key>"))
 	cmd.Short = i18n.G("Unset storage bucket configuration keys")
@@ -694,12 +694,12 @@ func (c *cmdStorageBucketUnset) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a storage bucket property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -709,7 +709,7 @@ func (c *cmdStorageBucketUnset) Run(cmd *cobra.Command, args []string) error {
 	c.storageBucketSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.storageBucketSet.Run(cmd, args)
+	return c.storageBucketSet.run(cmd, args)
 }
 
 // Key commands.
@@ -720,7 +720,7 @@ type cmdStorageBucketKey struct {
 	flagTarget string
 }
 
-func (c *cmdStorageBucketKey) Command() *cobra.Command {
+func (c *cmdStorageBucketKey) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("key")
 	cmd.Short = i18n.G("Manage storage bucket keys")
@@ -728,23 +728,23 @@ func (c *cmdStorageBucketKey) Command() *cobra.Command {
 
 	// Create.
 	storageBucketKeyCreateCmd := cmdStorageBucketKeyCreate{global: c.global, storageBucketKey: c}
-	cmd.AddCommand(storageBucketKeyCreateCmd.Command())
+	cmd.AddCommand(storageBucketKeyCreateCmd.command())
 
 	// Delete.
 	storageBucketKeyDeleteCmd := cmdStorageBucketKeyDelete{global: c.global, storageBucketKey: c}
-	cmd.AddCommand(storageBucketKeyDeleteCmd.Command())
+	cmd.AddCommand(storageBucketKeyDeleteCmd.command())
 
 	// Edit.
 	storageBucketKeyEditCmd := cmdStorageBucketKeyEdit{global: c.global, storageBucketKey: c}
-	cmd.AddCommand(storageBucketKeyEditCmd.Command())
+	cmd.AddCommand(storageBucketKeyEditCmd.command())
 
 	// List.
 	storageBucketKeyListCmd := cmdStorageBucketKeyList{global: c.global, storageBucketKey: c}
-	cmd.AddCommand(storageBucketKeyListCmd.Command())
+	cmd.AddCommand(storageBucketKeyListCmd.command())
 
 	// Show.
 	storageBucketKeyShowCmd := cmdStorageBucketKeyShow{global: c.global, storageBucketKey: c}
-	cmd.AddCommand(storageBucketKeyShowCmd.Command())
+	cmd.AddCommand(storageBucketKeyShowCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -759,7 +759,7 @@ type cmdStorageBucketKeyList struct {
 	flagFormat       string
 }
 
-func (c *cmdStorageBucketKeyList) Command() *cobra.Command {
+func (c *cmdStorageBucketKeyList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<pool> <bucket>"))
 	cmd.Aliases = []string{"ls"}
@@ -769,12 +769,12 @@ func (c *cmdStorageBucketKeyList) Command() *cobra.Command {
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 	cmd.Flags().StringVar(&c.storageBucketKey.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketKeyList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketKeyList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -840,7 +840,7 @@ type cmdStorageBucketKeyCreate struct {
 	flagSecretKey    string
 }
 
-func (c *cmdStorageBucketKeyCreate) Command() *cobra.Command {
+func (c *cmdStorageBucketKeyCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <bucket> <key>"))
 	cmd.Short = i18n.G("Create key for a storage bucket")
@@ -918,7 +918,7 @@ type cmdStorageBucketKeyDelete struct {
 	storageBucketKey *cmdStorageBucketKey
 }
 
-func (c *cmdStorageBucketKeyDelete) Command() *cobra.Command {
+func (c *cmdStorageBucketKeyDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <bucket> <key>"))
 	cmd.Short = i18n.G("Delete key from a storage bucket")
@@ -982,7 +982,7 @@ type cmdStorageBucketKeyEdit struct {
 	storageBucketKey *cmdStorageBucketKey
 }
 
-func (c *cmdStorageBucketKeyEdit) Command() *cobra.Command {
+func (c *cmdStorageBucketKeyEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<pool> <bucket> <key>"))
 	cmd.Short = i18n.G("Edit storage bucket key as YAML")
@@ -991,7 +991,7 @@ func (c *cmdStorageBucketKeyEdit) Command() *cobra.Command {
     Update a storage bucket key using the content of key.yaml.`))
 
 	cmd.Flags().StringVar(&c.storageBucketKey.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -1009,7 +1009,7 @@ func (c *cmdStorageBucketKeyEdit) helpTemplate() string {
 ###   size: "61203283968"`)
 }
 
-func (c *cmdStorageBucketKeyEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketKeyEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -1117,7 +1117,7 @@ type cmdStorageBucketKeyShow struct {
 	storageBucketKey *cmdStorageBucketKey
 }
 
-func (c *cmdStorageBucketKeyShow) Command() *cobra.Command {
+func (c *cmdStorageBucketKeyShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<pool> <bucket> <key>"))
 	cmd.Short = i18n.G("Show storage bucket key configurations")
@@ -1127,12 +1127,12 @@ func (c *cmdStorageBucketKeyShow) Command() *cobra.Command {
     Will show the properties of a bucket key called "foo" for a bucket called "data" in the "default" pool.`))
 
 	cmd.Flags().StringVar(&c.storageBucketKey.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageBucketKeyShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketKeyShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {

--- a/lxc/storage_bucket.go
+++ b/lxc/storage_bucket.go
@@ -845,7 +845,7 @@ func (c *cmdStorageBucketKeyCreate) command() *cobra.Command {
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <bucket> <key>"))
 	cmd.Short = i18n.G("Create key for a storage bucket")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create key for a storage bucket"))
-	cmd.RunE = c.RunAdd
+	cmd.RunE = c.runAdd
 
 	cmd.Flags().StringVar(&c.storageBucketKey.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagRole, "role", "read-only", i18n.G("Role (admin or read-only)")+"``")
@@ -855,7 +855,7 @@ func (c *cmdStorageBucketKeyCreate) command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdStorageBucketKeyCreate) RunAdd(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketKeyCreate) runAdd(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -923,14 +923,14 @@ func (c *cmdStorageBucketKeyDelete) command() *cobra.Command {
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <bucket> <key>"))
 	cmd.Short = i18n.G("Delete key from a storage bucket")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete key from a storage bucket"))
-	cmd.RunE = c.RunRemove
+	cmd.RunE = c.runRemove
 
 	cmd.Flags().StringVar(&c.storageBucketKey.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
 
-func (c *cmdStorageBucketKeyDelete) RunRemove(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageBucketKeyDelete) runRemove(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1598,11 +1598,11 @@ func (c *cmdStorageVolumeList) parseColumns(clustered bool, allVolumes bool) ([]
 
 		for _, columnRune := range columnEntry {
 			column, ok := columnsShorthandMap[columnRune]
-			if ok {
-				columns = append(columns, column)
-			} else {
+			if !ok {
 				return nil, fmt.Errorf(i18n.G("Unknown column shorthand char '%c' in '%s'"), columnRune, columnEntry)
 			}
+
+			columns = append(columns, column)
 		}
 	}
 

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -131,7 +131,7 @@ Unless specified through a prefix, all volume operations affect "custom" (user c
 	return cmd
 }
 
-func (c *cmdStorageVolume) parseVolume(defaultType string, name string) (string, string) {
+func (c *cmdStorageVolume) parseVolume(defaultType string, name string) (volumeName string, volumeType string) {
 	fields := strings.SplitN(name, "/", 2)
 	if len(fields) == 1 {
 		return fields[0], defaultType
@@ -142,7 +142,7 @@ func (c *cmdStorageVolume) parseVolume(defaultType string, name string) (string,
 	return fields[1], fields[0]
 }
 
-func (c *cmdStorageVolume) parseVolumeWithPool(name string) (string, string) {
+func (c *cmdStorageVolume) parseVolumeWithPool(name string) (volumeName string, poolName string) {
 	fields := strings.SplitN(name, "/", 2)
 	if len(fields) == 1 {
 		return fields[0], ""

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -36,7 +36,7 @@ type cmdStorageVolume struct {
 	flagDestinationTarget string
 }
 
-func (c *cmdStorageVolume) Command() *cobra.Command {
+func (c *cmdStorageVolume) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("volume")
 	cmd.Short = i18n.G("Manage storage volumes")
@@ -47,83 +47,83 @@ Unless specified through a prefix, all volume operations affect "custom" (user c
 
 	// Attach
 	storageVolumeAttachCmd := cmdStorageVolumeAttach{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeAttachCmd.Command())
+	cmd.AddCommand(storageVolumeAttachCmd.command())
 
 	// Attach profile
 	storageVolumeAttachProfileCmd := cmdStorageVolumeAttachProfile{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeAttachProfileCmd.Command())
+	cmd.AddCommand(storageVolumeAttachProfileCmd.command())
 
 	// Copy
 	storageVolumeCopyCmd := cmdStorageVolumeCopy{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeCopyCmd.Command())
+	cmd.AddCommand(storageVolumeCopyCmd.command())
 
 	// Create
 	storageVolumeCreateCmd := cmdStorageVolumeCreate{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeCreateCmd.Command())
+	cmd.AddCommand(storageVolumeCreateCmd.command())
 
 	// Delete
 	storageVolumeDeleteCmd := cmdStorageVolumeDelete{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeDeleteCmd.Command())
+	cmd.AddCommand(storageVolumeDeleteCmd.command())
 
 	// Detach
 	storageVolumeDetachCmd := cmdStorageVolumeDetach{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeDetachCmd.Command())
+	cmd.AddCommand(storageVolumeDetachCmd.command())
 
 	// Detach profile
 	storageVolumeDetachProfileCmd := cmdStorageVolumeDetachProfile{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeDetachProfileCmd.Command())
+	cmd.AddCommand(storageVolumeDetachProfileCmd.command())
 
 	// Edit
 	storageVolumeEditCmd := cmdStorageVolumeEdit{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeEditCmd.Command())
+	cmd.AddCommand(storageVolumeEditCmd.command())
 
 	// Export
 	storageVolumeExportCmd := cmdStorageVolumeExport{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeExportCmd.Command())
+	cmd.AddCommand(storageVolumeExportCmd.command())
 
 	// Get
 	storageVolumeGetCmd := cmdStorageVolumeGet{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeGetCmd.Command())
+	cmd.AddCommand(storageVolumeGetCmd.command())
 
 	// Import
 	storageVolumeImportCmd := cmdStorageVolumeImport{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeImportCmd.Command())
+	cmd.AddCommand(storageVolumeImportCmd.command())
 
 	// Info
 	storageVolumeInfoCmd := cmdStorageVolumeInfo{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeInfoCmd.Command())
+	cmd.AddCommand(storageVolumeInfoCmd.command())
 
 	// List
 	storageVolumeListCmd := cmdStorageVolumeList{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeListCmd.Command())
+	cmd.AddCommand(storageVolumeListCmd.command())
 
 	// Rename
 	storageVolumeRenameCmd := cmdStorageVolumeRename{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeRenameCmd.Command())
+	cmd.AddCommand(storageVolumeRenameCmd.command())
 
 	// Move
 	storageVolumeMoveCmd := cmdStorageVolumeMove{global: c.global, storage: c.storage, storageVolume: c, storageVolumeCopy: &storageVolumeCopyCmd, storageVolumeRename: &storageVolumeRenameCmd}
-	cmd.AddCommand(storageVolumeMoveCmd.Command())
+	cmd.AddCommand(storageVolumeMoveCmd.command())
 
 	// Set
 	storageVolumeSetCmd := cmdStorageVolumeSet{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeSetCmd.Command())
+	cmd.AddCommand(storageVolumeSetCmd.command())
 
 	// Show
 	storageVolumeShowCmd := cmdStorageVolumeShow{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeShowCmd.Command())
+	cmd.AddCommand(storageVolumeShowCmd.command())
 
 	// Snapshot
 	storageVolumeSnapshotCmd := cmdStorageVolumeSnapshot{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeSnapshotCmd.Command())
+	cmd.AddCommand(storageVolumeSnapshotCmd.command())
 
 	// Restore
 	storageVolumeRestoreCmd := cmdStorageVolumeRestore{global: c.global, storage: c.storage, storageVolume: c}
-	cmd.AddCommand(storageVolumeRestoreCmd.Command())
+	cmd.AddCommand(storageVolumeRestoreCmd.command())
 
 	// Unset
 	storageVolumeUnsetCmd := cmdStorageVolumeUnset{global: c.global, storage: c.storage, storageVolume: c, storageVolumeSet: &storageVolumeSetCmd}
-	cmd.AddCommand(storageVolumeUnsetCmd.Command())
+	cmd.AddCommand(storageVolumeUnsetCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -158,19 +158,19 @@ type cmdStorageVolumeAttach struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeAttach) Command() *cobra.Command {
+func (c *cmdStorageVolumeAttach) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("attach", i18n.G("[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"))
 	cmd.Short = i18n.G("Attach new storage volumes to instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Attach new storage volumes to instances`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeAttach) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeAttach) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 5)
 	if exit {
@@ -256,19 +256,19 @@ type cmdStorageVolumeAttachProfile struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeAttachProfile) Command() *cobra.Command {
+func (c *cmdStorageVolumeAttachProfile) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("attach-profile", i18n.G("[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"))
 	cmd.Short = i18n.G("Attach new storage volumes to profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Attach new storage volumes to profiles`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeAttachProfile) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeAttachProfile) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 5)
 	if exit {
@@ -346,7 +346,7 @@ type cmdStorageVolumeCopy struct {
 	flagRefresh       bool
 }
 
-func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
+func (c *cmdStorageVolumeCopy) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("copy", i18n.G("[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"))
 	cmd.Aliases = []string{"cp"}
@@ -360,12 +360,12 @@ func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagVolumeOnly, "volume-only", false, i18n.G("Copy the volume without its snapshots"))
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
 	cmd.Flags().BoolVar(&c.flagRefresh, "refresh", false, i18n.G("Refresh and update the existing storage volume copies"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeCopy) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -550,7 +550,7 @@ type cmdStorageVolumeCreate struct {
 	flagContentType string
 }
 
-func (c *cmdStorageVolumeCreate) Command() *cobra.Command {
+func (c *cmdStorageVolumeCreate) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <volume> [key=value...]"))
 	cmd.Short = i18n.G("Create new custom storage volumes")
@@ -559,12 +559,12 @@ func (c *cmdStorageVolumeCreate) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagContentType, "type", "filesystem", i18n.G("Content type, block or filesystem")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeCreate) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeCreate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
 	if exit {
@@ -628,7 +628,7 @@ type cmdStorageVolumeDelete struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeDelete) Command() *cobra.Command {
+func (c *cmdStorageVolumeDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <volume>[/<snapshot>]"))
 	cmd.Aliases = []string{"rm"}
@@ -637,12 +637,12 @@ func (c *cmdStorageVolumeDelete) Command() *cobra.Command {
 		`Delete storage volumes`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -704,19 +704,19 @@ type cmdStorageVolumeDetach struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeDetach) Command() *cobra.Command {
+func (c *cmdStorageVolumeDetach) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("detach", i18n.G("[<remote>:]<pool> <volume> <instance> [<device name>]"))
 	cmd.Short = i18n.G("Detach storage volumes from instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Detach storage volumes from instances`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeDetach) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeDetach) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 4)
 	if exit {
@@ -786,19 +786,19 @@ type cmdStorageVolumeDetachProfile struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeDetachProfile) Command() *cobra.Command {
+func (c *cmdStorageVolumeDetachProfile) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("detach-profile", i18n.G("[<remote:>]<pool> <volume> <profile> [<device name>]"))
 	cmd.Short = i18n.G("Detach storage volumes from profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Detach storage volumes from profiles`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeDetachProfile) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeDetachProfile) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 4)
 	if exit {
@@ -867,7 +867,7 @@ type cmdStorageVolumeEdit struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeEdit) Command() *cobra.Command {
+func (c *cmdStorageVolumeEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<pool> [<type>/]<volume>"))
 	cmd.Short = i18n.G("Edit storage volume configurations as YAML")
@@ -881,7 +881,7 @@ lxc storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml
     Update a storage volume using the content of pool.yaml.`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
@@ -900,7 +900,7 @@ func (c *cmdStorageVolumeEdit) helpTemplate() string {
 ###   size: "61203283968"`)
 }
 
-func (c *cmdStorageVolumeEdit) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1076,7 +1076,7 @@ type cmdStorageVolumeGet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageVolumeGet) Command() *cobra.Command {
+func (c *cmdStorageVolumeGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"))
 	cmd.Short = i18n.G("Get values for storage volume configuration keys")
@@ -1096,12 +1096,12 @@ lxc storage volume get default virtual-machine/data snapshots.expiry
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a storage volume property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeGet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -1191,7 +1191,7 @@ type cmdStorageVolumeInfo struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeInfo) Command() *cobra.Command {
+func (c *cmdStorageVolumeInfo) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:]<pool> [<type>/]<volume>"))
 	cmd.Short = i18n.G("Show storage volume state information")
@@ -1208,12 +1208,12 @@ lxc storage volume info default virtual-machine/data
     Returns state information for a virtual machine "data" in pool "default".`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1417,7 +1417,7 @@ type cmdStorageVolumeList struct {
 	defaultColumns string
 }
 
-func (c *cmdStorageVolumeList) Command() *cobra.Command {
+func (c *cmdStorageVolumeList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:][<pool>] [<filter>...]"))
 	cmd.Aliases = []string{"ls"}
@@ -1445,12 +1445,12 @@ Column shorthand chars:
     U - Current disk usage`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeList) run(cmd *cobra.Command, args []string) error {
 	// Quick checks
 	exit, err := c.global.CheckArgs(cmd, args, 0, -1)
 	if exit {
@@ -1666,7 +1666,7 @@ type cmdStorageVolumeMove struct {
 	storageVolumeRename *cmdStorageVolumeRename
 }
 
-func (c *cmdStorageVolumeMove) Command() *cobra.Command {
+func (c *cmdStorageVolumeMove) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("move", i18n.G("[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"))
 	cmd.Aliases = []string{"mv"}
@@ -1678,12 +1678,12 @@ func (c *cmdStorageVolumeMove) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.storageVolume.flagDestinationTarget, "destination-target", "", i18n.G("Destination cluster member name")+"``")
 	cmd.Flags().StringVar(&c.storageVolumeCopy.flagTargetProject, "target-project", "", i18n.G("Move to a project different from the source")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeMove) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeMove) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -1735,10 +1735,10 @@ func (c *cmdStorageVolumeMove) Run(cmd *cobra.Command, args []string) error {
 
 		args = append(args, srcVolName, dstVolName)
 
-		return c.storageVolumeRename.Run(cmd, args)
+		return c.storageVolumeRename.run(cmd, args)
 	}
 
-	return c.storageVolumeCopy.Run(cmd, args)
+	return c.storageVolumeCopy.run(cmd, args)
 }
 
 // Rename.
@@ -1748,7 +1748,7 @@ type cmdStorageVolumeRename struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeRename) Command() *cobra.Command {
+func (c *cmdStorageVolumeRename) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"))
 	cmd.Short = i18n.G("Rename storage volumes and storage volume snapshots")
@@ -1756,12 +1756,12 @@ func (c *cmdStorageVolumeRename) Command() *cobra.Command {
 		`Rename storage volumes`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeRename) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeRename) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -1863,7 +1863,7 @@ type cmdStorageVolumeSet struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageVolumeSet) Command() *cobra.Command {
+func (c *cmdStorageVolumeSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."))
 	cmd.Short = i18n.G("Set storage volume configuration keys")
@@ -1884,12 +1884,12 @@ lxc storage volume set default virtual-machine/data snapshots.expiry=7d
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a storage volume property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeSet) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
 	if exit {
@@ -2007,7 +2007,7 @@ type cmdStorageVolumeShow struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeShow) Command() *cobra.Command {
+func (c *cmdStorageVolumeShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"))
 	cmd.Short = i18n.G("Show storage volume configurations")
@@ -2029,12 +2029,12 @@ lxc storage volume show default virtual-machine/data/snap0
     Will show the properties of snapshot "snap0" for a virtual machine called "data" in the "default" pool.`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
@@ -2116,7 +2116,7 @@ type cmdStorageVolumeUnset struct {
 	flagIsProperty bool
 }
 
-func (c *cmdStorageVolumeUnset) Command() *cobra.Command {
+func (c *cmdStorageVolumeUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<pool> [<type>/]<volume> <key>"))
 	cmd.Short = i18n.G("Unset storage volume configuration keys")
@@ -2134,12 +2134,12 @@ lxc storage volume unset default virtual-machine/data snapshots.expiry
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a storage volume property"))
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeUnset) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -2149,7 +2149,7 @@ func (c *cmdStorageVolumeUnset) Run(cmd *cobra.Command, args []string) error {
 	c.storageVolumeSet.flagIsProperty = c.flagIsProperty
 
 	args = append(args, "")
-	return c.storageVolumeSet.Run(cmd, args)
+	return c.storageVolumeSet.run(cmd, args)
 }
 
 // Snapshot.
@@ -2162,14 +2162,14 @@ type cmdStorageVolumeSnapshot struct {
 	flagReuse    bool
 }
 
-func (c *cmdStorageVolumeSnapshot) Command() *cobra.Command {
+func (c *cmdStorageVolumeSnapshot) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("snapshot", i18n.G("[<remote>:]<pool> <volume> [<snapshot>]"))
 	cmd.Short = i18n.G("Snapshot storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Snapshot storage volumes`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagNoExpiry, "no-expiry", false, i18n.G("Ignore any configured auto-expiry for the storage volume"))
 	cmd.Flags().BoolVar(&c.flagReuse, "reuse", false, i18n.G("If the snapshot name already exists, delete and create a new one"))
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
@@ -2177,7 +2177,7 @@ func (c *cmdStorageVolumeSnapshot) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdStorageVolumeSnapshot) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeSnapshot) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
 	if exit {
@@ -2259,7 +2259,7 @@ type cmdStorageVolumeRestore struct {
 	storageVolume *cmdStorageVolume
 }
 
-func (c *cmdStorageVolumeRestore) Command() *cobra.Command {
+func (c *cmdStorageVolumeRestore) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("restore", i18n.G("[<remote>:]<pool> <volume> <snapshot>"))
 	cmd.Short = i18n.G("Restore storage volume snapshots")
@@ -2267,12 +2267,12 @@ func (c *cmdStorageVolumeRestore) Command() *cobra.Command {
 		`Restore storage volume snapshots`))
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeRestore) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeRestore) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
 	if exit {
@@ -2326,7 +2326,7 @@ type cmdStorageVolumeExport struct {
 	flagCompressionAlgorithm string
 }
 
-func (c *cmdStorageVolumeExport) Command() *cobra.Command {
+func (c *cmdStorageVolumeExport) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("export", i18n.G("[<remote>:]<pool> <volume> [<path>]"))
 	cmd.Short = i18n.G("Export custom storage volume")
@@ -2338,12 +2338,12 @@ func (c *cmdStorageVolumeExport) Command() *cobra.Command {
 		i18n.G("Use storage driver optimized format (can only be restored on a similar pool)"))
 	cmd.Flags().StringVar(&c.flagCompressionAlgorithm, "compression", "", i18n.G("Define a compression algorithm: for backup or none")+"``")
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeExport) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeExport) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
@@ -2480,7 +2480,7 @@ type cmdStorageVolumeImport struct {
 	flagType string
 }
 
-func (c *cmdStorageVolumeImport) Command() *cobra.Command {
+func (c *cmdStorageVolumeImport) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("import", i18n.G("[<remote>:]<pool> <backup file> [<volume name>]"))
 	cmd.Short = i18n.G("Import custom storage volumes")
@@ -2490,13 +2490,13 @@ func (c *cmdStorageVolumeImport) Command() *cobra.Command {
 		`lxc storage volume import default backup0.tar.gz
 		Create a new custom volume using backup0.tar.gz as the source.`))
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Flags().StringVar(&c.flagType, "type", "", i18n.G("Import type, backup or iso (default \"backup\")")+"``")
 
 	return cmd
 }
 
-func (c *cmdStorageVolumeImport) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdStorageVolumeImport) run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.

--- a/lxc/version.go
+++ b/lxc/version.go
@@ -15,19 +15,19 @@ type cmdVersion struct {
 	global *cmdGlobal
 }
 
-func (c *cmdVersion) Command() *cobra.Command {
+func (c *cmdVersion) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("version", i18n.G("[<remote>:]"))
 	cmd.Short = i18n.G("Show local and remote versions")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show local and remote versions`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdVersion) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdVersion) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -237,11 +237,11 @@ func (c *cmdWarningList) parseColumns(clustered bool) ([]warningColumn, error) {
 
 		for _, columnRune := range columnEntry {
 			column, ok := columnsShorthandMap[columnRune]
-			if ok {
-				columns = append(columns, column)
-			} else {
+			if !ok {
 				return nil, fmt.Errorf(i18n.G("Unknown column shorthand char '%c' in '%s'"), columnRune, columnEntry)
 			}
+
+			columns = append(columns, column)
 		}
 	}
 

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -22,7 +22,7 @@ type cmdWarning struct {
 	global *cmdGlobal
 }
 
-func (c *cmdWarning) Command() *cobra.Command {
+func (c *cmdWarning) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("warning")
 	cmd.Short = i18n.G("Manage warnings")
@@ -31,19 +31,19 @@ func (c *cmdWarning) Command() *cobra.Command {
 
 	// List
 	warningListCmd := cmdWarningList{global: c.global, warning: c}
-	cmd.AddCommand(warningListCmd.Command())
+	cmd.AddCommand(warningListCmd.command())
 
 	// Acknowledge
 	warningAcknowledgeCmd := cmdWarningAcknowledge{global: c.global, warning: c}
-	cmd.AddCommand(warningAcknowledgeCmd.Command())
+	cmd.AddCommand(warningAcknowledgeCmd.command())
 
 	// Show
 	warningShowCmd := cmdWarningShow{global: c.global, warning: c}
-	cmd.AddCommand(warningShowCmd.Command())
+	cmd.AddCommand(warningShowCmd.command())
 
 	// Delete
 	warningDeleteCmd := cmdWarningDelete{global: c.global, warning: c}
-	cmd.AddCommand(warningDeleteCmd.Command())
+	cmd.AddCommand(warningDeleteCmd.command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -63,7 +63,7 @@ type cmdWarningList struct {
 
 const defaultWarningColumns = "utSscpLl"
 
-func (c *cmdWarningList) Command() *cobra.Command {
+func (c *cmdWarningList) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
 	cmd.Aliases = []string{"ls"}
@@ -93,12 +93,12 @@ Column shorthand chars:
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 	cmd.Flags().BoolVarP(&c.flagAll, "all", "a", false, i18n.G("List all warnings")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdWarningList) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdWarningList) run(cmd *cobra.Command, args []string) error {
 	// Parse remote
 	remote := ""
 	if len(args) > 0 {
@@ -254,7 +254,7 @@ type cmdWarningAcknowledge struct {
 	warning *cmdWarning
 }
 
-func (c *cmdWarningAcknowledge) Command() *cobra.Command {
+func (c *cmdWarningAcknowledge) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("acknowledge", i18n.G("[<remote>:]<warning-uuid>"))
 	cmd.Aliases = []string{"ack"}
@@ -262,12 +262,12 @@ func (c *cmdWarningAcknowledge) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Acknowledge warning`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdWarningAcknowledge) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdWarningAcknowledge) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -296,19 +296,19 @@ type cmdWarningShow struct {
 	warning *cmdWarning
 }
 
-func (c *cmdWarningShow) Command() *cobra.Command {
+func (c *cmdWarningShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<warning-uuid>"))
 	cmd.Short = i18n.G("Show warning")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Show warning`))
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdWarningShow) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdWarningShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {
@@ -349,7 +349,7 @@ type cmdWarningDelete struct {
 	flagAll bool
 }
 
-func (c *cmdWarningDelete) Command() *cobra.Command {
+func (c *cmdWarningDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<warning-uuid>"))
 	cmd.Aliases = []string{"rm"}
@@ -359,12 +359,12 @@ func (c *cmdWarningDelete) Command() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&c.flagAll, "all", "a", false, i18n.G("Delete all warnings")+"``")
 
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 
 	return cmd
 }
 
-func (c *cmdWarningDelete) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdWarningDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
 	if exit {


### PR DESCRIPTION
The current linting rules are flagging all `Run` and `Command` methods in the `lxc` package as requiring a comment. These methods are following a pattern that was established years ago. None of the methods are imported elsewhere in the codebase and should be exported (the receivers are private and do not implement any interfaces). This PR unexports all methods defined on private receivers in the `lxc` package, then fixes any remaining linter errors that surfaced as a result.

See https://github.com/canonical/lxd/pull/13504#issuecomment-2146097451 and https://github.com/canonical/lxd/pull/13540#discussion_r1625506433