### PR TITLE
Revert "github: run code-tests with 1.21 to avoid swagger crash"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,12 +56,10 @@ jobs:
           path: ${{ steps.ShellCheck.outputs.sarif }}
         if: github.event_name == 'pull_request'
 
-      # XXX: using 1.21 to workaround swagger crashing under 1.22
-      #      https://github.com/go-swagger/go-swagger/issues/3070
-      - name: Install Go (1.21)
+      - name: Install Go (1.22)
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This reverts commit 21244792541688d4fa9a7b0b6dab9c9e9ffcda74.

With `swagger` version 0.31.0 we no longer have the crash.