### PR TITLE
lxc: Parse location header into URL

### DIFF
--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -340,8 +341,13 @@ func (c *cmdNetworkForwardCreate) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	networkForwardURL, err := url.Parse(transporter.location)
+	if err != nil {
+		return fmt.Errorf("Received invalid location header %q: %w", transporter.location, err)
+	}
+
 	forwardURLPrefix := api.NewURL().Path(version.APIVersion, "networks", networkName, "forwards").String()
-	_, err = fmt.Sscanf(transporter.location, forwardURLPrefix+"/%s", &listenAddress)
+	_, err = fmt.Sscanf(networkForwardURL.Path, forwardURLPrefix+"/%s", &listenAddress)
 	if err != nil {
 		return fmt.Errorf("Received unexpected location header %q: %w", transporter.location, err)
 	}

--- a/lxc/network_load_balancer.go
+++ b/lxc/network_load_balancer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -344,8 +345,13 @@ func (c *cmdNetworkLoadBalancerCreate) run(cmd *cobra.Command, args []string) er
 		return err
 	}
 
+	loadBalancerURL, err := url.Parse(transporter.location)
+	if err != nil {
+		return fmt.Errorf("Received invalid location header %q: %w", transporter.location, err)
+	}
+
 	loadBalancerURLPrefix := api.NewURL().Path(version.APIVersion, "networks", networkName, "load-balancers").String()
-	_, err = fmt.Sscanf(transporter.location, loadBalancerURLPrefix+"/%s", &listenAddress)
+	_, err = fmt.Sscanf(loadBalancerURL.Path, loadBalancerURLPrefix+"/%s", &listenAddress)
 	if err != nil {
 		return fmt.Errorf("Received unexpected location header %q: %w", transporter.location, err)
 	}


### PR DESCRIPTION
The location header must be parsed into a URL before extracting the IP address. This is so we can get the IP from the path only, and not from the full URL string (which may contain query parameters).