### PR TITLE
Server: Remove password authentication - From Incus

### DIFF
--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -7,8 +7,6 @@ import (
 )
 
 // GetCluster returns information about a cluster
-//
-// If this client is not trusted, the password must be supplied.
 func (r *ProtocolLXD) GetCluster() (*api.Cluster, string, error) {
 	err := r.CheckExtension("clustering")
 	if err != nil {

--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -6,7 +6,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
-// GetCluster returns information about a cluster
+// GetCluster returns information about a cluster.
 func (r *ProtocolLXD) GetCluster() (*api.Cluster, string, error) {
 	err := r.CheckExtension("clustering")
 	if err != nil {
@@ -29,7 +29,7 @@ func (r *ProtocolLXD) UpdateCluster(cluster api.ClusterPut, ETag string) (Operat
 		return nil, err
 	}
 
-	if cluster.ServerAddress != "" || cluster.ClusterPassword != "" || cluster.ClusterToken != "" || len(cluster.MemberConfig) > 0 {
+	if cluster.ServerAddress != "" || cluster.ClusterToken != "" || len(cluster.MemberConfig) > 0 {
 		err := r.CheckExtension("clustering_join")
 		if err != nil {
 			return nil, err

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -51,7 +51,6 @@ You can obtain the list of TLS certificates trusted by a LXD server with [`lxc c
 Trusted clients can be added in either of the following ways:
 
 - {ref}`authentication-add-certs`
-- {ref}`authentication-trust-pw`
 - {ref}`authentication-token`
 
 The workflow to authenticate with the server is similar to that of SSH, where an initial connection to an unknown server triggers a prompt:
@@ -61,8 +60,8 @@ The workflow to authenticate with the server is similar to that of SSH, where an
 1. The server attempts to authenticate the client:
 
    - If the client certificate is in the server's trust store, the connection is granted.
-   - If the client certificate is not in the server's trust store, the server prompts the user for a token or the trust password.
-     If the provided token or trust password matches, the client certificate is added to the server's trust store and the connection is granted.
+   - If the client certificate is not in the server's trust store, the server prompts the user for a token.
+     If the provided token matches, the client certificate is added to the server's trust store and the connection is granted.
      Otherwise, the connection is rejected.
 
 To revoke trust to a client, remove its certificate from the server with [`lxc config trust remove <fingerprint>`](lxc_config_trust_remove.md).
@@ -75,21 +74,13 @@ TLS clients can be restricted to a subset of projects, see {ref}`restricted-tls-
 The preferred way to add trusted clients is to directly add their certificates to the trust store on the server.
 To do so, copy the client certificate to the server and register it using [`lxc config trust add <file>`](lxc_config_trust_add.md).
 
-(authentication-trust-pw)=
-#### Adding client certificates using a trust password
-
-To allow establishing a new trust relationship from the client side, you must set a trust password ({config:option}`server-core:core.trust_password`) for the server. Clients can then add their own certificate to the server's trust store by providing the trust password when prompted.
-
-In a production setup, unset `core.trust_password` after all clients have been added.
-This prevents brute-force attacks trying to guess the password.
-
 (authentication-token)=
 #### Adding client certificates using tokens
 
-You can also add new clients by using tokens. This is a safer way than using the trust password, because tokens expire after a configurable time ({config:option}`server-core:core.remote_token_expiry`) or once they've been used.
+You can also add new clients by using tokens. These tokens expire after a configurable time ({config:option}`server-core:core.remote_token_expiry`) or once they've been used.
 
 To use this method, generate a token for each client by calling [`lxc config trust add`](lxc_config_trust_add.md), which will prompt for the client name.
-The clients can then add their certificates to the server's trust store by providing the generated token when prompted for the trust password.
+The clients can then add their certificates to the server's trust store by providing the generated token.
 
 <!-- Include start NAT authentication -->
 
@@ -98,7 +89,10 @@ If your LXD server is behind NAT, you must specify its external public address w
 
     lxc remote add <name> <IP_address>
 
-When you are prompted for the admin password, specify the generated token.
+When you are prompted for the token, specify the generated token from the previous step.
+Alternatively, use the `--token` flag:
+
+    lxc remote add <name> <IP_address> --token <token>
 
 When generating the token on the server, LXD includes a list of IP addresses that the client can use to access the server.
 However, if the server is behind NAT, these addresses might be local addresses that the client cannot connect to.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -4453,13 +4453,6 @@ Set this option to `true` to enable the syslog unixgram socket to receive log me
 
 ```
 
-```{config:option} core.trust_password server-core
-:scope: "global"
-:shortdesc: "Password to be provided by clients to set up a trust"
-:type: "string"
-
-```
-
 <!-- config group server-core end -->
 <!-- config group server-images start -->
 ```{config:option} images.auto_update_cached server-images

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -21,12 +21,11 @@ By default, the LXD server is not accessible from the network, because it only l
 
 You can enable it for remote access by following the instructions in {ref}`server-expose`.
 
-## When I do a `lxc remote add`, it asks for a password or token?
+## When I do a `lxc remote add`, it asks for a token?
 
 To be able to access the remote API, clients must authenticate with the LXD server.
-Depending on how the remote server is configured, you must provide either a trust token issued by the server or specify a trust password (if {config:option}`server-core:core.trust_password` is set).
 
-See {ref}`server-authenticate` for instructions on how to authenticate using a trust token (the recommended way), and  {doc}`authentication` for information about other authentication methods.
+See {ref}`server-authenticate` for instructions on how to authenticate using a trust token.
 
 ## Why should I not run privileged containers?
 

--- a/doc/howto/images_remote.md
+++ b/doc/howto/images_remote.md
@@ -61,7 +61,7 @@ For example, enter the following command to add a remote through an IP address:
 
     lxc remote add my-remote 192.0.2.10
 
-You are prompted to confirm the remote server fingerprint and then asked for the password or token, depending on the authentication method used by the remote.
+You are prompted to confirm the remote server fingerprint and then asked for the token.
 <!-- Include end add remotes -->
 
 ## Reference an image

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -55,7 +55,7 @@ Remote access (see {ref}`security_remote_access` and {ref}`authentication`)
   The default answer is `no`, which means remote access is not allowed.
   If you answer `yes`, you can connect to the server over the network.
 
-  You can choose to add client certificates to the server (manually or through tokens, the recommended way) or set a trust password.
+  You can choose to add client certificates to the server either manually or through tokens.
 
 Automatic image update (see {ref}`about-images`)
 : You can download images from image servers.
@@ -149,7 +149,6 @@ You can use it as a template for your own preseed file and add, change or remove
 # Daemon settings
 config:
   core.https_address: 192.0.2.1:9999
-  core.trust_password: sekret
   images.auto_update_interval: 6
 
 # Storage pools

--- a/doc/howto/projects_confine.md
+++ b/doc/howto/projects_confine.md
@@ -15,7 +15,6 @@ You can confine access to specific projects by restricting the TLS client certif
 See {ref}`authentication-tls-certs` for detailed information.
 
 To confine the access from the time the client certificate is added, you must either use token authentication or add the client certificate to the server directly.
-If you use password authentication, you can restrict the client certificate only after it has been added.
 
 Use the following command to add a restricted client certificate:
 
@@ -36,7 +35,7 @@ Use the following command to add a restricted client certificate:
 
 The client can then add the server as a remote in the usual way ([`lxc remote add <server_name> <token>`](lxc_remote_add.md) or [`lxc remote add <server_name> <server_address>`](lxc_remote_add.md)) and can only access the project or projects that have been specified.
 
-To confine access for an existing certificate (either because the access restrictions change or because the certificate was added with a trust password), use the following command:
+To confine access for an existing certificate, use the following command:
 
     lxc config trust edit <fingerprint>
 

--- a/doc/howto/server_expose.md
+++ b/doc/howto/server_expose.md
@@ -144,7 +144,7 @@ To authenticate a CLI or API client using a trust token, complete the following 
 
        curl -k -s --key "<keyfile_name>" --cert "<crtfile_name>" \
        -X POST https://<server_address>/1.0/certificates \
-       --data '{ "password": "<trust_token>" }'
+       --data '{ "trust_token": "<trust_token>" }'
 
    See [`POST /1.0/certificates?public`](swagger:/certificates/certificates_post_untrusted) for more information.
    ````

--- a/doc/reference/preseed_yaml_fields.md
+++ b/doc/reference/preseed_yaml_fields.md
@@ -8,7 +8,6 @@ The preseed YAML file fields are as follows:
 ```yaml
 config:
   core.https_address: ""
-  core.trust_password: ""
   images.auto_update_interval: 6
 
 networks:

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -210,7 +210,7 @@ definitions:
                 type: string
                 x-go-name: Name
             password:
-                description: Server trust password (used to add an untrusted client)
+                description: Server trust password (used to add an untrusted client, deprecated, use trust_token)
                 example: blah
                 type: string
                 x-go-name: Password
@@ -646,7 +646,7 @@ definitions:
                 type: string
                 x-go-name: ClusterCertificate
             cluster_password:
-                description: The trust password of the cluster you're trying to join
+                description: The trust password of the cluster you're trying to join (deprecated, use cluster_token)
                 example: blah
                 type: string
                 x-go-name: ClusterPassword
@@ -1369,7 +1369,7 @@ definitions:
                 type: string
                 x-go-name: ClusterCertificatePath
             cluster_password:
-                description: The trust password of the cluster you're trying to join
+                description: The trust password of the cluster you're trying to join (deprecated, use cluster_token)
                 example: blah
                 type: string
                 x-go-name: ClusterPassword
@@ -1410,7 +1410,6 @@ definitions:
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
-                    core.trust_password: xyz
                 type: object
                 x-go-name: Config
             networks:
@@ -5578,7 +5577,6 @@ definitions:
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
-                    core.trust_password: xyz
                 type: object
                 x-go-name: Config
             environment:
@@ -5758,7 +5756,6 @@ definitions:
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
-                    core.trust_password: xyz
                 type: object
                 x-go-name: Config
         type: object
@@ -7662,7 +7659,7 @@ paths:
                 - application/json
             description: |-
                 Adds a certificate to the trust store.
-                In this mode, the `password` property is always ignored.
+                In this mode, the `token` property is always ignored.
             operationId: certificates_post
             parameters:
                 - description: Certificate
@@ -7798,7 +7795,7 @@ paths:
                 - application/json
             description: |-
                 Adds a certificate to the trust store as an untrusted user.
-                In this mode, the `password` property must be set to the correct value.
+                In this mode, the `token` property must be set to the correct value.
 
                 The `certificate` field can be omitted in which case the TLS client
                 certificate in use for the connection will be retrieved and added to the

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -524,10 +524,7 @@ For backward compatibility, a single configuration key may still be set with:
     Will set a CPU limit of "2" for the instance.
 
 lxc config set core.https_address=[::]:8443
-    Will have LXD listen on IPv4 and IPv6 port 8443.
-
-lxc config set core.trust_password=blah
-    Will set the server's trust password to blah.`))
+    Will have LXD listen on IPv4 and IPv6 port 8443.`))
 
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as an instance property"))

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -546,9 +546,9 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 	run := func(op *operations.Operation) error {
 		logger.Debug("Running cluster join operation")
 
-		// If the user has provided a cluster password or token, setup the trust
+		// If the user has provided a join token, setup the trust
 		// relationship by adding our own certificate to the cluster.
-		if req.ClusterPassword != "" || req.ClusterToken != "" {
+		if req.ClusterToken != "" {
 			err := cluster.SetupTrust(serverCert, req)
 			if err != nil {
 				return fmt.Errorf("Failed to setup cluster trust: %w", err)

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -97,7 +97,6 @@ func (f *clusterFixture) EnableNetworking(daemon *Daemon, password string) {
 	require.NoError(f.t, err)
 	serverPut := server.Writable()
 	serverPut.Config["core.https_address"] = address
-	serverPut.Config["core.trust_password"] = password
 
 	require.NoError(f.t, client.UpdateServer(serverPut, ""))
 }
@@ -116,7 +115,6 @@ func (f *clusterFixture) EnableNetworkingWithClusterAddress(daemon *Daemon, pass
 	require.NoError(f.t, err)
 	serverPut := server.Writable()
 	serverPut.Config["core.https_address"] = address
-	serverPut.Config["core.trust_password"] = password
 	serverPut.Config["cluster.https_address"] = address
 
 	require.NoError(f.t, client.UpdateServer(serverPut, ""))

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -2,16 +2,12 @@ package config
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/scrypt"
 
 	"github.com/canonical/lxd/lxd/config"
 	"github.com/canonical/lxd/lxd/db"
@@ -820,28 +816,4 @@ func maxStandByValidator(value string) error {
 	}
 
 	return nil
-}
-
-func passwordSetter(value string) (string, error) {
-	// Nothing to do on unset
-	if value == "" {
-		return value, nil
-	}
-
-	// Hash the password
-	buf := make([]byte, 32)
-	_, err := io.ReadFull(rand.Reader, buf)
-	if err != nil {
-		return "", err
-	}
-
-	hash, err := scrypt.Key([]byte(value), buf, 1<<14, 8, 1, 64)
-	if err != nil {
-		return "", err
-	}
-
-	buf = append(buf, hash...)
-	value = hex.EncodeToString(buf)
-
-	return value, nil
 }

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -78,11 +78,6 @@ func (c *Config) HTTPSAllowedCredentials() bool {
 	return c.m.GetBool("core.https_allowed_credentials")
 }
 
-// TrustPassword returns the LXD trust password for authenticating clients.
-func (c *Config) TrustPassword() string {
-	return c.m.GetString("core.trust_password")
-}
-
 // TrustCACertificates returns whether client certificates are checked
 // against a CA.
 func (c *Config) TrustCACertificates() bool {
@@ -498,14 +493,6 @@ var ConfigSchema = config.Schema{
 	//  defaultdesc: `5`
 	//  shortdesc: How long to wait before shutdown
 	"core.shutdown_timeout": {Type: config.Int64, Default: "5"},
-
-	// lxdmeta:generate(entities=server; group=core; key=core.trust_password)
-	//
-	// ---
-	//  type: string
-	//  scope: global
-	//  shortdesc: Password to be provided by clients to set up a trust
-	"core.trust_password": {Setter: passwordSetter},
 
 	// lxdmeta:generate(entities=server; group=core; key=core.trust_ca_certificates)
 	//

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -202,7 +202,7 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 }
 
 // SetupTrust is a convenience around InstanceServer.CreateCertificate that adds the given server certificate to
-// the trusted pool of the cluster at the given address, using the given password. The certificate is added as
+// the trusted pool of the cluster at the given address, using the given token. The certificate is added as
 // type CertificateTypeServer to allow intra-member communication. If a certificate with the same fingerprint
 // already exists with a different name or type, then no error is returned.
 func SetupTrust(serverCert *shared.CertInfo, clusterPut api.ClusterPut) error {
@@ -228,7 +228,6 @@ func SetupTrust(serverCert *shared.CertInfo, clusterPut api.ClusterPut) error {
 		Projects:    cert.Projects,
 		Restricted:  cert.Restricted,
 		Certificate: cert.Certificate,
-		Password:    clusterPut.ClusterPassword,
 		TrustToken:  clusterPut.ClusterToken,
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1298,6 +1298,12 @@ func (d *Daemon) init() error {
 		version.UserAgentFeatures([]string{"cluster"})
 	}
 
+	// Apply all patches that need to be run before the cluster config gets loaded.
+	err = patchesApply(d, patchPreLoadClusterConfig)
+	if err != nil {
+		return err
+	}
+
 	// Load server name and config before patches run (so they can access them from d.State()).
 	err = d.db.Cluster.Transaction(d.shutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
 		config, err := clusterConfig.Load(ctx, tx)

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -33,7 +33,7 @@ func TestLoadPreClusteringData(t *testing.T) {
 	assert.Equal(t, "1.2.3.4:666", dump.Data["config"][0][2])
 	rows := []any{int64(1), "core.https_address", "1.2.3.4:666"}
 	assert.Equal(t, rows, dump.Data["config"][0])
-	rows = []any{int64(2), "core.trust_password", "sekret"}
+	rows = []any{int64(2), "user.foo", "bar"}
 	assert.Equal(t, rows, dump.Data["config"][1])
 	rows = []any{int64(3), "maas.machine", "mymaas"}
 	assert.Equal(t, rows, dump.Data["config"][2])
@@ -81,7 +81,7 @@ func TestImportPreClusteringData(t *testing.T) {
 	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		config, err := tx.Config(ctx)
 		require.NoError(t, err)
-		values := map[string]string{"core.trust_password": "sekret"}
+		values := map[string]string{"user.foo": "bar"}
 		assert.Equal(t, values, config)
 		return nil
 	})
@@ -244,7 +244,7 @@ func newPreClusteringTx(t *testing.T) *sql.Tx {
 		preClusteringNodeSchema,
 		"INSERT INTO certificates VALUES (1, 'abcd:efgh', 1, 'foo', 'FOO')",
 		"INSERT INTO config VALUES(1, 'core.https_address', '1.2.3.4:666')",
-		"INSERT INTO config VALUES(2, 'core.trust_password', 'sekret')",
+		"INSERT INTO config VALUES(2, 'user.foo', 'bar')",
 		"INSERT INTO config VALUES(3, 'maas.machine', 'mymaas')",
 		"INSERT INTO profiles VALUES(1, 'default', 'Default LXD profile')",
 		"INSERT INTO profiles VALUES(2, 'users', '')",

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -29,7 +29,6 @@ type cmdInit struct {
 	flagStorageDevice   string
 	flagStorageLoopSize int
 	flagStoragePool     string
-	flagTrustPassword   string
 
 	hostname string
 }
@@ -45,7 +44,7 @@ func (c *cmdInit) Command() *cobra.Command {
 	cmd.Example = `  init --minimal
   init --auto [--network-address=IP] [--network-port=8443] [--storage-backend=dir]
               [--storage-create-device=DEVICE] [--storage-create-loop=SIZE]
-              [--storage-pool=POOL] [--trust-password=PASSWORD]
+              [--storage-pool=POOL]
   init --preseed
   init --dump
 `
@@ -61,7 +60,6 @@ func (c *cmdInit) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.flagStorageDevice, "storage-create-device", "", "Setup device based storage using DEVICE"+"``")
 	cmd.Flags().IntVar(&c.flagStorageLoopSize, "storage-create-loop", -1, "Setup loop based storage with SIZE in GiB"+"``")
 	cmd.Flags().StringVar(&c.flagStoragePool, "storage-pool", "", "Storage pool to use or create"+"``")
-	cmd.Flags().StringVar(&c.flagTrustPassword, "trust-password", "", "Password required to add new clients"+"``")
 
 	return cmd
 }
@@ -83,8 +81,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 
 	if !c.flagAuto && (c.flagNetworkAddress != "" || c.flagNetworkPort != -1 ||
 		c.flagStorageBackend != "" || c.flagStorageDevice != "" ||
-		c.flagStorageLoopSize != -1 || c.flagStoragePool != "" ||
-		c.flagTrustPassword != "") {
+		c.flagStorageLoopSize != -1 || c.flagStoragePool != "") {
 		return fmt.Errorf("Configuration flags require --auto")
 	}
 
@@ -92,7 +89,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		c.flagPreseed || c.flagNetworkAddress != "" ||
 		c.flagNetworkPort != -1 || c.flagStorageBackend != "" ||
 		c.flagStorageDevice != "" || c.flagStorageLoopSize != -1 ||
-		c.flagStoragePool != "" || c.flagTrustPassword != "") {
+		c.flagStoragePool != "") {
 		return fmt.Errorf("Can't use --dump with other flags")
 	}
 
@@ -195,9 +192,6 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		if config.Cluster.ClusterCertificate == "" {
 			return fmt.Errorf("Unable to connect to any of the cluster members specified in join token")
 		}
-
-		// Raw join token used as cluster password so it can be validated.
-		config.Cluster.ClusterPassword = config.Cluster.ClusterToken
 	}
 
 	// If clustering is enabled, and no cluster.https_address network address

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -37,10 +37,6 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 		if c.flagNetworkPort != -1 {
 			return nil, fmt.Errorf("--network-port can't be used without --network-address")
 		}
-
-		if c.flagTrustPassword != "" {
-			return nil, fmt.Errorf("--trust-password can't be used without --network-address")
-		}
 	}
 
 	storagePools, err := d.GetStoragePoolNames()
@@ -68,10 +64,6 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 	// Network listening
 	if c.flagNetworkAddress != "" {
 		config.Config["core.https_address"] = util.CanonicalNetworkAddressFromAddressAndPort(c.flagNetworkAddress, c.flagNetworkPort, shared.HTTPSDefaultPort)
-
-		if c.flagTrustPassword != "" {
-			config.Config["core.trust_password"] = c.flagTrustPassword
-		}
 	}
 
 	// Storage configuration

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5050,14 +5050,6 @@
 							"shortdesc": "Whether to automatically trust clients signed by the CA",
 							"type": "bool"
 						}
-					},
-					{
-						"core.trust_password": {
-							"longdesc": "",
-							"scope": "global",
-							"shortdesc": "Password to be provided by clients to set up a trust",
-							"type": "string"
-						}
 					}
 				]
 			},

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -37,6 +37,7 @@ type patchStage int
 // Define the stages that patches can run at.
 const (
 	patchNoStageSet patchStage = iota
+	patchPreLoadClusterConfig
 	patchPreDaemonStorage
 	patchPostDaemonStorage
 	patchPostNetworks

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -90,6 +90,7 @@ var patches = []patch{
 	{name: "storage_set_volume_uuid_v2", stage: patchPostDaemonStorage, run: patchStorageSetVolumeUUIDV2},
 	{name: "storage_move_custom_iso_block_volumes_v2", stage: patchPostDaemonStorage, run: patchStorageRenameCustomISOBlockVolumesV2},
 	{name: "storage_unset_invalid_block_settings_v2", stage: patchPostDaemonStorage, run: patchStorageUnsetInvalidBlockSettingsV2},
+	{name: "config_remove_core_trust_password", stage: patchPreLoadClusterConfig, run: patchRemoveCoreTrustPassword},
 }
 
 type patch struct {
@@ -1429,6 +1430,21 @@ DELETE FROM storage_volumes_config
 	AND storage_volumes_config.key IN ("block.filesystem", "block.mount_options")
 	`)
 	return err
+}
+
+// patchRemoveCoreTrustPassword removes the core.trust_password config key from the cluster.
+func patchRemoveCoreTrustPassword(_ string, d *Daemon) error {
+	s := d.State()
+	err := s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.UpdateClusterConfig(map[string]string{
+			"core.trust_password": "",
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to remove core.trust_password config key: %w", err)
+	}
+
+	return nil
 }
 
 // Patches end here

--- a/lxd/util/encryption.go
+++ b/lxd/util/encryption.go
@@ -1,42 +1,12 @@
 package util
 
 import (
-	"bytes"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"golang.org/x/crypto/scrypt"
-
 	"github.com/canonical/lxd/shared"
 )
-
-// PasswordCheck validates the provided password against the encoded secret.
-func PasswordCheck(secret string, password string) error {
-	// No password set
-	if secret == "" {
-		return fmt.Errorf("No password is set")
-	}
-
-	// Compare the password
-	buff, err := hex.DecodeString(secret)
-	if err != nil {
-		return err
-	}
-
-	salt := buff[0:32]
-	hash, err := scrypt.Key([]byte(password), salt, 1<<14, 8, 1, 64)
-	if err != nil {
-		return err
-	}
-
-	if !bytes.Equal(hash, buff[32:]) {
-		return fmt.Errorf("Bad password provided")
-	}
-
-	return nil
-}
 
 // LoadCert reads the LXD server certificate from the given var dir.
 //

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1060,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1128,8 +1128,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1208,7 +1208,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1657,8 +1657,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1721,8 +1721,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1931,7 +1931,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2065,7 +2065,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2299,12 +2299,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2412,7 +2412,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,11 +2470,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3533,7 +3533,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3980,7 +3980,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4007,7 +4007,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4371,7 +4371,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4672,28 +4672,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4702,7 +4702,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4788,7 +4788,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4845,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4871,7 +4871,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5031,11 +5031,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5048,7 +5048,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5246,7 +5246,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5379,7 +5379,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5387,7 +5387,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5477,11 +5477,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5689,7 +5689,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5891,7 +5891,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5945,7 +5945,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5999,6 +5999,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6037,7 +6042,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6125,7 +6130,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6241,7 +6246,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6594,7 +6599,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6616,11 +6621,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7017,7 +7022,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7025,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7045,7 +7050,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7151,19 +7156,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7408,7 +7410,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7420,7 +7422,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7457,7 +7459,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -730,7 +730,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -754,7 +754,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -774,15 +774,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -1096,7 +1096,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1363,7 +1363,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1432,8 +1432,8 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1515,7 +1515,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1638,12 +1638,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1682,7 +1682,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -2001,8 +2001,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2065,8 +2065,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2294,7 +2294,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2431,7 +2431,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2441,7 +2441,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2688,12 +2688,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2805,7 +2805,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2863,12 +2863,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3291,7 +3291,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3313,7 +3313,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3397,7 +3397,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3798,7 +3798,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -4011,7 +4011,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4511,7 +4511,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4538,7 +4538,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4844,11 +4844,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4892,7 +4892,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4911,7 +4911,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -5224,28 +5224,28 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5254,7 +5254,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5353,7 +5353,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5417,7 +5417,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5445,7 +5445,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5572,7 +5572,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5613,11 +5613,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5844,7 +5844,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5920,7 +5920,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5989,7 +5989,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5999,7 +5999,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
@@ -6103,11 +6103,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6327,7 +6327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6537,7 +6537,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6594,7 +6594,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6648,6 +6648,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6687,7 +6692,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6756,7 +6761,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -6780,7 +6785,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6918,7 +6923,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7076,7 +7081,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -7457,7 +7462,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
@@ -7500,7 +7505,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7508,7 +7513,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8299,7 +8304,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8317,7 +8322,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8358,7 +8363,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -8464,19 +8469,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8725,7 +8727,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -8737,7 +8739,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8774,7 +8776,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -816,7 +816,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1067,7 +1067,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1135,8 +1135,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1215,7 +1215,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1333,12 +1333,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1672,8 +1672,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1736,8 +1736,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1951,7 +1951,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2080,7 +2080,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2324,12 +2324,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2437,7 +2437,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2475,7 +2475,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2495,11 +2495,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3378,7 +3378,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3575,7 +3575,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "  Χρήση δικτύου:"
@@ -4045,7 +4045,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4072,7 +4072,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4374,11 +4374,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4420,7 +4420,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4439,7 +4439,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4740,28 +4740,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4770,7 +4770,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4860,7 +4860,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4944,7 +4944,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5105,11 +5105,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5122,7 +5122,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5401,7 +5401,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5468,7 +5468,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5476,7 +5476,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5574,11 +5574,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5787,7 +5787,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5989,7 +5989,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "  Χρήση δικτύου:"
@@ -6044,7 +6044,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6098,6 +6098,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6136,7 +6141,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6204,7 +6209,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6225,7 +6230,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6357,7 +6362,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6504,7 +6509,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6710,7 +6715,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6732,11 +6737,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7133,7 +7138,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7141,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7161,7 +7166,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7267,19 +7272,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7524,7 +7526,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7536,7 +7538,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7573,7 +7575,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -717,7 +717,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -757,15 +757,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -1062,7 +1062,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1244,7 +1244,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1317,7 +1317,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1386,8 +1386,8 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1468,7 +1468,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1588,12 +1588,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1632,7 +1632,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1933,8 +1933,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1997,8 +1997,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2212,7 +2212,7 @@ msgstr "Perfil %s creado"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2589,12 +2589,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2703,7 +2703,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2741,7 +2741,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2761,11 +2761,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
@@ -3180,7 +3180,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
@@ -3203,7 +3203,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3285,7 +3285,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3664,7 +3664,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3863,7 +3863,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Nombre del Miembro del Cluster"
@@ -4343,7 +4343,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4370,7 +4370,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4599,7 +4599,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4670,11 +4670,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4716,7 +4716,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4735,7 +4735,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -5042,37 +5042,38 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
 #: lxc/remote.go:101
+#, fuzzy
 msgid "Remote admin password"
-msgstr ""
+msgstr "Contraseña admin para %s: "
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5163,7 +5164,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5222,7 +5223,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5248,7 +5249,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5373,7 +5374,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5414,11 +5415,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5431,7 +5432,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
@@ -5637,7 +5638,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5711,7 +5712,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5778,7 +5779,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Dispositivo %s añadido a %s"
@@ -5787,7 +5788,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5885,11 +5886,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6099,7 +6100,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6303,7 +6304,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nombre del Miembro del Cluster"
@@ -6359,7 +6360,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6413,6 +6414,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6453,7 +6459,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6521,7 +6527,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
@@ -6543,7 +6549,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6675,7 +6681,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6823,7 +6829,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -7069,7 +7075,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
@@ -7096,12 +7102,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7589,7 +7595,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7599,7 +7605,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7624,7 +7630,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7730,19 +7736,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7987,7 +7990,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7999,7 +8002,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8036,7 +8039,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 
@@ -8266,7 +8269,3 @@ msgstr ""
 #, fuzzy
 #~ msgid "[<remote>:]<network> <listen_address> [<default_target_address>]"
 #~ msgstr "No se puede proveer el nombre del container a la lista"
-
-#, fuzzy
-#~ msgid "Admin password for %s:"
-#~ msgstr "Contraseña admin para %s: "

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -725,7 +725,7 @@ msgstr "--console fonctionne seulement avec une instance seule"
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
@@ -745,7 +745,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
@@ -764,17 +764,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -817,7 +817,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -984,7 +984,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -1099,7 +1099,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1282,7 +1282,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1357,7 +1357,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1426,8 +1426,8 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1517,7 +1517,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1641,12 +1641,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1685,7 +1685,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -2025,8 +2025,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2089,8 +2089,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2313,7 +2313,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2451,7 +2451,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2461,7 +2461,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2720,12 +2720,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2838,7 +2838,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2896,11 +2896,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -3335,7 +3335,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
@@ -3358,7 +3358,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3441,7 +3441,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3885,7 +3885,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -4092,7 +4092,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -4598,7 +4598,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr "NOM"
@@ -4625,7 +4625,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr "NON"
 
@@ -4867,7 +4867,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4943,11 +4943,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4992,7 +4992,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5011,7 +5011,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -5327,28 +5327,28 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
@@ -5357,7 +5357,7 @@ msgstr "le serveur distant %s est statique et ne peut être modifié"
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5457,7 +5457,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5521,7 +5521,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5549,7 +5549,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5693,7 +5693,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5737,11 +5737,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -5970,7 +5970,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6046,7 +6046,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6115,7 +6115,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6125,7 +6125,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
@@ -6234,12 +6234,12 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
@@ -6461,7 +6461,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6674,7 +6674,7 @@ msgstr "le périphérique indiqué ne correspond pas au réseau"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6734,7 +6734,7 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6788,6 +6788,11 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6828,7 +6833,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr "URL"
 
@@ -6897,7 +6902,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -6921,7 +6926,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7062,7 +7067,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7218,7 +7223,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr "OUI"
 
@@ -7626,7 +7631,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
@@ -7672,7 +7677,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7680,7 +7685,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8546,7 +8551,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8570,7 +8575,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8614,7 +8619,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8721,19 +8726,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -9000,7 +9002,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -9013,7 +9015,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9050,7 +9052,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr "o"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1064,7 +1064,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,8 +1132,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1212,7 +1212,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1661,8 +1661,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1725,8 +1725,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2059,7 +2059,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2303,12 +2303,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2416,7 +2416,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2474,11 +2474,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3537,7 +3537,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4011,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4311,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4676,28 +4676,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4706,7 +4706,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4792,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4849,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4875,7 +4875,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4994,7 +4994,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5035,11 +5035,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5250,7 +5250,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5383,7 +5383,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5391,7 +5391,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5481,11 +5481,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5693,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5895,7 +5895,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5949,7 +5949,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6003,6 +6003,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6041,7 +6046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6109,7 +6114,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6129,7 +6134,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6245,7 +6250,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6392,7 +6397,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6598,7 +6603,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6620,11 +6625,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7021,7 +7026,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7029,7 +7034,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7049,7 +7054,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7155,19 +7160,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7412,7 +7414,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7424,7 +7426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7461,7 +7463,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -721,7 +721,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -759,15 +759,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -1064,7 +1064,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1243,7 +1243,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1315,7 +1315,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1384,8 +1384,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1464,7 +1464,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1582,12 +1582,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1928,8 +1928,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1992,8 +1992,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2209,7 +2209,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -2338,7 +2338,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2348,7 +2348,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2585,12 +2585,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2700,7 +2700,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2738,7 +2738,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2758,11 +2758,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -3172,7 +3172,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
@@ -3195,7 +3195,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3278,7 +3278,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3658,7 +3658,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3861,7 +3861,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -4341,7 +4341,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4368,7 +4368,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4598,7 +4598,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4669,11 +4669,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4716,7 +4716,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4735,7 +4735,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -5041,37 +5041,38 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
 #: lxc/remote.go:101
+#, fuzzy
 msgid "Remote admin password"
-msgstr ""
+msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5163,7 +5164,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5222,7 +5223,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5248,7 +5249,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5373,7 +5374,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5414,11 +5415,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5431,7 +5432,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -5635,7 +5636,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5707,7 +5708,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5774,7 +5775,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "errore di processamento degli alias %s\n"
@@ -5783,7 +5784,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5881,11 +5882,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6097,7 +6098,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6301,7 +6302,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Il nome del container è: %s"
@@ -6357,7 +6358,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6411,6 +6412,11 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6450,7 +6456,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6519,7 +6525,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6542,7 +6548,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6668,7 +6674,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6817,7 +6823,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -7066,7 +7072,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
@@ -7093,12 +7099,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7586,7 +7592,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -7596,7 +7602,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
@@ -7621,7 +7627,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7727,19 +7733,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7984,7 +7987,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -7997,7 +8000,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8034,7 +8037,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 
@@ -8270,7 +8273,3 @@ msgstr "si"
 #, fuzzy
 #~ msgid "[<remote>:]<network> <listen_address> [<default_target_address>]"
 #~ msgstr "Creazione del container in corso"
-
-#, fuzzy
-#~ msgid "Admin password for %s:"
-#~ msgstr "Password amministratore per %s: "

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -95,7 +95,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -712,7 +712,7 @@ msgstr "--console は単一のインスタンスのときのみ指定できま�
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
@@ -732,7 +732,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
@@ -749,15 +749,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -792,7 +792,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -962,7 +962,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -1075,7 +1075,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1280,7 +1280,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1332,7 +1332,7 @@ msgid ""
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1346,7 +1346,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1400,8 +1400,8 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1484,7 +1484,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1617,12 +1617,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1661,7 +1661,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -1956,8 +1956,8 @@ msgstr "警告を削除します"
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2020,8 +2020,8 @@ msgstr "警告を削除します"
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2241,7 +2241,7 @@ msgstr "プロファイル設定をYAMLで編集します"
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを編集します"
@@ -2377,7 +2377,7 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2387,7 +2387,7 @@ msgstr "イメージの取得中: %s"
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
@@ -2636,12 +2636,12 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2765,7 +2765,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2803,7 +2803,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2823,11 +2823,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -3245,7 +3245,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
@@ -3268,7 +3268,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3357,7 +3357,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3850,7 +3850,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -4079,7 +4079,7 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを管理します"
@@ -4555,7 +4555,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr "NAME"
@@ -4582,7 +4582,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr "NO"
 
@@ -4814,7 +4814,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4885,11 +4885,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4930,7 +4930,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -4949,7 +4949,7 @@ msgstr "終了するには ctrl+c を押してください"
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -5257,28 +5257,28 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
@@ -5287,7 +5287,7 @@ msgstr "リモート %s は static ですので変更できません"
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
@@ -5377,7 +5377,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5436,7 +5436,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -5463,7 +5463,7 @@ msgstr "レンダー: %s (%s)"
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5589,7 +5589,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5631,11 +5631,11 @@ msgstr "直接リクエスト (raw query) を LXD に送ります"
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -5648,7 +5648,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -5904,7 +5904,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -5981,7 +5981,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6048,7 +6048,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを表示します"
@@ -6057,7 +6057,7 @@ msgstr "インスタンスのメタデータファイルを表示します"
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
@@ -6147,11 +6147,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -6359,7 +6359,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6569,7 +6569,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6640,7 +6640,7 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6696,6 +6696,11 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
+#: lxc/remote.go:564
+#, fuzzy, c-format
+msgid "Trust token for %s: "
+msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6736,7 +6741,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr "URL"
 
@@ -6804,7 +6809,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
@@ -6825,7 +6830,7 @@ msgstr "デバイスの設定を削除します"
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -6950,7 +6955,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7106,7 +7111,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr "YES"
 
@@ -7321,7 +7326,7 @@ msgstr "[<remote>:]<image> [<target>]"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -7343,12 +7348,12 @@ msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
@@ -7766,7 +7771,7 @@ msgstr "[<remote>:]<zone> <record> <type> <value>"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
@@ -7774,7 +7779,7 @@ msgstr "[<remote>:][<instance>[/<snapshot>]]"
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
@@ -7796,7 +7801,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr "現在値"
 
@@ -7929,15 +7934,13 @@ msgstr ""
 "    インスタンスの設定を config.yaml を使って更新します。"
 
 #: lxc/config.go:522
+#, fuzzy
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    インスタンスの設定値 limits.cpu を \"2\" に設定します。\n"
@@ -7948,7 +7951,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 #, fuzzy
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
@@ -7957,7 +7960,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8315,7 +8318,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr "n"
 
@@ -8327,7 +8330,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -8366,7 +8369,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr "y"
 
@@ -8374,10 +8377,6 @@ msgstr "y"
 #: lxc/image.go:1131
 msgid "yes"
 msgstr "yes"
-
-#, fuzzy, c-format
-#~ msgid "Trust token for %s: "
-#~ msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
 #~ msgid ""
 #~ "lxc init ubuntu:22.04 u1\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1060,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1128,8 +1128,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1208,7 +1208,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1657,8 +1657,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1721,8 +1721,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1931,7 +1931,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2065,7 +2065,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2299,12 +2299,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2412,7 +2412,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,11 +2470,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3533,7 +3533,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3980,7 +3980,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4007,7 +4007,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4371,7 +4371,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4672,28 +4672,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4702,7 +4702,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4788,7 +4788,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4845,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4871,7 +4871,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5031,11 +5031,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5048,7 +5048,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5246,7 +5246,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5379,7 +5379,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5387,7 +5387,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5477,11 +5477,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5689,7 +5689,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5891,7 +5891,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5945,7 +5945,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5999,6 +5999,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6037,7 +6042,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6125,7 +6130,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6241,7 +6246,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6594,7 +6599,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6616,11 +6621,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7017,7 +7022,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7025,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7045,7 +7050,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7151,19 +7156,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7408,7 +7410,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7420,7 +7422,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7457,7 +7459,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-06-12 10:01+0200\n"
+        "POT-Creation-Date: 2024-06-13 10:35+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid   "### This is a YAML representation of the UEFI variables configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -446,7 +446,7 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
@@ -466,7 +466,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797 lxc/info.go:452
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794 lxc/info.go:452
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -482,15 +482,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -522,7 +522,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -664,7 +664,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -771,7 +771,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -947,7 +947,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -971,7 +971,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -1017,7 +1017,7 @@ msgstr  ""
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -1031,7 +1031,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1085,7 +1085,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738 lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:174 lxc/network_forward.go:239 lxc/network_forward.go:456 lxc/network_forward.go:579 lxc/network_forward.go:721 lxc/network_forward.go:798 lxc/network_forward.go:864 lxc/network_load_balancer.go:176 lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459 lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725 lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865 lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:358 lxc/storage_volume.go:560 lxc/storage_volume.go:639 lxc/storage_volume.go:883 lxc/storage_volume.go:1097 lxc/storage_volume.go:1210 lxc/storage_volume.go:1678 lxc/storage_volume.go:1758 lxc/storage_volume.go:1885 lxc/storage_volume.go:2031 lxc/storage_volume.go:2135 lxc/storage_volume.go:2175 lxc/storage_volume.go:2268 lxc/storage_volume.go:2340 lxc/storage_volume.go:2492
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735 lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:174 lxc/network_forward.go:239 lxc/network_forward.go:456 lxc/network_forward.go:579 lxc/network_forward.go:721 lxc/network_forward.go:798 lxc/network_forward.go:864 lxc/network_load_balancer.go:176 lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459 lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725 lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865 lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:358 lxc/storage_volume.go:560 lxc/storage_volume.go:639 lxc/storage_volume.go:883 lxc/storage_volume.go:1097 lxc/storage_volume.go:1210 lxc/storage_volume.go:1678 lxc/storage_volume.go:1758 lxc/storage_volume.go:1885 lxc/storage_volume.go:2031 lxc/storage_volume.go:2135 lxc/storage_volume.go:2175 lxc/storage_volume.go:2268 lxc/storage_volume.go:2340 lxc/storage_volume.go:2492
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1136,7 +1136,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272 lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686 lxc/network_acl.go:620 lxc/network_forward.go:685 lxc/network_load_balancer.go:689 lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016 lxc/storage_volume.go:1048
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272 lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686 lxc/network_acl.go:620 lxc/network_forward.go:685 lxc/network_load_balancer.go:689 lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016 lxc/storage_volume.go:1048
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1240,12 +1240,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1284,7 +1284,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1543,7 +1543,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172 lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354 lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:171 lxc/network_forward.go:236 lxc/network_forward.go:379 lxc/network_forward.go:448 lxc/network_forward.go:546 lxc/network_forward.go:576 lxc/network_forward.go:718 lxc/network_forward.go:780 lxc/network_forward.go:795 lxc/network_forward.go:860 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383 lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549 lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722 lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90 lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824 lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:263 lxc/storage_volume.go:354 lxc/storage_volume.go:557 lxc/storage_volume.go:636 lxc/storage_volume.go:711 lxc/storage_volume.go:793 lxc/storage_volume.go:874 lxc/storage_volume.go:1083 lxc/storage_volume.go:1198 lxc/storage_volume.go:1345 lxc/storage_volume.go:1429 lxc/storage_volume.go:1674 lxc/storage_volume.go:1755 lxc/storage_volume.go:1870 lxc/storage_volume.go:2014 lxc/storage_volume.go:2123 lxc/storage_volume.go:2169 lxc/storage_volume.go:2266 lxc/storage_volume.go:2333 lxc/storage_volume.go:2487 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930 lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172 lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354 lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:171 lxc/network_forward.go:236 lxc/network_forward.go:379 lxc/network_forward.go:448 lxc/network_forward.go:546 lxc/network_forward.go:576 lxc/network_forward.go:718 lxc/network_forward.go:780 lxc/network_forward.go:795 lxc/network_forward.go:860 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383 lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549 lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722 lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90 lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838 lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:263 lxc/storage_volume.go:354 lxc/storage_volume.go:557 lxc/storage_volume.go:636 lxc/storage_volume.go:711 lxc/storage_volume.go:793 lxc/storage_volume.go:874 lxc/storage_volume.go:1083 lxc/storage_volume.go:1198 lxc/storage_volume.go:1345 lxc/storage_volume.go:1429 lxc/storage_volume.go:1674 lxc/storage_volume.go:1755 lxc/storage_volume.go:1870 lxc/storage_volume.go:2014 lxc/storage_volume.go:2123 lxc/storage_volume.go:2169 lxc/storage_volume.go:2266 lxc/storage_volume.go:2333 lxc/storage_volume.go:2487 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1723,7 +1723,7 @@ msgstr  ""
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid   "Edit instance UEFI variables"
 msgstr  ""
 
@@ -1842,12 +1842,12 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194 lxc/network_acl.go:467 lxc/network_forward.go:519 lxc/network_load_balancer.go:522 lxc/network_peer.go:463 lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856 lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597 lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194 lxc/network_acl.go:467 lxc/network_forward.go:519 lxc/network_load_balancer.go:522 lxc/network_peer.go:463 lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856 lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597 lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid   "Error unsetting properties: %v"
 msgstr  ""
@@ -2071,12 +2071,12 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -2170,7 +2170,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1446 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2206,7 +2206,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2226,11 +2226,11 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
@@ -2622,7 +2622,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid   "Instance name must be specified"
 msgstr  ""
 
@@ -2644,7 +2644,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2724,7 +2724,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -3074,7 +3074,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3267,7 +3267,7 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid   "Manage instance UEFI variables"
 msgstr  ""
 
@@ -3638,7 +3638,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid   "NAME"
 msgstr  ""
 
@@ -3662,7 +3662,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid   "NO"
 msgstr  ""
 
@@ -3889,7 +3889,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3960,11 +3960,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4005,7 +4005,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -4022,7 +4022,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:686 lxc/network_load_balancer.go:690 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017 lxc/storage_volume.go:1049
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:686 lxc/network_load_balancer.go:690 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017 lxc/storage_volume.go:1049
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4300,27 +4300,27 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901 lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915 lxc/remote.go:955
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
@@ -4329,7 +4329,7 @@ msgstr  ""
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
@@ -4415,7 +4415,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4471,7 +4471,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4497,7 +4497,7 @@ msgstr  ""
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid   "Requested UEFI variable does not exist"
 msgstr  ""
 
@@ -4613,7 +4613,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid   "STATIC"
 msgstr  ""
 
@@ -4654,11 +4654,11 @@ msgstr  ""
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -4671,7 +4671,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
@@ -4841,7 +4841,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4909,7 +4909,7 @@ msgstr  ""
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid   "Set the key as an instance property"
 msgstr  ""
 
@@ -4970,7 +4970,7 @@ msgstr  ""
 msgid   "Show image properties"
 msgstr  ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid   "Show instance UEFI variables"
 msgstr  ""
 
@@ -4978,7 +4978,7 @@ msgstr  ""
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid   "Show instance or server configurations"
 msgstr  ""
 
@@ -5066,11 +5066,11 @@ msgid   "Show the current identity\n"
         "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid   "Show the expanded configuration"
 msgstr  ""
 
@@ -5278,7 +5278,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5473,7 +5473,7 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
@@ -5522,7 +5522,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777 lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774 lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5575,6 +5575,11 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid   "Trust token for %s: "
+msgstr  ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
@@ -5610,7 +5615,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid   "URL"
 msgstr  ""
 
@@ -5675,7 +5680,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
@@ -5695,7 +5700,7 @@ msgstr  ""
 msgid   "Unset image properties"
 msgstr  ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -5811,7 +5816,7 @@ msgstr  ""
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
@@ -5948,7 +5953,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid   "YES"
 msgstr  ""
 
@@ -6144,7 +6149,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53 lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53 lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -6164,11 +6169,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid   "[<remote>:]<instance> <key>"
 msgstr  ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
@@ -6540,7 +6545,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6548,7 +6553,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
@@ -6568,7 +6573,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid   "current"
 msgstr  ""
 
@@ -6658,18 +6663,15 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"
         "lxc config set core.https_address=[::]:8443\n"
-        "    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-        "\n"
-        "lxc config set core.trust_password=blah\n"
-        "    Will set the server's trust password to blah."
+        "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr  ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid   "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
         "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr  ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid   "lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
         "    Set a UEFI variable with name \"testvar\", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for the instance."
 msgstr  ""
@@ -6868,7 +6870,7 @@ msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid   "n"
 msgstr  ""
 
@@ -6880,7 +6882,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6917,7 +6919,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -99,7 +99,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -702,7 +702,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -739,15 +739,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -780,7 +780,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1037,7 +1037,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1287,7 +1287,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1355,8 +1355,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1435,7 +1435,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1553,12 +1553,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1884,8 +1884,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1948,8 +1948,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2158,7 +2158,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2526,12 +2526,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2639,7 +2639,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2677,7 +2677,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2697,11 +2697,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -3096,7 +3096,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3118,7 +3118,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3199,7 +3199,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3565,7 +3565,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3760,7 +3760,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4207,7 +4207,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4234,7 +4234,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4463,7 +4463,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4534,11 +4534,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4579,7 +4579,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4598,7 +4598,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4899,28 +4899,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4929,7 +4929,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5015,7 +5015,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5072,7 +5072,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5098,7 +5098,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5217,7 +5217,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5258,11 +5258,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5275,7 +5275,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5473,7 +5473,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5541,7 +5541,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5606,7 +5606,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5614,7 +5614,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5704,11 +5704,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5916,7 +5916,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6118,7 +6118,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6172,7 +6172,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6226,6 +6226,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6264,7 +6269,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6332,7 +6337,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6352,7 +6357,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6468,7 +6473,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6615,7 +6620,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6821,7 +6826,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6843,11 +6848,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7244,7 +7249,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7252,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7272,7 +7277,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7378,19 +7383,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7635,7 +7637,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7647,7 +7649,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7684,7 +7686,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -740,7 +740,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -777,15 +777,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1075,7 +1075,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1325,7 +1325,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1339,7 +1339,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1393,8 +1393,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1473,7 +1473,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1591,12 +1591,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1635,7 +1635,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1922,8 +1922,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1986,8 +1986,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2320,7 +2320,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2330,7 +2330,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2564,12 +2564,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2677,7 +2677,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -3134,7 +3134,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3156,7 +3156,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3237,7 +3237,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3603,7 +3603,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3798,7 +3798,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4245,7 +4245,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4272,7 +4272,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4501,7 +4501,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4572,11 +4572,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4617,7 +4617,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4636,7 +4636,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4937,28 +4937,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5053,7 +5053,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5110,7 +5110,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5136,7 +5136,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5255,7 +5255,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5296,11 +5296,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5313,7 +5313,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5511,7 +5511,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5579,7 +5579,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5644,7 +5644,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5742,11 +5742,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5954,7 +5954,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6156,7 +6156,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6210,7 +6210,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6264,6 +6264,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6302,7 +6307,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6370,7 +6375,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6390,7 +6395,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6506,7 +6511,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6653,7 +6658,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6859,7 +6864,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6881,11 +6886,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7282,7 +7287,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7290,7 +7295,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7310,7 +7315,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7416,19 +7421,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7673,7 +7675,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7685,7 +7687,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7722,7 +7724,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1060,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1128,8 +1128,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1208,7 +1208,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1657,8 +1657,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1721,8 +1721,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1931,7 +1931,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2065,7 +2065,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2299,12 +2299,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2412,7 +2412,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,11 +2470,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3533,7 +3533,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3980,7 +3980,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4007,7 +4007,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4371,7 +4371,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4672,28 +4672,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4702,7 +4702,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4788,7 +4788,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4845,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4871,7 +4871,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5031,11 +5031,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5048,7 +5048,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5246,7 +5246,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5379,7 +5379,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5387,7 +5387,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5477,11 +5477,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5689,7 +5689,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5891,7 +5891,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5945,7 +5945,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5999,6 +5999,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6037,7 +6042,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6125,7 +6130,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6241,7 +6246,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6594,7 +6599,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6616,11 +6621,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7017,7 +7022,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7025,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7045,7 +7050,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7151,19 +7156,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7408,7 +7410,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7420,7 +7422,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7457,7 +7459,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -102,7 +102,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -730,7 +730,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
@@ -755,7 +755,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -1088,7 +1088,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1268,7 +1268,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1293,7 +1293,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1341,7 +1341,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1410,8 +1410,8 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1499,7 +1499,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1619,12 +1619,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1663,7 +1663,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1980,8 +1980,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2044,8 +2044,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2266,7 +2266,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -2403,7 +2403,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2413,7 +2413,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2648,12 +2648,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2762,7 +2762,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2800,7 +2800,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2820,11 +2820,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -3241,7 +3241,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3263,7 +3263,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3345,7 +3345,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3720,7 +3720,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3922,7 +3922,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -4407,7 +4407,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4434,7 +4434,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4734,11 +4734,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4799,7 +4799,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -5108,37 +5108,38 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
 #: lxc/remote.go:101
+#, fuzzy
 msgid "Remote admin password"
-msgstr ""
+msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5236,7 +5237,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5297,7 +5298,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5323,7 +5324,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5452,7 +5453,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5493,11 +5494,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5510,7 +5511,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -5721,7 +5722,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5796,7 +5797,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5865,7 +5866,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -5875,7 +5876,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5978,11 +5979,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6193,7 +6194,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6399,7 +6400,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nome de membro do cluster"
@@ -6455,7 +6456,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6509,6 +6510,11 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6548,7 +6554,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6617,7 +6623,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6642,7 +6648,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6777,7 +6783,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6926,7 +6932,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -7157,7 +7163,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -7179,12 +7185,12 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -7625,7 +7631,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7633,7 +7639,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7656,7 +7662,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7762,19 +7768,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8019,7 +8022,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -8031,7 +8034,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8068,7 +8071,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 
@@ -8229,10 +8232,6 @@ msgstr "sim"
 #~ "### type: bridge\n"
 #~ "###\n"
 #~ "### Note que o nome é exibido, porém não pode ser alterado."
-
-#, fuzzy
-#~ msgid "Admin password for %s:"
-#~ msgstr "Senha de administrador para %s: "
 
 #~ msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 #~ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -735,7 +735,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -755,7 +755,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -819,7 +819,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -1085,7 +1085,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1290,7 +1290,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1338,7 +1338,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1407,8 +1407,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1487,7 +1487,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1607,12 +1607,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1651,7 +1651,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -1966,8 +1966,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2030,8 +2030,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2247,7 +2247,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2379,7 +2379,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2632,12 +2632,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2784,7 +2784,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3226,7 +3226,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
@@ -3249,7 +3249,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3331,7 +3331,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3714,7 +3714,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3917,7 +3917,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4408,7 +4408,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4435,7 +4435,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4668,7 +4668,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4739,11 +4739,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4804,7 +4804,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -5109,37 +5109,38 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
 #: lxc/remote.go:101
+#, fuzzy
 msgid "Remote admin password"
-msgstr ""
+msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5231,7 +5232,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5292,7 +5293,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5320,7 +5321,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5446,7 +5447,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5487,11 +5488,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5504,7 +5505,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5710,7 +5711,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5786,7 +5787,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5854,7 +5855,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5864,7 +5865,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5964,11 +5965,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6183,7 +6184,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6385,7 +6386,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Копирование образа: %s"
@@ -6440,7 +6441,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6494,6 +6495,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6533,7 +6539,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6601,7 +6607,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6623,7 +6629,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6757,7 +6763,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6906,7 +6912,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -7272,7 +7278,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
@@ -7314,7 +7320,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7322,7 +7328,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8087,7 +8093,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8103,7 +8109,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8143,7 +8149,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -8249,19 +8255,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8506,7 +8509,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -8518,7 +8521,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8555,7 +8558,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 
@@ -8934,7 +8937,3 @@ msgstr "да"
 #~ "Изменение состояния одного или нескольких контейнеров %s.\n"
 #~ "\n"
 #~ "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#, fuzzy
-#~ msgid "Admin password for %s:"
-#~ msgstr "Пароль администратора для %s: "

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1064,7 +1064,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,8 +1132,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1212,7 +1212,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1661,8 +1661,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1725,8 +1725,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2059,7 +2059,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2303,12 +2303,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2416,7 +2416,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2474,11 +2474,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3537,7 +3537,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4011,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4311,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4676,28 +4676,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4706,7 +4706,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4792,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4849,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4875,7 +4875,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4994,7 +4994,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5035,11 +5035,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5250,7 +5250,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5383,7 +5383,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5391,7 +5391,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5481,11 +5481,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5693,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5895,7 +5895,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5949,7 +5949,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6003,6 +6003,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6041,7 +6046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6109,7 +6114,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6129,7 +6134,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6245,7 +6250,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6392,7 +6397,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6598,7 +6603,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6620,11 +6625,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7021,7 +7026,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7029,7 +7034,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7049,7 +7054,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7155,19 +7160,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7412,7 +7414,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7424,7 +7426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7461,7 +7463,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1064,7 +1064,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,8 +1132,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1212,7 +1212,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1661,8 +1661,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1725,8 +1725,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2059,7 +2059,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2303,12 +2303,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2416,7 +2416,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2474,11 +2474,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3537,7 +3537,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4011,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4311,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4676,28 +4676,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4706,7 +4706,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4792,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4849,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4875,7 +4875,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4994,7 +4994,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5035,11 +5035,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5250,7 +5250,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5383,7 +5383,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5391,7 +5391,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5481,11 +5481,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5693,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5895,7 +5895,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5949,7 +5949,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6003,6 +6003,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6041,7 +6046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6109,7 +6114,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6129,7 +6134,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6245,7 +6250,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6392,7 +6397,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6598,7 +6603,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6620,11 +6625,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7021,7 +7026,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7029,7 +7034,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7049,7 +7054,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7155,19 +7160,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7412,7 +7414,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7424,7 +7426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7461,7 +7463,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1060,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1128,8 +1128,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1208,7 +1208,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1657,8 +1657,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1721,8 +1721,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1931,7 +1931,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2065,7 +2065,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2299,12 +2299,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2412,7 +2412,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,11 +2470,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3533,7 +3533,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3980,7 +3980,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4007,7 +4007,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4371,7 +4371,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4672,28 +4672,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4702,7 +4702,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4788,7 +4788,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4845,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4871,7 +4871,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5031,11 +5031,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5048,7 +5048,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5246,7 +5246,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5379,7 +5379,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5387,7 +5387,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5477,11 +5477,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5689,7 +5689,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5891,7 +5891,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5945,7 +5945,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5999,6 +5999,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6037,7 +6042,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6125,7 +6130,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6241,7 +6246,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6388,7 +6393,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6594,7 +6599,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6616,11 +6621,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7017,7 +7022,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7025,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7045,7 +7050,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7151,19 +7156,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7408,7 +7410,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7420,7 +7422,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7457,7 +7459,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1064,7 +1064,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,8 +1132,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1212,7 +1212,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1661,8 +1661,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1725,8 +1725,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2059,7 +2059,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2303,12 +2303,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2416,7 +2416,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2474,11 +2474,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3537,7 +3537,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4011,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4311,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4676,28 +4676,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4706,7 +4706,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4792,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4849,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4875,7 +4875,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4994,7 +4994,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5035,11 +5035,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5052,7 +5052,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5250,7 +5250,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5383,7 +5383,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5391,7 +5391,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5481,11 +5481,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5693,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5895,7 +5895,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5949,7 +5949,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6003,6 +6003,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6041,7 +6046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6109,7 +6114,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6129,7 +6134,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6245,7 +6250,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6392,7 +6397,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6598,7 +6603,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6620,11 +6625,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7021,7 +7026,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7029,7 +7034,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7049,7 +7054,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7155,19 +7160,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7412,7 +7414,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7424,7 +7426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7461,7 +7463,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -639,7 +639,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -659,7 +659,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -676,15 +676,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -974,7 +974,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1224,7 +1224,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1292,8 +1292,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1372,7 +1372,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1490,12 +1490,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1821,8 +1821,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1885,8 +1885,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2095,7 +2095,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2463,12 +2463,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2576,7 +2576,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2634,11 +2634,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3055,7 +3055,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3136,7 +3136,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3502,7 +3502,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3697,7 +3697,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4144,7 +4144,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4171,7 +4171,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4400,7 +4400,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4471,11 +4471,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4516,7 +4516,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4535,7 +4535,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4836,28 +4836,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4866,7 +4866,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4952,7 +4952,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -5009,7 +5009,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -5035,7 +5035,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5195,11 +5195,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5212,7 +5212,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5410,7 +5410,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5478,7 +5478,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5543,7 +5543,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5551,7 +5551,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5641,11 +5641,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5853,7 +5853,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6109,7 +6109,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6163,6 +6163,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6201,7 +6206,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6269,7 +6274,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6289,7 +6294,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6405,7 +6410,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6552,7 +6557,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6758,7 +6763,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6780,11 +6785,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7181,7 +7186,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7189,7 +7194,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7209,7 +7214,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7315,19 +7320,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7572,7 +7574,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7584,7 +7586,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7621,7 +7623,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-12 10:01+0200\n"
+"POT-Creation-Date: 2024-06-13 10:35+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1177
+#: lxc/config.go:1174
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:472 lxc/config.go:771
+#: lxc/config.go:472 lxc/config.go:768
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:595 lxc/config.go:794
 #: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:821 lxc/remote.go:878
+#: lxc/remote.go:835 lxc/remote.go:892
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:918
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:748
+#: lxc/remote.go:762
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:744
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:574
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:544
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:857
+#: lxc/remote.go:871
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:664 lxc/config.go:1034
+#: lxc/config.go:661 lxc/config.go:1031
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:447
+#: lxc/remote.go:450
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:599
+#: lxc/remote.go:613
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:529 lxc/config.go:735
+#: lxc/config.go:858 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:174 lxc/network_forward.go:239
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
-#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config.go:347 lxc/config.go:1274 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:685
 #: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:482
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:466
+#: lxc/remote.go:224 lxc/remote.go:469
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1660,8 +1660,8 @@ msgstr ""
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
 #: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
-#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
-#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930
+#: lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
-#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
+#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1163 lxc/config.go:1164
+#: lxc/config.go:1160 lxc/config.go:1161
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:621 lxc/config.go:653 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:519
 #: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:618 lxc/config.go:650
+#: lxc/config.go:615 lxc/config.go:647
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:259
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:266
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:733
+#: lxc/remote.go:747
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,11 +2473,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:393
+#: lxc/remote.go:159 lxc/remote.go:396
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:932 lxc/config.go:933
+#: lxc/config.go:929 lxc/config.go:930
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#: lxc/config.go:955 lxc/config.go:1013 lxc/config.go:1132 lxc/config.go:1224
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:348
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:334
+#: lxc/remote.go:337
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:664 lxc/remote.go:665
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "List the available remotes"
 msgstr ""
 
@@ -3536,7 +3536,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:892 lxc/config.go:893
+#: lxc/config.go:889 lxc/config.go:890
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:328
+#: lxc/remote.go:331
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:743
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:731
+#: lxc/image.go:1073 lxc/remote.go:745
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:461
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
-#: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
+#: lxc/config.go:1275 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:686
 #: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
@@ -4675,28 +4675,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:795
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
-#: lxc/remote.go:941
+#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
+#: lxc/remote.go:955
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:300
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:853
+#: lxc/remote.go:867
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
+#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:294
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:823 lxc/remote.go:824
+#: lxc/remote.go:837 lxc/remote.go:838
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:750 lxc/remote.go:751
+#: lxc/remote.go:764 lxc/remote.go:765
 msgid "Rename remotes"
 msgstr ""
 
@@ -4874,7 +4874,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:969
+#: lxc/config.go:966
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:746
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5034,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:459
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:595
+#: lxc/remote.go:609
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:987 lxc/config.go:988
+#: lxc/config.go:984 lxc/config.go:985
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5249,7 +5249,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:533
+#: lxc/config.go:530
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1109 lxc/config.go:1110
+#: lxc/config.go:1106 lxc/config.go:1107
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5390,7 +5390,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:733 lxc/config.go:734
+#: lxc/config.go:730 lxc/config.go:731
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5480,11 +5480,11 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:626 lxc/remote.go:627
+#: lxc/remote.go:640 lxc/remote.go:641
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:737
+#: lxc/config.go:734
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:879 lxc/remote.go:880
+#: lxc/remote.go:893 lxc/remote.go:894
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:636
+#: lxc/config.go:633
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5948,7 +5948,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:682 lxc/config.go:774
 #: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6002,6 +6002,11 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
+#: lxc/remote.go:564
+#, c-format
+msgid "Trust token for %s: "
+msgstr ""
+
 #: lxc/action.go:287 lxc/launch.go:114
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
@@ -6040,7 +6045,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:728
+#: lxc/cluster.go:184 lxc/remote.go:742
 msgid "URL"
 msgstr ""
 
@@ -6108,7 +6113,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1078 lxc/config.go:1079
+#: lxc/config.go:1075 lxc/config.go:1076
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6128,7 +6133,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:857 lxc/config.go:858
+#: lxc/config.go:854 lxc/config.go:855
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6244,7 +6249,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:862
+#: lxc/config.go:859
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6391,7 +6396,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
+#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "YES"
 msgstr ""
 
@@ -6597,7 +6602,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config.go:1105 lxc/config.go:1159 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6619,11 +6624,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:931 lxc/config.go:1077
+#: lxc/config.go:928 lxc/config.go:1074
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:986
+#: lxc/config.go:983
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7020,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:97 lxc/config.go:732
+#: lxc/config.go:97 lxc/config.go:729
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7028,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:382 lxc/config.go:856
+#: lxc/config.go:382 lxc/config.go:853
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -7048,7 +7053,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:718
+#: lxc/project.go:488 lxc/remote.go:732
 msgid "current"
 msgstr ""
 
@@ -7154,19 +7159,16 @@ msgid ""
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "lxc config set core.https_address=[::]:8443\n"
-"    Will have LXD listen on IPv4 and IPv6 port 8443.\n"
-"\n"
-"lxc config set core.trust_password=blah\n"
-"    Will set the server's trust password to blah."
+"    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1166
+#: lxc/config.go:1163
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:990
+#: lxc/config.go:987
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7411,7 +7413,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:458
 msgid "n"
 msgstr ""
 
@@ -7423,7 +7425,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:448
+#: lxc/remote.go:451
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7460,7 +7462,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:460
 msgid "y"
 msgstr ""
 

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -111,7 +111,6 @@ _have lxc && {
       core.storage_buckets_address \
       core.syslog_socket \
       core.trust_ca_certificates \
-      core.trust_password \
       cluster.healing_threshold cluster.https_address cluster.images_minimal_replica cluster.join_token_expiry cluster.max_standby cluster.max_voters cluster.offline_threshold \
       images.auto_update_cached images.auto_update_interval \
       images.compression_algorithm images.default_architecture images.remote_cache_expiry \

--- a/shared/api/certificate.go
+++ b/shared/api/certificate.go
@@ -48,9 +48,9 @@ type CertificatesPost struct {
 	// API extension: certificate_self_renewal
 	Certificate string `json:"certificate" yaml:"certificate"`
 
-	// Server trust password (used to add an untrusted client)
+	// Server trust password (used to add an untrusted client, deprecated, use trust_token)
 	// Example: blah
-	Password string `json:"password" yaml:"password"`
+	Password string `json:"password" yaml:"password"` // Deprecated, use TrustToken.
 
 	// Trust token (used to add an untrusted client)
 	// Example: blah

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -82,11 +82,11 @@ type ClusterPut struct {
 	// API extension: clustering_join
 	ServerAddress string `json:"server_address" yaml:"server_address"`
 
-	// The trust password of the cluster you're trying to join
+	// The trust password of the cluster you're trying to join (deprecated, use cluster_token)
 	// Example: blah
 	//
 	// API extension: clustering_join
-	ClusterPassword string `json:"cluster_password" yaml:"cluster_password"`
+	ClusterPassword string `json:"cluster_password" yaml:"cluster_password"` // Deprecated, use ClusterToken.
 
 	// The cluster join token for the cluster you're trying to join
 	// Example: blah

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -157,7 +157,7 @@ type ServerStorageDriverInfo struct {
 // swagger:model
 type ServerPut struct {
 	// Server configuration map (refer to doc/server.md)
-	// Example: {"core.https_address": ":8443", "core.trust_password": "xyz"}
+	// Example: {"core.https_address": ":8443"}
 	Config map[string]any `json:"config" yaml:"config"`
 }
 

--- a/test/extras/stresstest.sh
+++ b/test/extras/stresstest.sh
@@ -102,9 +102,6 @@ spawn_lxd() {
 
   echo "==> Binding to network"
   LXD_DIR="$lxddir" lxc config set core.https_address "$addr"
-
-  echo "==> Setting trust password"
-  LXD_DIR="$lxddir" lxc config set core.trust_password foo
 }
 
 spawn_lxd 127.0.0.1:18443 "$LXD_DIR"

--- a/test/godeps/lxd-agent.list
+++ b/test/godeps/lxd-agent.list
@@ -178,7 +178,6 @@ golang.org/x/crypto/ed25519
 golang.org/x/crypto/internal/alias
 golang.org/x/crypto/internal/poly1305
 golang.org/x/crypto/pbkdf2
-golang.org/x/crypto/scrypt
 golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/net/bpf

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -60,8 +60,6 @@ spawn_lxd() {
         done
     fi
 
-    echo "==> Setting trust password"
-    LXD_DIR="${lxddir}" lxc config set core.trust_password foo
     if [ -n "${DEBUG:-}" ]; then
         set -x
     fi

--- a/test/includes/setup.sh
+++ b/test/includes/setup.sh
@@ -4,7 +4,8 @@ ensure_has_localhost_remote() {
     # shellcheck disable=SC2039,3043
     local addr="${1}"
     if ! lxc remote list | grep -q "localhost"; then
-        lxc remote add localhost "https://${addr}" --accept-certificate --password foo
+        token="$(lxc config trust add --name foo -q)"
+        lxc remote add localhost "https://${addr}" --accept-certificate --token "${token}"
     fi
 }
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -225,31 +225,22 @@ fine_grained_authorization() {
   lxc auth group permission remove test-group server can_view_warnings
 
   # Check we are not able to view any server config currently.
-  # Here we explicitly use two settings that contain actual passwords.
-  lxc config set core.trust_password foo2
-  lxc config set loki.auth.password bar2
+  # Here we explicitly a setting that contains an actual password.
+  lxc config set loki.auth.password bar
   [ "$(lxc_remote query oidc:/1.0 | jq '.config | length')" = 0 ]
-  [ "$(lxc_remote query oidc:/1.0 | jq -r '.config."core.trust_password"')" = "null" ]
   [ "$(lxc_remote query oidc:/1.0 | jq -r '.config."loki.auth.password"')" = "null" ]
 
   # Check we are not able to set any server config currently.
-  ! lxc_remote config set oidc: core.trust_password foo3 || false
-  ! lxc_remote config set oidc: loki.auth.password bar3 || false
+  ! lxc_remote config set oidc: loki.auth.password bar2 || false
 
   # Add "can_edit" permission to group.
   lxc auth group permission add test-group server can_edit
 
   # Check we can view the server's config.
-  # As the core.trust_password is stored as scrypt value together with its hash, we cannot easily compare it against the original value.
-  [ "$(lxc_remote query oidc:/1.0 | jq -r '.config."core.trust_password"')" != "null" ]
-  [ "$(lxc_remote query oidc:/1.0 | jq -r '.config."loki.auth.password"')" = "bar2" ]
+  [ "$(lxc_remote query oidc:/1.0 | jq -r '.config."loki.auth.password"')" = "bar" ]
 
   # Check we can modify the server's config.
-  lxc_remote config set oidc: core.trust_password foo3
-  lxc_remote config set oidc: loki.auth.password bar3
-
-  # Reset the trust password to prevent side effects.
-  lxc config set core.trust_password foo
+  lxc_remote config set oidc: loki.auth.password bar2
 
   lxc auth group permission remove test-group server can_edit
   lxc config unset loki.auth.password

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -656,11 +656,9 @@ test_basic_usage() {
 
   # Test rebuilding an instance with a new image.
   lxc init c1 --empty
-  lxc remote add l1 "${LXD_ADDR}" --accept-certificate --password foo
-  lxc rebuild l1:testimage c1
+  lxc rebuild testimage c1
   lxc start c1
   lxc delete c1 -f
-  lxc remote remove l1
 
   # Test rebuilding an instance with an empty file system.
   lxc init testimage c1
@@ -680,6 +678,8 @@ test_basic_usage() {
   lxc launch testimage c2
   lxc launch testimage c3
 
+  fingerprint="$(lxc config trust ls --format csv | cut -d, -f4)"
+  lxc config trust remove "${fingerprint}"
   lxc delete -f c1 c2 c3
   remaining_instances="$(lxc list --format csv)"
   [ -z "${remaining_instances}" ]

--- a/test/suites/clustering_instance_placement_scriptlet.sh
+++ b/test/suites/clustering_instance_placement_scriptlet.sh
@@ -28,14 +28,14 @@ test_clustering_instance_placement_scriptlet() {
   LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_TWO_DIR}"
   ns2="${prefix}2"
-  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}" "${poolDriver}"
+  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}" "${LXD_ONE_DIR}" "${poolDriver}"
 
   # Spawn a third node
   setup_clustering_netns 3
   LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_THREE_DIR}"
   ns3="${prefix}3"
-  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${poolDriver}"
+  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}" "${poolDriver}"
 
   LXD_DIR="${LXD_ONE_DIR}" ensure_import_testimage
 

--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -20,14 +20,14 @@ test_clustering_move() {
   LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_TWO_DIR}"
   ns2="${prefix}2"
-  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}"
+  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}" "${LXD_ONE_DIR}"
 
   # Spawn a third node
   setup_clustering_netns 3
   LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_THREE_DIR}"
   ns3="${prefix}3"
-  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}"
+  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}"
 
   ensure_import_testimage
 

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -8,9 +8,12 @@ test_image_expiry() {
 
   ensure_import_testimage
 
+  token="$(lxc config trust add --name foo -q)"
   # shellcheck disable=2153
-  lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --password foo
-  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --password foo
+  lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --token "${token}"
+
+  token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
+  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
 
   # Create containers from a remote image in two projects.
   lxc_remote project create l2:p1 -c features.images=true -c features.profiles=false
@@ -131,7 +134,8 @@ test_image_refresh() {
 
   ensure_import_testimage
 
-  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --password foo
+  token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
+  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
 
   poolDriver="$(lxc storage show "$(lxc profile device get default root pool)" | awk '/^driver:/ {print $2}')"
 

--- a/test/suites/image_auto_update.sh
+++ b/test/suites/image_auto_update.sh
@@ -13,7 +13,8 @@ test_image_auto_update() {
   (LXD_DIR=${LXD2_DIR} deps/import-busybox --alias testimage --public)
   fp1="$(LXD_DIR=${LXD2_DIR} lxc image info testimage | awk '/^Fingerprint/ {print $2}')"
 
-  lxc remote add l2 "${LXD2_ADDR}" --accept-certificate --password foo
+  token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
+  lxc remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
   lxc init l2:testimage c1
 
   # Now the first image image is in the local store, since it was

--- a/test/suites/image_prefer_cached.sh
+++ b/test/suites/image_prefer_cached.sh
@@ -16,7 +16,8 @@ test_image_prefer_cached() {
   (LXD_DIR=${LXD2_DIR} deps/import-busybox --alias testimage --public)
   fp1="$(LXD_DIR=${LXD2_DIR} lxc image info testimage | awk '/^Fingerprint/ {print $2}')"
 
-  lxc remote add l2 "${LXD2_ADDR}" --accept-certificate --password foo
+  token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
+  lxc remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
   lxc init l2:testimage c1
 
   # Now the first image image is in the local store, since it was

--- a/test/suites/init_auto.sh
+++ b/test/suites/init_auto.sh
@@ -57,12 +57,12 @@ test_init_auto() {
     kill_lxd "${LXD_INIT_DIR}"
   fi
 
-  # lxd init --trust-password test --network-address 127.0.0.1 --network-port LOCAL --auto
+  # lxd init --network-address 127.0.0.1 --network-port LOCAL --auto
   LXD_INIT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_INIT_DIR}"
   spawn_lxd "${LXD_INIT_DIR}" false
 
-  LXD_DIR=${LXD_INIT_DIR} lxd init --trust-password test --network-address 127.0.0.1 --network-port "$(local_tcp_port)" --auto
+  LXD_DIR=${LXD_INIT_DIR} lxd init --network-address 127.0.0.1 --network-port "$(local_tcp_port)" --auto
 
   kill_lxd "${LXD_INIT_DIR}"
 }

--- a/test/suites/init_dump.sh
+++ b/test/suites/init_dump.sh
@@ -45,12 +45,9 @@ profiles:
 EOF
   lxd init --dump > config.yaml
 
-  # XXX: mangle the trust_password field as a workaround
-  sed -i 's/^\( *core.trust_password\): .\+$/\1: true/' config.yaml
 cat <<EOF > expected.yaml
 config:
   core.https_address: 127.0.0.1:9999
-  core.trust_password: true
   images.auto_update_interval: "15"
 networks:
 - config:

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -13,9 +13,12 @@ test_migration() {
   # workaround for kernel/criu
   umount /sys/kernel/debug >/dev/null 2>&1 || true
 
+  token="$(lxc config trust add --name foo -q)"
   # shellcheck disable=2153
-  lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --password foo
-  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --password foo
+  lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --token "${token}"
+
+  token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
+  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
 
   migration "$LXD2_DIR"
 

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -521,7 +521,7 @@ test_projects_network() {
   # Create a container in the project
   lxc init -n "${network}" testimage c1
 
-  lxc network show "${network}" |grep -q "/1.0/instances/c1?project=foo"
+  lxc network show "${network}" | grep -q "/1.0/instances/c1?project=foo"
 
   # Delete the container
   lxc delete c1
@@ -754,7 +754,8 @@ test_projects_limits() {
     LXD_REMOTE_ADDR=$(cat "${LXD_REMOTE_DIR}/lxd.addr")
     (LXD_DIR=${LXD_REMOTE_DIR} deps/import-busybox --alias remoteimage --template start --public)
 
-    lxc remote add l2 "${LXD_REMOTE_ADDR}" --accept-certificate --password foo
+    token="$(LXD_DIR=${LXD_REMOTE_DIR} lxc config trust add --name foo -q)"
+    lxc remote add l2 "${LXD_REMOTE_ADDR}" --accept-certificate --token "${token}"
 
     # Relax all constraints except the disk limits, which won't be enough for the
     # image to be downloaded.

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -3,22 +3,10 @@ test_server_config() {
   spawn_lxd "${LXD_SERVERCONFIG_DIR}" true
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  _server_config_password
   _server_config_access
   _server_config_storage
 
   kill_lxd "${LXD_SERVERCONFIG_DIR}"
-}
-
-_server_config_password() {
-  lxc config set core.trust_password 123456
-
-  config=$(lxc config show)
-  echo "${config}" | grep -q "trust_password"
-  echo "${config}" | grep -q -v "123456"
-
-  lxc config unset core.trust_password
-  lxc config show | grep -q -v "trust_password"
 }
 
 _server_config_access() {

--- a/test/suites/sql.sh
+++ b/test/suites/sql.sh
@@ -8,14 +8,15 @@ test_sql() {
   lxd sql local "SELECT * FROM config" | grep -qF "core.https_address"
 
   # Global database query
-  lxd sql global "SELECT * FROM config" | grep -qF "core.trust_password"
+  lxc config set user.foo=bar
+  lxd sql global "SELECT * FROM config" | grep -qF "user.foo"
 
   # Global database insert
   lxd sql global "INSERT INTO config(key,value) VALUES('core.https_allowed_credentials','true')" | grep -qxF "Rows affected: 1"
   lxd sql global "DELETE FROM config WHERE key='core.https_allowed_credentials'" | grep -qxF "Rows affected: 1"
 
   # Standard input
-  echo "SELECT * FROM config" | lxd sql global - | grep -qF "core.trust_password"
+  echo "SELECT * FROM config" | lxd sql global - | grep -qF "user.foo"
 
   # Multiple queries
   lxd sql global "SELECT * FROM config; SELECT * FROM instances" | grep -qxF "=> Query 0:"

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -1,5 +1,6 @@
 test_storage_volume_snapshots() {
   ensure_import_testimage
+  ensure_has_localhost_remote "${LXD_ADDR}"
 
   # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
@@ -8,7 +9,6 @@ test_storage_volume_snapshots() {
   LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)
   chmod +x "${LXD_STORAGE_DIR}"
   spawn_lxd "${LXD_STORAGE_DIR}" false
-  lxc remote add test "${LXD_ADDR}" --accept-certificate --password foo
 
   # shellcheck disable=2039,3043
   local storage_pool storage_volume
@@ -160,7 +160,7 @@ test_storage_volume_snapshots() {
   lxc storage volume delete "${storage_pool}" "vol2"
 
   # Check snapshot copy (mode pull, remote).
-  lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool}/vol2" --mode pull
+  lxc storage volume copy "${storage_pool}/vol1/snap0" "localhost:${storage_pool}/vol2" --mode pull
   lxc launch testimage "c1"
   lxc storage volume attach "${storage_pool}" "vol2" "c1" /mnt
   lxc exec "c1" -- test -f /mnt/foo
@@ -176,7 +176,7 @@ test_storage_volume_snapshots() {
   lxc storage volume delete "${storage_pool}" "vol2"
 
   # Check snapshot copy (mode push, remote).
-  lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool}/vol2" --mode push
+  lxc storage volume copy "${storage_pool}/vol1/snap0" "localhost:${storage_pool}/vol2" --mode push
   lxc launch testimage "c1"
   lxc storage volume attach "${storage_pool}" "vol2" "c1" /mnt
   lxc exec "c1" -- test -f /mnt/foo
@@ -192,7 +192,7 @@ test_storage_volume_snapshots() {
   lxc storage volume delete "${storage_pool}" "vol2"
 
   # Check snapshot copy (mode relay, remote).
-  lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool}/vol2" --mode relay
+  lxc storage volume copy "${storage_pool}/vol1/snap0" "localhost:${storage_pool}/vol2" --mode relay
   lxc launch testimage "c1"
   lxc storage volume attach "${storage_pool}" "vol2" "c1" /mnt
   lxc exec "c1" -- test -f /mnt/foo
@@ -211,13 +211,13 @@ test_storage_volume_snapshots() {
 
   # Check snapshot copy between pools (remote).
   lxc storage create "${storage_pool2}" dir
-  lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool2}/vol2"
+  lxc storage volume copy "${storage_pool}/vol1/snap0" "localhost:${storage_pool2}/vol2"
   lxc launch testimage "c1"
   lxc storage volume attach "${storage_pool2}" "vol2" "c1" /mnt
   lxc exec "c1" -- test -f /mnt/foo
   lxc delete -f "c1"
   lxc storage volume delete "${storage_pool2}" "vol2"
-  lxc storage volume copy "test:${storage_pool}/vol1/snap0" "${storage_pool2}/vol2"
+  lxc storage volume copy "localhost:${storage_pool}/vol1/snap0" "${storage_pool2}/vol2"
   lxc launch testimage "c1"
   lxc storage volume attach "${storage_pool2}" "vol2" "c1" /mnt
   lxc exec "c1" -- test -f /mnt/foo
@@ -232,8 +232,8 @@ test_storage_volume_snapshots() {
   lxc storage volume delete "${storage_pool}" "vol2"
 
   # Check snapshot volume only copy (remote).
-  ! lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool}/vol2" --volume-only || false
-  lxc storage volume copy "${storage_pool}/vol1" "test:${storage_pool}/vol2" --volume-only
+  ! lxc storage volume copy "${storage_pool}/vol1/snap0" "localhost:${storage_pool}/vol2" --volume-only || false
+  lxc storage volume copy "${storage_pool}/vol1" "localhost:${storage_pool}/vol2" --volume-only
   [ "$(lxc query "/1.0/storage-pools/${storage_pool}/volumes/custom/vol2/snapshots" | jq "length == 0")" = "true" ]
   lxc storage volume delete "${storage_pool}" "vol2"
 
@@ -243,8 +243,8 @@ test_storage_volume_snapshots() {
   lxc storage volume delete "${storage_pool}" "vol2"
 
   # Check snapshot refresh (remote).
-  lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool}/vol2"
-  lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool}/vol2" --refresh
+  lxc storage volume copy "${storage_pool}/vol1/snap0" "localhost:${storage_pool}/vol2"
+  lxc storage volume copy "${storage_pool}/vol1/snap0" "localhost:${storage_pool}/vol2" --refresh
   lxc storage volume delete "${storage_pool}" "vol2"
 
   # Check snapshot copy between projects.
@@ -254,7 +254,7 @@ test_storage_volume_snapshots() {
   lxc storage volume delete "${storage_pool}" "vol1" --project project1
 
   # Check snapshot copy between projects (remote).
-  lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool}/vol1" --target-project project1
+  lxc storage volume copy "${storage_pool}/vol1/snap0" "localhost:${storage_pool}/vol1" --target-project project1
   [ "$(lxc query "/1.0/storage-pools/${storage_pool}/volumes?project=project1" | jq "length == 1")" = "true" ]
   lxc storage volume delete "${storage_pool}" "vol1" --project project1
   lxc storage volume delete "${storage_pool}" "vol1"
@@ -264,15 +264,18 @@ test_storage_volume_snapshots() {
   lxc storage volume snapshot "${storage_pool}" "vol1" "snap0"
   ! lxc storage volume show "${storage_pool}" "vol1" | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
   ! lxc storage volume show "${storage_pool}" "vol1/snap0" | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
-  lxc storage volume copy "${storage_pool}/vol1" "test:${storage_pool}/vol1-copy"
-  ! lxc storage volume show "${storage_pool}" "test:${storage_pool}" "vol1-copy" | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
-  [ "$(lxc storage volume show "${storage_pool}" "vol1/snap0" | awk /created_at:/)" = "$(lxc storage volume show "test:${storage_pool}" "vol1-copy/snap0" | awk /created_at:/)" ]
+  lxc storage volume copy "${storage_pool}/vol1" "localhost:${storage_pool}/vol1-copy"
+  ! lxc storage volume show "${storage_pool}" "localhost:${storage_pool}" "vol1-copy" | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  [ "$(lxc storage volume show "${storage_pool}" "vol1/snap0" | awk /created_at:/)" = "$(lxc storage volume show "localhost:${storage_pool}" "vol1-copy/snap0" | awk /created_at:/)" ]
   lxc storage volume delete "${storage_pool}" "vol1"
   lxc storage volume delete "${storage_pool}" "vol1-copy"
 
   lxc project delete "project1"
   lxc storage delete "${storage_pool}"
-  lxc remote remove "test"
+
+  fingerprint="$(lxc config trust ls --format csv | grep foo | cut -d, -f4)"
+  lxc config trust remove "${fingerprint}"
+  lxc remote remove "localhost"
 
   # shellcheck disable=SC2031,2269
   LXD_DIR="${LXD_DIR}"

--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -154,7 +154,7 @@ test_certificate_edit() {
 
   curl -k -s --cert "${LXD_CONF}/client.crt" --key "${LXD_CONF}/client.key" -X PATCH -d "{\"restricted\": false}" "https://${LXD_ADDR}/1.0/certificates/${FINGERPRINT}" | grep -F '"error_code":403'
 
-  ! lxc_remote config trust show "${FINGERPRINT}" | sed -e "s/name:.*/name: foo/" | lxc_remote config trust edit localhost:"${FINGERPRINT}" || false
+  ! lxc_remote config trust show "${FINGERPRINT}" | sed -e "s/name:.*/name: bar/" | lxc_remote config trust edit localhost:"${FINGERPRINT}" || false
 
   curl -k -s --cert "${LXD_CONF}/client.crt" --key "${LXD_CONF}/client.key" -X PATCH -d "{\"name\": \"bar\"}" "https://${LXD_ADDR}/1.0/certificates/${FINGERPRINT}" | grep -F '"error_code":403'
 


### PR DESCRIPTION
This PR is mainly based on https://github.com/lxc/incus/pull/62 and effectively removes the `core.trust_password` config setting together with its internals from the API. The following API changes are covered by this PR:

* `POST /1.0/certificates`: Ignore the payloads `password` field as it is now marked as deprecated. Instead use the `trust_token` field.
* `PUT /1.0/cluster`: Ignore the payloads `cluster_password` field as it is now marked as deprecated. Instead use the `cluster_token` field.

For backwards compatibility the `lxd-migrate` and `lxc` clients still support using the password to be able to communicate with older LXD servers. The clients check for the presence of the `explicit_trust_token` extension in order to decide if the upstream server supports the token field.

The PR also contains an enhancement for the patch system to allow running patches before loading the cluster configuration for the first time. This ensures we can safely remove cluster configuration settings without getting any error in the daemons log.