### PR TITLE
lxd/apparmor/lxc: reorganize mount options rules for priv containers

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -479,7 +479,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   ### Configuration: unprivileged containers
   pivot_root,
 
-  # Allow modifying mount propagation
+  # Allow unlimited modification of mount propagation
   mount options=(rw,slave) -> /{,**},
   mount options=(rw,rslave) -> /{,**},
   mount options=(rw,shared) -> /{,**},
@@ -520,6 +520,19 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Allow remounting things read-only
   mount options=(ro,remount) /,
   mount options=(ro,remount) /**,
+{{- else }}
+
+  ### Configuration: privileged containers
+
+  # Allow limited modification of mount propagation
+  mount options=(rw,slave) -> /,
+  mount options=(rw,rslave) -> /,
+  mount options=(rw,shared) -> /,
+  mount options=(rw,rshared) -> /,
+  mount options=(rw,private) -> /,
+  mount options=(rw,rprivate) -> /,
+  mount options=(rw,unbindable) -> /,
+  mount options=(rw,runbindable) -> /,
 {{- end }}
 
 {{- if .raw }}


### PR DESCRIPTION
As noticed by Aleks we have duplicated mount options rules for unprivileged containers.

The apparmor parser does rule deduplication so it doesn't really matter. However, the "limited" part of the "Allow limited modification of mount propagation" comment was misleading. As such, it's best to avoid the duplicated rules and make it clear that privileged containers have limited permissions while unprivileged ones have unlimited permissions for mount options.

Fixes "lxd/apparmor/lxc: remove dup mount options rules" commit 2e55b23f9f24537ce4469f6e5f0fd70f55ef615d.



lxd/apparmor/lxc: reorganize mount options rules for priv containers