### PR TITLE
Storage: Fix PowerFlex apparmor warnings

### DIFF
--- a/lxd/apparmor/qemuimg.go
+++ b/lxd/apparmor/qemuimg.go
@@ -23,7 +23,15 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   capability dac_read_search,
   capability ipc_lock,
 
-  /sys/devices/**/block/*/queue/max_segments  r,
+  /sys/devices/**/block/*/queue/max_segments r,
+  /sys/devices/**/block/*/queue/zoned r,
+  /sys/devices/virtual/nvme-subsystem/**/queue/max_segments r,
+  /sys/devices/virtual/nvme-subsystem/**/queue/zoned r,
+  /sys/devices/system/node/ r,
+  /sys/devices/system/node/*/meminfo r,
+
+  # PowerFlex storage driver specific for NVMe/TCP mode
+  network inet tcp,
 
 {{range $index, $element := .allowedCmdPaths}}
   {{$element}} mixr,

--- a/lxd/apparmor/rsync.go
+++ b/lxd/apparmor/rsync.go
@@ -29,6 +29,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 
   unix (connect, send, receive) type=stream,
 
+  # PowerFlex storage driver specific for NVMe/TCP mode
+  network inet tcp,
+
   @{PROC}/@{pid}/cmdline r,
   @{PROC}/@{pid}/cpuset r,
   {{ .rootPath }}/{etc,lib,usr/lib}/os-release r,

--- a/lxd/apparmor/rsync.go
+++ b/lxd/apparmor/rsync.go
@@ -178,7 +178,7 @@ func rsyncProfile(sysOS *sys.OS, name string, sourcePath string, dstPath string)
 		execPath = fullPath
 	}
 
-	var sb *strings.Builder = &strings.Builder{}
+	sb := &strings.Builder{}
 	err = rsyncProfileTpl.Execute(sb, map[string]any{
 		"name":        name,
 		"execPath":    execPath,


### PR DESCRIPTION
During the work on the SDC mode in PowerFlex I was closely following the `dmesg` output throughout the entire lxd-ci `tests/storage-vm` test suite (when executed for the NVMe/TCP mode) and I found some apparmor warnings that interestingly do not cause any errors on LXD side but indicate some missing access.

They only appear from time to time and do not happen consistently.
The IPs/ports listed in the error messages correspond to the NVMe/TCP connections to the PowerFlex SDT's:

![Screenshot from 2024-06-05 09-04-27](https://github.com/canonical/lxd/assets/6641364/42fadd46-e329-4701-845a-5746fb77b0e8)

This PR adds additional rules to both the `rsync` and `qemuimg` profile to mitigate the following errors. At least one of the warnings was reported unrelated to PowerFlex here https://github.com/canonical/lxd/issues/13585.

![Screenshot from 2024-06-04 12-12-47](https://github.com/canonical/lxd/assets/6641364/8bf7f919-0d94-4160-8133-9ff272e40ce6)

![nvme_apparmor](https://github.com/canonical/lxd/assets/6641364/f3b74299-5174-48c9-b174-6a4e52e02081)