### PR TITLE
Storage: Prevent race when unmapping PowerFlex volume

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2002,7 +2002,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	var vol drivers.Volume
-	if isRemoteClusterMove {
+	if isRemoteClusterMove || args.Refresh {
 		// In case it's a cluster move don't instantiate a new volume.
 		// Instead load the existing volume and config from the database.
 		vol = b.GetVolume(volType, contentType, volStorageName, volumeConfig)
@@ -5254,8 +5254,14 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 	}
 
 	// Check if the volume exists on storage.
+	var vol drivers.Volume
 	volStorageName := project.StorageVolume(projectName, args.Name)
-	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(args.ContentType), volStorageName, volumeConfig)
+	if args.Refresh {
+		vol = b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(args.ContentType), volStorageName, volumeConfig)
+	} else {
+		vol = b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(args.ContentType), volStorageName, volumeConfig)
+	}
+
 	volExists, err := b.driver.HasVolume(vol)
 	if err != nil {
 		return err

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -508,7 +508,7 @@ func (d *btrfs) GetResources() (*api.ResourcesStoragePool, error) {
 	return genericVFSGetResources(d)
 }
 
-// MigrationType returns the type of transfer methods to be used when doing migrations between pools in preference order.
+// MigrationTypes returns the type of transfer methods to be used when doing migrations between pools in preference order.
 func (d *btrfs) MigrationTypes(contentType ContentType, refresh bool, copySnapshots bool) []migration.Type {
 	var rsyncFeatures []string
 	btrfsFeatures := []string{migration.BTRFSFeatureMigrationHeader, migration.BTRFSFeatureSubvolumes, migration.BTRFSFeatureSubvolumeUUIDs}

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -1,11 +1,13 @@
 package drivers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -207,7 +209,10 @@ func (d *btrfs) Create() error {
 		// Confirm that the symlink is appearing (give it 10s).
 		// In case of timeout it falls back to using the volume's path
 		// instead of its UUID.
-		if tryExists(fmt.Sprintf("/dev/disk/by-uuid/%s", devUUID)) {
+		ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 10*time.Second)
+		defer cancel()
+
+		if tryExists(ctx, fmt.Sprintf("/dev/disk/by-uuid/%s", devUUID)) {
 			// Override the config to use the UUID.
 			d.config["source"] = devUUID
 		} else {

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -157,14 +157,6 @@ func (d *powerflex) Create() error {
 
 // Delete removes the storage pool from the storage device.
 func (d *powerflex) Delete(op *operations.Operation) error {
-	// Disconnect from the NVMe/TCP subsystem.
-	if d.config["powerflex.mode"] == "nvme" {
-		err := d.disconnectNVMeSubsys()
-		if err != nil {
-			return err
-		}
-	}
-
 	// If the user completely destroyed it, call it done.
 	if !shared.PathExists(GetPoolMountPath(d.name)) {
 		return nil

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -551,7 +551,7 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 	}
 
 	if cleanup != nil {
-		defer func() { cleanup() }()
+		defer cleanup()
 	}
 
 	oldSizeBytes, err := BlockDiskSizeBytes(devPath)
@@ -729,11 +729,6 @@ func (d *powerflex) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.
 	mountPath := vol.MountPath()
 	refCount := vol.MountRefCountDecrement()
 
-	volName, err := d.getVolumeName(vol)
-	if err != nil {
-		return false, err
-	}
-
 	// Attempt to unmount the volume.
 	if vol.contentType == ContentTypeFS && filesystem.IsMountPoint(mountPath) {
 		if refCount > 0 {
@@ -750,7 +745,7 @@ func (d *powerflex) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.
 
 		// Attempt to unmap.
 		if !keepBlockDev {
-			err = d.unmapVolume(volName)
+			err = d.unmapVolume(vol)
 			if err != nil {
 				return false, err
 			}
@@ -777,7 +772,7 @@ func (d *powerflex) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.
 				}
 
 				// Attempt to unmap.
-				err := d.unmapVolume(volName)
+				err := d.unmapVolume(vol)
 				if err != nil {
 					return false, err
 				}

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -534,15 +534,6 @@ func (d *powerflex) GetVolumeUsage(vol Volume) (int64, error) {
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
 func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
-	inUse := vol.MountInUse()
-
-	// Only perform pre-resize checks if we are not in "unsafe" mode.
-	// In unsafe mode we expect the caller to know what they are doing and understand the risks.
-	if !allowUnsafeResize && inUse {
-		// We don't allow online resizing of block volumes.
-		return ErrInUse
-	}
-
 	// Convert to bytes.
 	sizeBytes, err := units.ParseByteSizeString(size)
 	if err != nil {
@@ -554,27 +545,18 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 		return nil
 	}
 
-	// Ignore the cleanup as we have to unmap the volume later anyway.
-	devPath, _, err := d.getMappedDevPath(vol, true)
+	devPath, cleanup, err := d.getMappedDevPath(vol, true)
 	if err != nil {
 		return err
+	}
+
+	if cleanup != nil {
+		defer func() { cleanup() }()
 	}
 
 	oldSizeBytes, err := BlockDiskSizeBytes(devPath)
 	if err != nil {
 		return fmt.Errorf("Error getting current size: %w", err)
-	}
-
-	volName, err := d.getVolumeName(vol)
-	if err != nil {
-		return err
-	}
-
-	// Ensure the volume is unmapped.
-	// Resizing the volume in PowerFlex whilst it is mapped to the system using NVMe/TCP will raise errors.
-	err = d.unmapVolume(volName)
-	if err != nil {
-		return err
 	}
 
 	// Do nothing if volume is already specified size (+/- 512 bytes).
@@ -594,6 +576,11 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 		return ErrNotSupported
 	}
 
+	volName, err := d.getVolumeName(vol)
+	if err != nil {
+		return err
+	}
+
 	client := d.client()
 	volumeID, err := client.getVolumeID(volName)
 	if err != nil {
@@ -611,16 +598,6 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 				return err
 			}
 
-			// Map the volume again to grow its filesystem.
-			devPath, cleanup, err := d.getMappedDevPath(vol, true)
-			if err != nil {
-				return err
-			}
-
-			if cleanup != nil {
-				defer cleanup()
-			}
-
 			// Grow the filesystem to fill block device.
 			err = growFileSystem(fsType, devPath, vol)
 			if err != nil {
@@ -628,20 +605,19 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 			}
 		}
 	} else {
+		inUse := vol.MountInUse()
+
+		// Only perform pre-resize checks if we are not in "unsafe" mode.
+		// In unsafe mode we expect the caller to know what they are doing and understand the risks.
+		if !allowUnsafeResize && inUse {
+			// We don't allow online resizing of block volumes.
+			return ErrInUse
+		}
+
 		// Resize block device.
 		err = client.setVolumeSize(volumeID, sizeBytes/factorGiB)
 		if err != nil {
 			return err
-		}
-
-		// Map the volume again to allow moving the GPT alt header.
-		devPath, cleanup, err := d.getMappedDevPath(vol, true)
-		if err != nil {
-			return err
-		}
-
-		if cleanup != nil {
-			defer cleanup()
 		}
 
 		// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as it is

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -215,6 +215,23 @@ func tryExists(ctx context.Context, path string) bool {
 	}
 }
 
+// waitGone waits for a file to not exist anymore or the context being cancelled.
+// The probe happens at intervals of 500 milliseconds.
+func waitGone(ctx context.Context, path string) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			if !shared.PathExists(path) {
+				return true
+			}
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
 // fsUUID returns the filesystem UUID for the given block path.
 // error is returned if the given block device exists but has no UUID.
 func fsUUID(path string) (string, error) {

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -197,18 +198,21 @@ func TryUnmount(path string, flags int) error {
 	return nil
 }
 
-// tryExists waits up to 10s for a file to exist.
-func tryExists(path string) bool {
-	// Attempt 20 checks over 10s
-	for i := 0; i < 20; i++ {
-		if shared.PathExists(path) {
-			return true
+// tryExists waits for a file to exist or the context being cancelled.
+// The probe happens at intervals of 500 milliseconds.
+func tryExists(ctx context.Context, path string) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			if shared.PathExists(path) {
+				return true
+			}
 		}
 
 		time.Sleep(500 * time.Millisecond)
 	}
-
-	return false
 }
 
 // fsUUID returns the filesystem UUID for the given block path.


### PR DESCRIPTION
https://github.com/canonical/lxd/pull/13073 was meant to resolve an error that happens during the resizing of a volume. As the error wasn't anymore present I thought this has fixed it by unmapping the volume prior to the resize.

But this breaks the `lxc import ...` command as the `driver.SetVolumeQuota()` function isn't expected to unmap/map the volume which might cause the path of the device to be different after the map. This can lead to an error during the unpack operations.

Instead it looks that the actual error comes from a race if LXD doesn't wait for the volume to disappear from the system. A subsequent map operation might pick the path from the old volume that is still to be removed from the system.
For Ceph RBD this is not an issue as we call `rbd unmap` directly on the host and the command presumably blocks until the actual device is removed from the system.

Furthermore during the execution of `lxd-ci/tests/storage-vm` I found that PowerFlex backed volume refreshes (`lxc cp abc remote:def --refresh` and `lxc storage volume cp pool/abc remote:pool/def --refresh` to a remote LXD currently do not work as the volumes receive a new `volatile.uuid` due to the call to `GetNewVolume()` when doing a refresh. The conditions are changed for both custom volume and instance refreshes.
This didn't surface until now as the tests (https://github.com/canonical/lxd-ci/pull/101) were landed after we have merged PowerFlex.

Additionally the `nvme` lock got moved to ensure that multiple LXD storage pools backed by the same PowerFlex storage cluster will not remove the NVMe/TCP connection from each other.