### PR TITLE
doc/Makefile.sp: replace subshell by command group

### DIFF
--- a/doc/Makefile.sp
+++ b/doc/Makefile.sp
@@ -91,7 +91,7 @@ sp-spellcheck:
 sp-spelling: sp-html sp-spellcheck
 
 sp-linkcheck: sp-install
-	. $(VENV) ; $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) || (grep --color -F "[broken]" "$(BUILDDIR)/output.txt"; exit 1)
+	. $(VENV) ; $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) || { grep --color -F "[broken]" "$(BUILDDIR)/output.txt"; exit 1; }
 	exit 0
 
 sp-woke: sp-woke-install


### PR DESCRIPTION
In `false || (true; exit 1)`, the `exit 1` only exists the subshell. Since the intention is to terminate the whole command pipeline, `{}` should be used instead.

Here it is in action:

Will sleep 30:

```
false || (true; exit 1) ; sleep 30
```

Will exit immediately, closing the terminal window:

```
false || { true; exit 1; }; sleep 30
```