### PR TITLE
lxd/archive: Properly anchor exclude rules - from Incus

### DIFF
--- a/lxd/archive/archive.go
+++ b/lxd/archive/archive.go
@@ -24,6 +24,7 @@ type nullWriteCloser struct {
 	*bytes.Buffer
 }
 
+// Close closes the null IO writer.
 func (nwc *nullWriteCloser) Close() error {
 	return nil
 }

--- a/lxd/archive/archive.go
+++ b/lxd/archive/archive.go
@@ -138,11 +138,14 @@ func Unpack(file string, path string, blockBackend bool, sysOS *sys.OS, tracker 
 		command = "tar"
 		if sysOS.RunningInUserNS {
 			// We can't create char/block devices so avoid extracting them.
+			args = append(args, "--anchored")
 			args = append(args, "--wildcards")
 			args = append(args, "--exclude=dev/*")
+			args = append(args, "--exclude=/dev/*")
 			args = append(args, "--exclude=./dev/*")
 			args = append(args, "--exclude=rootfs/dev/*")
-			args = append(args, "--exclude=rootfs/./dev/*")
+			args = append(args, "--exclude=/rootfs/dev/*")
+			args = append(args, "--exclude=./rootfs/dev/*")
 		}
 
 		args = append(args, "--restrict", "--force-local")


### PR DESCRIPTION
Closes https://github.com/lxc/incus/issues/815


(cherry picked from commit c72cfab8a91db44e8f1871cf7bf09c9282280915)

License: Apache-2.0