### PR TITLE
lxd/apparmor/lxc: remove dup mount options rules

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -84,16 +84,6 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Handle tmpfs
   mount fstype=tmpfs,
 
-  # Allow limited modification of mount propagation
-  mount options=(rw,slave) -> /,
-  mount options=(rw,rslave) -> /,
-  mount options=(rw,shared) -> /,
-  mount options=(rw,rshared) -> /,
-  mount options=(rw,private) -> /,
-  mount options=(rw,rprivate) -> /,
-  mount options=(rw,unbindable) -> /,
-  mount options=(rw,runbindable) -> /,
-
   # Allow various ro-bind-*re*-mounts of anything except /proc, /sys and /dev/.lxc
   mount options=(ro,remount,bind) /[^spd]*{,/**},
   mount options=(ro,remount,bind) /d[^e]*{,/**},


### PR DESCRIPTION
As noticed by Aleks in https://github.com/canonical/lxd/pull/13555#issuecomment-2152322350 we have duplicated mount options rules.

The apparmor parser does rule deduplication do it doesn't really matter. However, the "limited" part of the "Allow limited modification of mount propagation" comment is a bit of a lie. As such, it's best to remove the duplicated/misleading rules and comment.