### PR TITLE
Remove the `cloud-init` way of installing the LXD agent

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -248,32 +248,6 @@ config:
       - name: documentation_example
 ```
 
-(cloud-init-lxd-agent)=
-#### Enable the LXD agent
-
-The {ref}`VM images provided by LXD <remote-image-servers>` typically have the LXD agent enabled.
-However, if you use an image or ISO that does not include the LXD agent to create your VM, you can enable the LXD agent as follows:
-
-```yaml
-config:
-  cloud-init.user-data: |
-    #cloud-config
-    runcmd:
-      - mount -t 9p config /mnt
-      - cd /mnt
-      - ./install.sh
-      - cd /
-      - umount /mnt
-      - systemctl start lxd-agent
-```
-
-```{note}
-For these commands to work, the VM must be running a Linux distribution that uses `systemd`.
-
-Depending on the version of `cloud-init` that the distribution has, you might need to add the `config` disk device explicitly.
-See [VM `cloud-init`](vm-cloud-init-config) for instructions.
-```
-
 ## How to specify network configuration data
 
 By default, `cloud-init` configures a DHCP client on an instance's `eth0` interface.

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -344,8 +344,16 @@ Now the VM can be rebooted, and it will boot from disk.
 <!-- iso_vm_step7 end -->
 
 <!-- iso_vm_step8 start -->
-If the VM installed from an ISO is a Linux distribution using `systemd`, it is possible to install the LXD agent inside of it. This can be done manually or with the help of `cloud-init` (see {ref}`cloud-init-lxd-agent` for instructions).
+If the VM installed from an ISO is a Linux distribution using `systemd`, it is possible to install the LXD agent inside of it. This can be done manually as the root user inside the VM:
 <!-- iso_vm_step8 end -->
+
+    mount -t 9p config /mnt
+    cd /mnt
+    ./install.sh
+    cd /
+    umount /mnt
+    systemctl start lxd-agent
+
 
 ````
 ````{group-tab} API


### PR DESCRIPTION
While we could use `cloud-init` to install the LXD agent on a VM image that doesn't yet have it, it is cumbersome.

The main issue is that by the time we have the manually installed VM, `cloud-init` has already fired as during the first boot. As such, even if we provide it with a new recipe, it will simply not process it.

Furthermore, when `cloud-init` detects it executes in a LXD instance, it tries to use the LXD data source which depends on the `lxd-agent` to be functional.

Technically, providing a config disk would allow to side-step this catch-22 but then you have to ensure `cloud-init` was "re-armed" (`cloud-init clean`) so that it processes the "new" recipe upon the next reboot.

At this point, it is probably easier/simpler and less confusing to simply give instruction on how to run the `install.sh` script manually (done in the previous commit).