### PR TITLE
Server: Add support for explicitly specifying a trust token - From Incus

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,7 @@ jobs:
           sudo chmod o+w ./lxd/metadata/configuration.json
           sudo chmod o+w ./doc/config_options.txt
           sudo chmod o+w ./lxd/auth/entity/
+          sudo chmod o+w ./po/*
           make static-analysis
 
       - name: Unit tests (all)

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -269,9 +269,6 @@ func (r *ProtocolLXD) rawQuery(method string, url string, data any, ETag string)
 
 			// Set the encoding accordingly
 			req.Header.Set("Content-Type", "application/json")
-
-			// Log the data
-			logger.Debugf(logger.Pretty(data))
 		}
 	} else {
 		// No data to be sent along with the request

--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -31,10 +31,17 @@ func (r *ProtocolLXD) UpdateCluster(cluster api.ClusterPut, ETag string) (Operat
 		return nil, err
 	}
 
-	if cluster.ServerAddress != "" || cluster.ClusterPassword != "" || len(cluster.MemberConfig) > 0 {
+	if cluster.ServerAddress != "" || cluster.ClusterPassword != "" || cluster.ClusterToken != "" || len(cluster.MemberConfig) > 0 {
 		err := r.CheckExtension("clustering_join")
 		if err != nil {
 			return nil, err
+		}
+
+		if cluster.ClusterToken != "" {
+			err := r.CheckExtension("explicit_trust_token")
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2419,3 +2419,8 @@ Adds the ability to use an unspecified IPv4 (`0.0.0.0`) or IPv6 (`::`) address i
 If an unspecified IP address is used, supported drivers will allocate an available listen address automatically.
 Allocation of external IP addresses is currently supported by the OVN network driver.
 The OVN driver will allocate IP addresses from the subnets specified in the uplink network's `ipv4.routes` and `ipv6.routes` configuration options.
+
+## `explicit_trust_token`
+
+Adds the ability to explicitly specify a trust token when creating a certificate
+and joining an existing cluster.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -234,6 +234,11 @@ definitions:
                 example: true
                 type: boolean
                 x-go-name: Token
+            trust_token:
+                description: Trust token (used to add an untrusted client)
+                example: blah
+                type: string
+                x-go-name: TrustToken
             type:
                 description: Usage type for the certificate
                 example: client
@@ -645,6 +650,11 @@ definitions:
                 example: blah
                 type: string
                 x-go-name: ClusterPassword
+            cluster_token:
+                description: The cluster join token for the cluster you're trying to join
+                example: blah
+                type: string
+                x-go-name: ClusterToken
             enabled:
                 description: Whether clustering is enabled
                 example: true
@@ -1364,8 +1374,8 @@ definitions:
                 type: string
                 x-go-name: ClusterPassword
             cluster_token:
-                description: A cluster join token
-                example: BASE64-TOKEN
+                description: The cluster join token for the cluster you're trying to join
+                example: blah
                 type: string
                 x-go-name: ClusterToken
             enabled:

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -546,10 +546,10 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 	run := func(op *operations.Operation) error {
 		logger.Debug("Running cluster join operation")
 
-		// If the user has provided a cluster password, setup the trust
+		// If the user has provided a cluster password or token, setup the trust
 		// relationship by adding our own certificate to the cluster.
-		if req.ClusterPassword != "" {
-			err := cluster.SetupTrust(serverCert, req.ServerName, req.ClusterAddress, req.ClusterCertificate, req.ClusterPassword)
+		if req.ClusterPassword != "" || req.ClusterToken != "" {
+			err := cluster.SetupTrust(serverCert, req)
 			if err != nil {
 				return fmt.Errorf("Failed to setup cluster trust: %w", err)
 			}

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -313,7 +313,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 				return err
 			}
 
-			err = cluster.SetupTrust(serverCert, config.Cluster.ServerName, config.Cluster.ClusterAddress, config.Cluster.ClusterCertificate, config.Cluster.ClusterPassword)
+			err = cluster.SetupTrust(serverCert, config.Cluster.ClusterPut)
 			if err != nil {
 				return fmt.Errorf("Failed to setup trust relationship with cluster: %w", err)
 			}
@@ -321,6 +321,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 			// Now we have setup trust, don't send to server, othwerwise it will try and setup trust
 			// again and if using a one-time join token, will fail.
 			config.Cluster.ClusterPassword = ""
+			config.Cluster.ClusterToken = ""
 
 			// Client parameters to connect to the target cluster member.
 			args := &lxd.ConnectionArgs{

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -415,27 +415,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -444,17 +444,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -496,7 +496,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,19 +541,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -607,11 +607,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -631,11 +631,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -672,11 +672,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -747,12 +747,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -762,11 +762,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -810,12 +810,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -824,20 +824,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -864,8 +864,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -927,24 +927,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -953,21 +953,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -988,15 +988,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1039,12 +1039,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1054,13 +1054,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,17 +1129,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1210,8 +1210,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1317,21 +1317,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1447,11 +1447,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1487,7 +1487,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1501,19 +1501,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1589,11 +1589,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1669,15 +1669,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1688,20 +1688,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1720,9 +1720,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1843,24 +1843,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1885,7 +1885,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1897,7 +1897,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1915,7 +1915,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1955,11 +1955,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2056,8 +2056,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2071,7 +2071,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2117,17 +2117,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2255,31 +2255,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2299,17 +2299,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2324,17 +2324,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2407,12 +2407,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2435,30 +2435,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2498,11 +2498,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2566,11 +2566,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2638,30 +2638,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2670,12 +2670,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2692,7 +2692,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2700,11 +2700,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2756,7 +2756,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2772,21 +2772,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2847,15 +2847,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2873,16 +2873,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2905,12 +2905,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2920,12 +2920,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2935,17 +2935,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2983,17 +2983,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3014,12 +3014,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3037,26 +3037,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3097,11 +3097,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3156,11 +3156,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3195,11 +3195,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3377,7 +3377,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3402,7 +3402,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3424,11 +3424,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3557,23 +3557,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3653,12 +3653,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3687,19 +3687,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3763,7 +3763,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3772,14 +3772,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3799,16 +3799,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3883,12 +3883,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3909,15 +3909,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3977,10 +3977,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -3997,53 +3997,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4093,22 +4093,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4142,7 +4142,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4186,11 +4186,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4211,7 +4211,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4269,7 +4269,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4278,11 +4278,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4291,39 +4291,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4340,7 +4340,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4352,20 +4352,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4373,8 +4373,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4398,7 +4398,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4408,7 +4408,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4460,11 +4460,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4483,15 +4483,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4581,11 +4581,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4599,20 +4599,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4621,7 +4621,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4650,7 +4650,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4658,7 +4658,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4667,46 +4667,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4736,7 +4740,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4744,11 +4748,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4772,11 +4776,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4784,7 +4788,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4841,7 +4845,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4858,7 +4862,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4875,7 +4879,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4918,7 +4922,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4955,11 +4959,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4967,26 +4971,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -4998,7 +5002,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5023,19 +5027,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5078,7 +5082,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5121,11 +5125,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5134,11 +5138,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5242,19 +5246,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5266,11 +5270,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5314,7 +5318,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5371,7 +5375,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5387,7 +5391,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5411,11 +5415,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5473,7 +5477,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5481,11 +5485,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5505,7 +5509,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5517,12 +5521,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5535,11 +5539,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5549,7 +5553,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5562,7 +5566,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5571,11 +5575,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5663,21 +5667,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5685,7 +5689,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5697,22 +5701,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5728,7 +5732,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5800,7 +5804,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5815,7 +5819,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5866,7 +5870,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5911,7 +5915,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5919,7 +5923,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5931,7 +5935,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5942,7 +5946,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5951,12 +5955,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6000,7 +6004,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6008,19 +6012,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6029,11 +6033,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6051,17 +6055,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6070,23 +6074,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6096,7 +6100,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6117,7 +6121,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6133,19 +6137,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6193,11 +6197,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6245,7 +6249,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6268,7 +6272,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6291,7 +6295,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6304,12 +6308,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6326,17 +6330,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6353,7 +6357,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6384,7 +6388,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6404,7 +6408,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6441,7 +6445,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6558,15 +6562,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6586,13 +6590,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6657,20 +6661,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6717,8 +6721,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6738,44 +6742,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6813,7 +6817,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7017,7 +7021,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7033,7 +7037,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7041,7 +7045,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7049,7 +7053,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7057,7 +7061,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7174,20 +7178,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7208,7 +7212,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7255,7 +7259,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7404,7 +7408,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7412,11 +7416,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7428,16 +7432,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7453,11 +7457,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -372,7 +372,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -414,7 +414,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -667,27 +667,27 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -696,17 +696,17 @@ msgstr "'%s' ist kein unterstützter Dateityp"
 msgid "(none)"
 msgstr "(kein Wert)"
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Level %d (Typ: %s): %s"
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
@@ -755,7 +755,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -774,19 +774,19 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -808,19 +808,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
@@ -879,11 +879,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -905,11 +905,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -946,11 +946,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -969,7 +969,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Add rules to an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
@@ -979,7 +979,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -1008,7 +1008,7 @@ msgstr "Aliasname fehlt"
 msgid "Aliases already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
@@ -1018,7 +1018,7 @@ msgstr "Aliasse:\n"
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1027,12 +1027,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
@@ -1042,11 +1042,11 @@ msgstr "Architektur: %s\n"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1083,12 +1083,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1096,12 +1096,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1110,21 +1110,21 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 #, fuzzy
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1152,8 +1152,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
@@ -1191,11 +1191,11 @@ msgstr "Erstellt: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1215,25 +1215,25 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr " Prozessorauslastung:"
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1243,16 +1243,16 @@ msgstr ""
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1261,7 +1261,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 #, fuzzy
 msgid "Caches:"
 msgstr ""
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1287,15 +1287,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1303,11 +1303,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1338,12 +1338,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1357,13 +1357,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1433,17 +1433,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Spalten"
@@ -1517,8 +1517,8 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1527,7 +1527,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1628,22 +1628,22 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Fehler: %v\n"
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 #, fuzzy
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1682,7 +1682,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -1714,7 +1714,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1770,12 +1770,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1819,7 +1819,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1834,19 +1834,19 @@ msgstr "Erstelle %s"
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1854,7 +1854,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1862,7 +1862,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1886,7 +1886,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1927,11 +1927,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2013,15 +2013,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -2032,20 +2032,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -2064,9 +2064,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2185,7 +2185,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2197,27 +2197,27 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 #, fuzzy
 msgid "Disk:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 #, fuzzy
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -2256,7 +2256,7 @@ msgstr "ABLAUFDATUM"
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2275,7 +2275,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2323,12 +2323,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2432,8 +2432,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2447,7 +2447,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2502,17 +2502,17 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -2574,12 +2574,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2594,12 +2594,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2629,7 +2629,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2644,31 +2644,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2678,7 +2678,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2688,17 +2688,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2713,17 +2713,17 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2735,7 +2735,7 @@ msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -2800,12 +2800,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2828,30 +2828,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -2877,7 +2877,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2893,12 +2893,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2973,12 +2973,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3052,31 +3052,31 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3085,12 +3085,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3107,7 +3107,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3117,11 +3117,11 @@ msgstr "Profil %s erstellt\n"
 msgid "IP addresses:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -3174,7 +3174,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -3190,21 +3190,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3256,7 +3256,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Importing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3268,16 +3268,16 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3295,16 +3295,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3313,7 +3313,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3328,12 +3328,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3343,12 +3343,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3358,17 +3358,17 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3392,12 +3392,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3409,17 +3409,17 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3436,7 +3436,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3444,12 +3444,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3458,7 +3458,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3467,26 +3467,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3532,11 +3532,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3594,11 +3594,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3635,12 +3635,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "List instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 #, fuzzy
 msgid "List instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -3798,7 +3798,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3838,7 +3838,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3847,7 +3847,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3865,7 +3865,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -3875,7 +3875,7 @@ msgstr "Profil %s erstellt\n"
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3892,11 +3892,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4040,27 +4040,27 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4156,12 +4156,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage warnings"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4191,19 +4191,19 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -4275,7 +4275,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4286,14 +4286,14 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4316,16 +4316,16 @@ msgstr "Profilname kann nicht geändert werden"
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4395,7 +4395,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -4408,12 +4408,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4434,17 +4434,17 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Mounted: %v"
 msgstr "Erstellt: %s"
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4508,10 +4508,10 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4528,53 +4528,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4624,22 +4624,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -4674,7 +4674,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -4722,11 +4722,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4747,7 +4747,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4794,7 +4794,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4806,7 +4806,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4815,11 +4815,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4828,39 +4828,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4878,7 +4878,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
@@ -4892,20 +4892,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4913,8 +4913,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4938,7 +4938,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -4948,7 +4948,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -5003,12 +5003,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
@@ -5028,16 +5028,16 @@ msgstr "Profil %s gelöscht\n"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -5127,11 +5127,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
@@ -5146,22 +5146,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5170,7 +5170,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5186,7 +5186,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -5201,7 +5201,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5210,7 +5210,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -5219,46 +5219,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -5292,7 +5296,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5300,12 +5304,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5334,12 +5338,12 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5349,7 +5353,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5413,7 +5417,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5432,7 +5436,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5449,7 +5453,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -5496,7 +5500,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 #, fuzzy
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5537,11 +5541,11 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5549,26 +5553,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5580,7 +5584,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5605,21 +5609,21 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5665,7 +5669,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5710,12 +5714,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5724,12 +5728,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5840,19 +5844,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -5864,12 +5868,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5920,7 +5924,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5981,7 +5985,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -6000,7 +6004,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
@@ -6027,12 +6031,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Profil %s erstellt\n"
@@ -6099,7 +6103,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -6107,12 +6111,12 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 #, fuzzy
 msgid "Show the instance's last 100 log lines?"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -6134,7 +6138,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6146,12 +6150,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Erstellt: %s"
@@ -6165,11 +6169,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6179,7 +6183,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -6193,7 +6197,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -6203,11 +6207,11 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6301,21 +6305,21 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6323,7 +6327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6335,23 +6339,23 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6368,7 +6372,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6459,7 +6463,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6510,7 +6514,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6558,7 +6562,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6567,7 +6571,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
@@ -6580,7 +6584,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6591,7 +6595,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6600,12 +6604,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, fuzzy, c-format
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
@@ -6649,7 +6653,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6658,19 +6662,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6679,11 +6683,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6701,17 +6705,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
@@ -6721,23 +6725,23 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, fuzzy, c-format
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6747,7 +6751,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, fuzzy, c-format
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6772,7 +6776,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6790,22 +6794,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6861,12 +6865,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6922,7 +6926,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6946,7 +6950,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6970,7 +6974,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6983,12 +6987,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -7005,17 +7009,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "Fehler: %v\n"
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -7072,7 +7076,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -7095,7 +7099,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7163,7 +7167,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7387,7 +7391,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7396,7 +7400,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7405,7 +7409,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7445,7 +7449,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7455,7 +7459,7 @@ msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7591,7 +7595,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7600,7 +7604,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7608,7 +7612,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7618,7 +7622,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7718,8 +7722,8 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7759,9 +7763,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7769,7 +7773,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -7777,7 +7781,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -7787,8 +7791,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -7796,7 +7800,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -7804,7 +7808,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -7814,13 +7818,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -7894,7 +7898,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8304,7 +8308,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -8337,7 +8341,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8354,7 +8358,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -8362,7 +8366,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -8370,7 +8374,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -8487,20 +8491,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8521,7 +8525,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -8568,7 +8572,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8721,7 +8725,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -8729,11 +8733,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8745,16 +8749,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8770,12 +8774,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -612,11 +612,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -636,11 +636,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -677,11 +677,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -753,12 +753,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -768,11 +768,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -804,11 +804,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -816,12 +816,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -830,20 +830,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -870,8 +870,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -909,11 +909,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -933,25 +933,25 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "  Χρήση CPU:"
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 #, fuzzy
 msgid "CPU usage:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -960,21 +960,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -995,15 +995,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1011,11 +1011,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1046,12 +1046,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1061,13 +1061,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1136,17 +1136,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1177,7 +1177,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1217,8 +1217,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1240,7 +1240,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1324,21 +1324,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1455,11 +1455,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1511,19 +1511,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1600,11 +1600,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -1684,15 +1684,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1703,20 +1703,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1735,9 +1735,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1847,7 +1847,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1859,27 +1859,27 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 #, fuzzy
 msgid "Disk:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 #, fuzzy
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1975,11 +1975,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2028,7 +2028,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2081,8 +2081,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2096,7 +2096,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2142,17 +2142,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2230,12 +2230,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2265,7 +2265,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2280,31 +2280,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2314,7 +2314,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2324,17 +2324,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2349,17 +2349,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2368,7 +2368,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2432,12 +2432,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2460,30 +2460,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2523,12 +2523,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -2598,12 +2598,12 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2676,30 +2676,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2708,12 +2708,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2730,7 +2730,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2738,11 +2738,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2794,7 +2794,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2810,21 +2810,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2885,15 +2885,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2911,16 +2911,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2943,12 +2943,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2958,12 +2958,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2973,17 +2973,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3005,12 +3005,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3021,17 +3021,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3052,12 +3052,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3066,7 +3066,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3075,26 +3075,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3135,11 +3135,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -3196,11 +3196,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3235,11 +3235,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3378,7 +3378,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3417,7 +3417,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3426,7 +3426,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3442,7 +3442,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3451,7 +3451,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3464,11 +3464,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3485,7 +3485,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3527,7 +3527,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3600,25 +3600,25 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "  Χρήση δικτύου:"
@@ -3707,12 +3707,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3741,20 +3741,20 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 #, fuzzy
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
@@ -3825,7 +3825,7 @@ msgstr "  Χρήση δικτύου:"
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3835,14 +3835,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3862,16 +3862,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3936,7 +3936,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3948,12 +3948,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3974,15 +3974,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -4024,7 +4024,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4042,10 +4042,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4062,53 +4062,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4158,22 +4158,22 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network Zone %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -4208,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -4253,11 +4253,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4278,7 +4278,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4336,7 +4336,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4345,11 +4345,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4358,39 +4358,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4407,7 +4407,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4420,20 +4420,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4441,8 +4441,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4466,7 +4466,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4528,11 +4528,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4551,15 +4551,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4649,11 +4649,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4667,20 +4667,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4689,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4718,7 +4718,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4726,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4735,46 +4735,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4805,7 +4809,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4813,12 +4817,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "  Χρήση δικτύου:"
@@ -4843,11 +4847,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "  Χρήση δικτύου:"
@@ -4856,7 +4860,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4914,7 +4918,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4948,7 +4952,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4991,7 +4995,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -5029,11 +5033,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5041,26 +5045,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5072,7 +5076,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5097,19 +5101,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5127,7 +5131,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5153,7 +5157,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5196,12 +5200,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5210,12 +5214,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5323,19 +5327,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5347,12 +5351,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -5401,7 +5405,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5460,7 +5464,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5501,11 +5505,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "  Χρήση δικτύου:"
@@ -5570,7 +5574,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5578,11 +5582,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5603,7 +5607,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5615,12 +5619,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5633,11 +5637,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5647,7 +5651,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5660,7 +5664,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5669,11 +5673,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5761,21 +5765,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5783,7 +5787,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5795,22 +5799,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5826,7 +5830,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5898,7 +5902,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -5913,7 +5917,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -5964,7 +5968,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6010,7 +6014,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6018,7 +6022,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -6030,7 +6034,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6041,7 +6045,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6050,12 +6054,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6107,19 +6111,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6128,11 +6132,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6150,17 +6154,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6169,23 +6173,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6195,7 +6199,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6217,7 +6221,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6233,22 +6237,22 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "  Χρήση δικτύου:"
@@ -6302,12 +6306,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "  Χρήση δικτύου:"
@@ -6361,7 +6365,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6384,7 +6388,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6420,12 +6424,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6442,17 +6446,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6469,7 +6473,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6500,7 +6504,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6520,7 +6524,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6557,7 +6561,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6674,15 +6678,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6702,13 +6706,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6773,20 +6777,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6833,8 +6837,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6854,44 +6858,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6929,7 +6933,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7133,7 +7137,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7149,7 +7153,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7157,7 +7161,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7165,7 +7169,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7173,7 +7177,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7290,20 +7294,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7324,7 +7328,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7371,7 +7375,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7520,7 +7524,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7528,11 +7532,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7544,16 +7548,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7569,12 +7573,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -374,7 +374,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -413,7 +413,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -655,27 +655,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -684,17 +684,17 @@ msgstr "%s no es un tipo de archivo soportado."
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partición %d"
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Puerto %d (%s)"
@@ -740,7 +740,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -757,19 +757,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -787,19 +787,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -807,7 +807,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
@@ -855,11 +855,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -880,11 +880,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -921,11 +921,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Expira: %s"
@@ -952,7 +952,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -981,7 +981,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -989,7 +989,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -998,12 +998,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
@@ -1013,11 +1013,11 @@ msgstr "Arquitectura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1050,11 +1050,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1062,12 +1062,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1076,20 +1076,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1116,8 +1116,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Creado: %s"
@@ -1156,11 +1156,11 @@ msgstr "Creado: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1180,24 +1180,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1206,21 +1206,21 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREADO"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 #, fuzzy
 msgid "Caches:"
 msgstr "Cacheado: %s"
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1244,15 +1244,15 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr "No se puede especificar --fast con --columns"
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1261,11 +1261,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1296,12 +1296,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Cacheado: %s"
@@ -1311,13 +1311,13 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1387,17 +1387,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1428,7 +1428,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Columnas"
@@ -1470,8 +1470,8 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1480,7 +1480,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr "Log de la consola:"
 
@@ -1493,7 +1493,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1578,22 +1578,22 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Expira: %s"
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 #, fuzzy
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1632,7 +1632,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1663,7 +1663,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1714,11 +1714,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Perfil %s creado"
@@ -1756,7 +1756,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1771,19 +1771,19 @@ msgstr "Creando %s"
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1791,7 +1791,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1861,11 +1861,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
@@ -1945,15 +1945,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1964,20 +1964,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1996,9 +1996,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
@@ -2109,7 +2109,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2121,24 +2121,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr "Disco:"
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr "Discos:"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -2177,7 +2177,7 @@ msgstr "FECHA DE EXPIRACIÓN"
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2236,11 +2236,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2342,8 +2342,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2357,7 +2357,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2404,18 +2404,18 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr "Expira: nunca"
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
@@ -2475,12 +2475,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2495,12 +2495,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2530,7 +2530,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2545,31 +2545,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2579,7 +2579,7 @@ msgstr "Acepta certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2589,17 +2589,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2614,17 +2614,17 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
@@ -2698,12 +2698,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2726,30 +2726,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2774,7 +2774,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,12 +2790,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Nombre del contenedor es: %s"
@@ -2865,12 +2865,12 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
@@ -2943,31 +2943,31 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -2976,12 +2976,12 @@ msgstr "Copiando la imagen: %s"
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3008,11 +3008,11 @@ msgstr "Expira: %s"
 msgid "IP addresses:"
 msgstr "Expira: %s"
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -3080,21 +3080,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3144,7 +3144,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Importing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3156,16 +3156,16 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3185,16 +3185,16 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3203,7 +3203,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3217,12 +3217,12 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3232,12 +3232,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3247,17 +3247,17 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3280,12 +3280,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3297,17 +3297,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Cacheado: %s"
@@ -3320,7 +3320,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3328,12 +3328,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3351,26 +3351,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3416,11 +3416,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nombre del contenedor es: %s"
@@ -3478,11 +3478,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3517,12 +3517,12 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 #, fuzzy
 msgid "List instances"
 msgstr "Aliases:"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3664,7 +3664,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3704,7 +3704,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3713,7 +3713,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr "Registro:"
 
@@ -3729,7 +3729,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -3739,7 +3739,7 @@ msgstr "Expira: %s"
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
@@ -3752,11 +3752,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3773,7 +3773,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3815,7 +3815,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3888,25 +3888,25 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nombre del contenedor es: %s"
@@ -3995,12 +3995,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
@@ -4030,19 +4030,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -4114,7 +4114,7 @@ msgstr "Nombre del Miembro del Cluster"
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
@@ -4125,14 +4125,14 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
@@ -4154,16 +4154,16 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4231,7 +4231,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -4245,12 +4245,12 @@ msgstr "%s no es un directorio"
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4271,16 +4271,16 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Mounted: %v"
 msgstr "Creado: %s"
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4340,10 +4340,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4360,53 +4360,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4456,22 +4456,22 @@ msgstr "Perfil %s creado"
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
@@ -4505,7 +4505,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4549,11 +4549,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4574,7 +4574,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4599,7 +4599,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4620,7 +4620,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4632,7 +4632,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4641,11 +4641,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4654,39 +4654,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4703,7 +4703,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4716,20 +4716,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4737,8 +4737,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -4772,7 +4772,7 @@ msgstr "Procesos: %d"
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4827,11 +4827,11 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 #, fuzzy
 msgid "Profiles: "
 msgstr "Perfil %s creado"
@@ -4851,15 +4851,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4949,11 +4949,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr "Público: %s"
@@ -4967,20 +4967,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4989,7 +4989,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5005,7 +5005,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -5020,7 +5020,7 @@ msgstr "Creando el contenedor"
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5028,7 +5028,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -5037,46 +5037,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -5108,7 +5112,7 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5116,12 +5120,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
@@ -5146,11 +5150,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
@@ -5159,7 +5163,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5218,7 +5222,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5235,7 +5239,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5252,7 +5256,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -5298,7 +5302,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -5338,11 +5342,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5350,26 +5354,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5381,7 +5385,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5406,19 +5410,19 @@ msgstr "Creado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5437,7 +5441,7 @@ msgstr "Aliases:"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5463,7 +5467,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5506,12 +5510,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5520,12 +5524,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5633,19 +5637,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5657,12 +5661,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Perfil %s creado"
@@ -5711,7 +5715,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5770,7 +5774,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5787,7 +5791,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5812,11 +5816,11 @@ msgstr "Perfil %s creado"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Perfil %s creado"
@@ -5881,7 +5885,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5889,11 +5893,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5926,12 +5930,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
@@ -5944,11 +5948,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5958,7 +5962,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5971,7 +5975,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -5981,11 +5985,11 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6073,21 +6077,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6095,7 +6099,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6107,22 +6111,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6139,7 +6143,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6212,7 +6216,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6227,7 +6231,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6278,7 +6282,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6325,7 +6329,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6333,7 +6337,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -6345,7 +6349,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6356,7 +6360,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6365,12 +6369,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6414,7 +6418,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -6424,19 +6428,19 @@ msgstr "Expira: %s"
 msgid "Type of certificate"
 msgstr "Acepta certificado"
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6445,11 +6449,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6467,17 +6471,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6486,23 +6490,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6512,7 +6516,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6535,7 +6539,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6551,22 +6555,22 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
@@ -6620,12 +6624,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Perfil %s creado"
@@ -6679,7 +6683,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6703,7 +6707,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6726,7 +6730,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6739,12 +6743,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6761,17 +6765,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
@@ -6788,7 +6792,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6819,7 +6823,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6839,7 +6843,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6883,7 +6887,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7025,17 +7029,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7060,14 +7064,14 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7147,23 +7151,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7221,8 +7225,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7247,50 +7251,50 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7337,7 +7341,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7590,7 +7594,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7610,7 +7614,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7620,7 +7624,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7628,7 +7632,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7636,7 +7640,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7753,20 +7757,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7787,7 +7791,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7834,7 +7838,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7983,7 +7987,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7991,11 +7995,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8007,16 +8011,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8032,12 +8036,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -382,7 +382,7 @@ msgstr ""
 "### Notez que seules les règles d'entrée et de sortie, la description et les "
 "clés de configuration peuvent être modifiées ."
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -424,7 +424,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -664,27 +664,27 @@ msgstr ""
 "### Ceci est une représentation yaml d'un membre du cluster.\n"
 "### Toute ligne commençant par un '#' sera ignorée."
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -693,17 +693,17 @@ msgstr "'%s' n'est pas un format de fichier pris en charge."
 msgid "(none)"
 msgstr "(aucun)"
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Niveau %d (type: %s): %s"
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
@@ -746,7 +746,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
@@ -764,21 +764,21 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -804,20 +804,20 @@ msgstr "<cible>"
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -826,7 +826,7 @@ msgstr "TYPE"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -875,11 +875,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -901,11 +901,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -951,11 +951,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Add rules to an ACL"
 msgstr "Création du conteneur"
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Expire : %s"
@@ -984,7 +984,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr "Alias :"
 
@@ -1022,7 +1022,7 @@ msgstr "Alias :"
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1031,12 +1031,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accepter le certificat"
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
@@ -1046,11 +1046,11 @@ msgstr "Architecture : %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1086,12 +1086,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1099,12 +1099,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1113,21 +1113,21 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 #, fuzzy
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1146,7 +1146,7 @@ msgstr "Copie de l'image : %s"
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1155,8 +1155,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1185,7 +1185,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Créé : %s"
@@ -1194,11 +1194,11 @@ msgstr "Créé : %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1218,24 +1218,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "CPU utilisé :"
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1245,21 +1245,21 @@ msgstr ""
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, fuzzy, c-format
 msgid "CUDA Version: %v"
 msgstr "Afficher la version du client"
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr "Créé : %s"
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 #, fuzzy
 msgid "Caches:"
 msgstr "Créé : %s"
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1282,16 +1282,16 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1299,11 +1299,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1314,7 +1314,7 @@ msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1336,12 +1336,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Créé : %s"
@@ -1351,13 +1351,13 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1427,17 +1427,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1468,7 +1468,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colonnes"
@@ -1519,8 +1519,8 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1529,7 +1529,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1542,7 +1542,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1631,22 +1631,22 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "erreur : %v"
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 #, fuzzy
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1685,7 +1685,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -1717,7 +1717,7 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1789,12 +1789,12 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Copie de l'image : %s"
@@ -1838,7 +1838,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1853,19 +1853,19 @@ msgstr "Création de %s"
 msgid "Creating the instance"
 msgstr "Création du conteneur"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1881,7 +1881,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr "PILOTE"
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1907,7 +1907,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
@@ -1949,11 +1949,11 @@ msgstr "Copie de l'image : %s"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
@@ -2037,15 +2037,15 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -2056,20 +2056,20 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -2088,9 +2088,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2185,7 +2185,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
@@ -2203,7 +2203,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2215,27 +2215,27 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 #, fuzzy
 msgid "Disk:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 #, fuzzy
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
@@ -2275,7 +2275,7 @@ msgstr "DATE D'EXPIRATION"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2294,7 +2294,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2342,12 +2342,12 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2398,7 +2398,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2452,8 +2452,8 @@ msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2467,7 +2467,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2530,18 +2530,18 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
@@ -2596,7 +2596,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
@@ -2605,12 +2605,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2625,12 +2625,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2660,7 +2660,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2675,32 +2675,32 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2710,7 +2710,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2720,17 +2720,17 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2745,17 +2745,17 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
@@ -2765,7 +2765,7 @@ msgstr "Mode rapide (identique à --columns=nsacPt"
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
@@ -2833,12 +2833,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2861,30 +2861,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2896,7 +2896,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -2909,7 +2909,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2925,12 +2925,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Copie de l'image : %s"
@@ -3006,12 +3006,12 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3087,31 +3087,31 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3121,12 +3121,12 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "ID"
 msgstr "PID"
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, fuzzy, c-format
 msgid "ID: %d"
 msgstr "Pid : %d"
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3143,7 +3143,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -3153,11 +3153,11 @@ msgstr "Expire : %s"
 msgid "IP addresses:"
 msgstr "Expire : %s"
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -3213,7 +3213,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -3230,21 +3230,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3298,7 +3298,7 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Importing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3310,17 +3310,17 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3340,16 +3340,16 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Conteneur publié avec l'empreinte : %s"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3358,7 +3358,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3372,12 +3372,12 @@ msgstr "Cible invalide %s"
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3387,12 +3387,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3402,17 +3402,17 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3436,12 +3436,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3453,17 +3453,17 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Créé : %s"
@@ -3477,7 +3477,7 @@ msgstr "Garder l'image à jour après la copie initiale"
 msgid "LAST SEEN"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
@@ -3485,12 +3485,12 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3499,7 +3499,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3508,26 +3508,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architecture : %s"
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3573,11 +3573,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nom du réseau"
@@ -3635,11 +3635,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3676,12 +3676,12 @@ msgstr "Création du conteneur"
 msgid "List instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 #, fuzzy
 msgid "List instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -3885,7 +3885,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3925,7 +3925,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3934,7 +3934,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr "Journal : "
 
@@ -3952,7 +3952,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -3962,7 +3962,7 @@ msgstr "Expire : %s"
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
@@ -3975,11 +3975,11 @@ msgstr "GÉRÉ"
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -4040,7 +4040,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
@@ -4122,27 +4122,27 @@ msgstr "Copie de l'image : %s"
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nom du réseau"
@@ -4237,12 +4237,12 @@ msgstr "Copie de l'image : %s"
 msgid "Manage warnings"
 msgstr "Rendre l'image publique"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
@@ -4272,20 +4272,20 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 #, fuzzy
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
@@ -4358,7 +4358,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4369,14 +4369,14 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4399,16 +4399,16 @@ msgstr "Nom du réseau"
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4479,7 +4479,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4494,12 +4494,12 @@ msgstr "%s n'est pas un répertoire"
 msgid "Mode"
 msgstr "Publié : %s"
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, fuzzy, c-format
 msgid "Model: %s"
 msgstr "Publié : %s"
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4521,17 +4521,17 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Mounted: %v"
 msgstr "Publié : %s"
@@ -4576,7 +4576,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4595,10 +4595,10 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr "NOM"
@@ -4615,54 +4615,54 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr "NON"
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, fuzzy, c-format
 msgid "Name: %v"
 msgstr "Nom : %s"
@@ -4712,22 +4712,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -4810,11 +4810,11 @@ msgstr "Aucun périphérique existant pour ce réseau"
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4835,7 +4835,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4867,7 +4867,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4892,7 +4892,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4905,7 +4905,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4914,11 +4914,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr "PID"
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
@@ -4927,39 +4927,39 @@ msgstr "Pid : %d"
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr "Paquets émis"
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 #, fuzzy
 msgid "Partitions:"
 msgstr "Options :"
@@ -4978,7 +4978,7 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
@@ -4992,20 +4992,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5013,8 +5013,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -5039,7 +5039,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -5049,7 +5049,7 @@ msgstr "Processus : %d"
 msgid "Processing aliases failed: %s"
 msgstr "l'analyse des alias a échoué %s\n"
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -5104,12 +5104,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profils : %s"
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profils : %s"
@@ -5129,15 +5129,15 @@ msgstr "Profil %s supprimé"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -5227,11 +5227,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
@@ -5246,22 +5246,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5270,7 +5270,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5287,7 +5287,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -5302,7 +5302,7 @@ msgstr "Création du conteneur"
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -5312,7 +5312,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
@@ -5322,46 +5322,51 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+#, fuzzy
+msgid "Remote trust token"
+msgstr "Ajouter de nouveaux clients de confiance"
+
+#: lxc/info.go:283
 #, fuzzy, c-format
 msgid "Removable: %v"
 msgstr "Serveur distant : %s"
@@ -5395,7 +5400,7 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5403,12 +5408,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5437,12 +5442,12 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "Création du conteneur"
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
@@ -5452,7 +5457,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5516,7 +5521,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5535,7 +5540,7 @@ msgstr "Copie de l'image : %s"
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5552,7 +5557,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -5616,7 +5621,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 #, fuzzy
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -5657,11 +5662,11 @@ msgstr "Rendre l'image publique"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
@@ -5669,26 +5674,26 @@ msgstr "INSTANTANÉS"
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5702,7 +5707,7 @@ msgstr "ÉTAT"
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
@@ -5728,21 +5733,21 @@ msgstr "Créé : %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -5761,7 +5766,7 @@ msgstr "Création du conteneur"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5788,7 +5793,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5834,12 +5839,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5848,12 +5853,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5965,19 +5970,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -5989,12 +5994,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Nom du réseau"
@@ -6045,7 +6050,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6106,7 +6111,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -6125,7 +6130,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
@@ -6155,12 +6160,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Afficher la configuration étendue"
@@ -6229,7 +6234,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6238,12 +6243,12 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 #, fuzzy
 msgid "Show the instance's last 100 log lines?"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -6265,7 +6270,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6277,12 +6282,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "État : %s"
@@ -6296,11 +6301,11 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6310,7 +6315,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr "Source :"
 
@@ -6324,7 +6329,7 @@ msgstr "Création du conteneur"
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -6334,12 +6339,12 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -6433,21 +6438,21 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -6456,7 +6461,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6469,23 +6474,23 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6501,7 +6506,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6582,7 +6587,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6597,7 +6602,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6648,7 +6653,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6695,7 +6700,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6704,7 +6709,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
@@ -6717,7 +6722,7 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6730,7 +6735,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6739,12 +6744,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, fuzzy, c-format
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
@@ -6788,7 +6793,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -6798,19 +6803,19 @@ msgstr "Expire : %s"
 msgid "Type of certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
@@ -6819,11 +6824,11 @@ msgstr "Type : éphémère"
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr "URL"
 
@@ -6841,17 +6846,17 @@ msgstr "UTILISÉ PAR"
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
@@ -6861,23 +6866,23 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6887,7 +6892,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6912,7 +6917,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6931,22 +6936,22 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
@@ -7004,12 +7009,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Nom du réseau"
@@ -7065,7 +7070,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7089,7 +7094,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
@@ -7113,7 +7118,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
@@ -7127,12 +7132,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -7149,17 +7154,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "erreur : %v"
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
@@ -7177,7 +7182,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, fuzzy, c-format
 msgid "WWN: %s"
 msgstr "Nom : %s"
@@ -7213,7 +7218,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr "OUI"
 
@@ -7236,7 +7241,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -7307,7 +7312,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7549,7 +7554,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7561,7 +7566,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7573,7 +7578,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7613,7 +7618,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7623,7 +7628,7 @@ msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7780,7 +7785,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7792,7 +7797,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7800,7 +7805,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7813,7 +7818,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7937,8 +7942,8 @@ msgstr ""
 "(configuration, instantanés, …)."
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7978,9 +7983,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7988,7 +7993,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -7996,7 +8001,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8006,8 +8011,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8015,7 +8020,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8023,7 +8028,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8033,13 +8038,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8113,7 +8118,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8553,7 +8558,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -8589,7 +8594,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8609,7 +8614,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8618,7 +8623,7 @@ msgstr "Swap (courant)"
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr "désactivé"
 
@@ -8626,7 +8631,7 @@ msgstr "désactivé"
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr "activé"
 
@@ -8743,20 +8748,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8777,7 +8782,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 #, fuzzy
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
@@ -8834,7 +8839,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8995,7 +9000,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -9004,11 +9009,11 @@ msgstr "non"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9020,16 +9025,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -9045,12 +9050,12 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr "oui"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -258,7 +258,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -282,7 +282,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -419,27 +419,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -448,17 +448,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -500,7 +500,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -516,19 +516,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -545,19 +545,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -611,11 +611,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -676,11 +676,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -696,7 +696,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -751,12 +751,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -766,11 +766,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -814,12 +814,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -828,20 +828,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -868,8 +868,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -931,24 +931,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -957,21 +957,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -992,15 +992,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1008,11 +1008,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1043,12 +1043,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1058,13 +1058,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1133,17 +1133,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,8 +1214,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1224,7 +1224,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1237,7 +1237,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1321,21 +1321,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1403,7 +1403,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1451,11 +1451,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1491,7 +1491,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1505,19 +1505,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1525,7 +1525,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1557,7 +1557,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1593,11 +1593,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1673,15 +1673,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1692,20 +1692,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1724,9 +1724,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1835,7 +1835,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1847,24 +1847,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1889,7 +1889,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1919,7 +1919,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1959,11 +1959,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2060,8 +2060,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2075,7 +2075,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2121,17 +2121,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2180,7 +2180,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2189,12 +2189,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2209,12 +2209,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2244,7 +2244,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2259,31 +2259,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2303,17 +2303,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2328,17 +2328,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2347,7 +2347,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2411,12 +2411,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2439,30 +2439,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2502,11 +2502,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2570,11 +2570,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2642,30 +2642,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2674,12 +2674,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2696,7 +2696,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2704,11 +2704,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2776,21 +2776,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2851,15 +2851,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2877,16 +2877,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2909,12 +2909,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2924,12 +2924,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2939,17 +2939,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2971,12 +2971,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2987,17 +2987,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3018,12 +3018,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3032,7 +3032,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3041,26 +3041,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3101,11 +3101,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3160,11 +3160,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3199,11 +3199,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3381,7 +3381,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3406,7 +3406,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3415,7 +3415,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3428,11 +3428,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3449,7 +3449,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3561,23 +3561,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3657,12 +3657,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3691,19 +3691,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3767,7 +3767,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3776,14 +3776,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3803,16 +3803,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3875,7 +3875,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3887,12 +3887,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3913,15 +3913,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3963,7 +3963,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3981,10 +3981,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4001,53 +4001,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4097,22 +4097,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4146,7 +4146,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4190,11 +4190,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4215,7 +4215,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4273,7 +4273,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4282,11 +4282,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4295,39 +4295,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4344,7 +4344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4356,20 +4356,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4377,8 +4377,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4402,7 +4402,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4412,7 +4412,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4464,11 +4464,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4487,15 +4487,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4585,11 +4585,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4603,20 +4603,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4625,7 +4625,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4641,7 +4641,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4654,7 +4654,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4671,46 +4671,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4740,7 +4744,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4748,11 +4752,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4776,11 +4780,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4862,7 +4866,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4922,7 +4926,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4959,11 +4963,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4971,26 +4975,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5002,7 +5006,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5027,19 +5031,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5056,7 +5060,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5082,7 +5086,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5125,11 +5129,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5138,11 +5142,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5246,19 +5250,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5270,11 +5274,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5318,7 +5322,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5375,7 +5379,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5391,7 +5395,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5415,11 +5419,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5485,11 +5489,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5509,7 +5513,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5521,12 +5525,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5539,11 +5543,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5553,7 +5557,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5566,7 +5570,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5575,11 +5579,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5667,21 +5671,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5689,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5701,22 +5705,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5732,7 +5736,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5804,7 +5808,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5870,7 +5874,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5915,7 +5919,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5923,7 +5927,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5935,7 +5939,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5946,7 +5950,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5955,12 +5959,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6004,7 +6008,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6012,19 +6016,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6033,11 +6037,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6055,17 +6059,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6074,23 +6078,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6100,7 +6104,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6121,7 +6125,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6137,19 +6141,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6197,11 +6201,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6249,7 +6253,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6272,7 +6276,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6295,7 +6299,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6308,12 +6312,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6330,17 +6334,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6357,7 +6361,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6388,7 +6392,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6408,7 +6412,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6445,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6562,15 +6566,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6590,13 +6594,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6661,20 +6665,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6721,8 +6725,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6742,44 +6746,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6817,7 +6821,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7021,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7037,7 +7041,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7045,7 +7049,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7061,7 +7065,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7178,20 +7182,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7212,7 +7216,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7259,7 +7263,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7408,7 +7412,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7416,11 +7420,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7432,16 +7436,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7457,11 +7461,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -379,7 +379,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -418,7 +418,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -660,27 +660,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -689,17 +689,17 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -742,7 +742,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -759,19 +759,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -789,19 +789,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -857,11 +857,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -882,11 +882,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -923,11 +923,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -944,7 +944,7 @@ msgstr "Il nome del container è: %s"
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -983,7 +983,7 @@ msgstr "Nome dell'alias mancante"
 msgid "Aliases already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr "Alias:"
 
@@ -991,7 +991,7 @@ msgstr "Alias:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1000,12 +1000,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
@@ -1015,11 +1015,11 @@ msgstr "Architettura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1052,11 +1052,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1064,12 +1064,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1078,20 +1078,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1109,7 +1109,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1118,8 +1118,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -1157,11 +1157,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1181,24 +1181,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1208,21 +1208,21 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -1234,7 +1234,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1243,15 +1243,15 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1259,11 +1259,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1294,12 +1294,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1309,13 +1309,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1385,17 +1385,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colonne"
@@ -1466,8 +1466,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1476,7 +1476,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1573,21 +1573,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1658,7 +1658,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1710,11 +1710,11 @@ msgstr "Creazione del container in corso"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Creazione del container in corso"
@@ -1752,7 +1752,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1767,19 +1767,19 @@ msgstr "Creazione di %s in corso"
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1787,7 +1787,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1795,7 +1795,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
@@ -1857,11 +1857,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
@@ -1940,15 +1940,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1959,20 +1959,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1991,9 +1991,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2087,7 +2087,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2104,7 +2104,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2116,26 +2116,26 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
@@ -2152,7 +2152,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2161,7 +2161,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -2174,7 +2174,7 @@ msgstr "DATA DI SCADENZA"
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2192,7 +2192,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -2234,11 +2234,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
@@ -2286,7 +2286,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2339,8 +2339,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2354,7 +2354,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2401,17 +2401,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2462,7 +2462,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2471,12 +2471,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2491,12 +2491,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2526,7 +2526,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2541,31 +2541,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2575,7 +2575,7 @@ msgstr "Accetta certificato"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2585,17 +2585,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2610,17 +2610,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2630,7 +2630,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2695,12 +2695,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2723,30 +2723,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2758,7 +2758,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2771,7 +2771,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2787,11 +2787,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Creazione del container in corso"
@@ -2860,11 +2860,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2937,31 +2937,31 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -2970,12 +2970,12 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2992,7 +2992,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -3000,11 +3000,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -3057,7 +3057,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -3073,21 +3073,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3137,7 +3137,7 @@ msgstr "Creazione del container in corso"
 msgid "Importing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3149,16 +3149,16 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3177,16 +3177,16 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Il nome del container è: %s"
@@ -3195,7 +3195,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3209,12 +3209,12 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3224,12 +3224,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3239,17 +3239,17 @@ msgstr "Il nome del container è: %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3273,12 +3273,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3290,17 +3290,17 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3313,7 +3313,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3321,12 +3321,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3335,7 +3335,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3344,26 +3344,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architettura: %s"
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3409,11 +3409,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Creazione del container in corso"
@@ -3471,11 +3471,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3511,12 +3511,12 @@ msgstr "Creazione del container in corso"
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 #, fuzzy
 msgid "List instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3658,7 +3658,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3698,7 +3698,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3707,7 +3707,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3725,7 +3725,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3734,7 +3734,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3747,11 +3747,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3811,7 +3811,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
@@ -3887,25 +3887,25 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Creazione del container in corso"
@@ -3996,12 +3996,12 @@ msgstr "Il nome del container è: %s"
 msgid "Manage warnings"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -4030,19 +4030,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr "Il nome del container è: %s"
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
@@ -4124,14 +4124,14 @@ msgstr "Il nome del container è: %s"
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
@@ -4153,16 +4153,16 @@ msgstr "Il nome del container è: %s"
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4230,7 +4230,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -4243,12 +4243,12 @@ msgstr "Il nome del container è: %s"
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4269,16 +4269,16 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -4320,7 +4320,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4338,10 +4338,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4358,53 +4358,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4454,22 +4454,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4503,7 +4503,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4547,11 +4547,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4572,7 +4572,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4598,7 +4598,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4619,7 +4619,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4631,7 +4631,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4640,11 +4640,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4653,39 +4653,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4703,7 +4703,7 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4716,20 +4716,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4737,8 +4737,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4826,11 +4826,11 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4849,15 +4849,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4947,11 +4947,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4965,21 +4965,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4988,7 +4988,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5004,7 +5004,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -5019,7 +5019,7 @@ msgstr "Creazione del container in corso"
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5027,7 +5027,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -5036,46 +5036,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -5107,7 +5111,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5115,12 +5119,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
@@ -5146,11 +5150,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
@@ -5159,7 +5163,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5218,7 +5222,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5235,7 +5239,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5252,7 +5256,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -5298,7 +5302,7 @@ msgstr "Il nome del container è: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -5338,11 +5342,11 @@ msgstr "Creazione del container in corso"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5350,26 +5354,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5381,7 +5385,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5406,19 +5410,19 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5437,7 +5441,7 @@ msgstr "Creazione del container in corso"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5463,7 +5467,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5506,11 +5510,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5519,12 +5523,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5631,19 +5635,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5655,11 +5659,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
@@ -5707,7 +5711,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5766,7 +5770,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5783,7 +5787,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5808,11 +5812,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Il nome del container è: %s"
@@ -5877,7 +5881,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5885,11 +5889,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5910,7 +5914,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5922,12 +5926,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -5940,11 +5944,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5954,7 +5958,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5968,7 +5972,7 @@ msgstr "Creazione del container in corso"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -5978,11 +5982,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6071,21 +6075,21 @@ msgstr "Creazione del container in corso"
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6093,7 +6097,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6105,23 +6109,23 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6137,7 +6141,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6210,7 +6214,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6225,7 +6229,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6276,7 +6280,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6323,7 +6327,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6331,7 +6335,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -6343,7 +6347,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6354,7 +6358,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6363,12 +6367,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6412,7 +6416,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6421,19 +6425,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Accetta certificato"
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6442,11 +6446,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6464,17 +6468,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
@@ -6484,23 +6488,23 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6510,7 +6514,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6534,7 +6538,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6550,20 +6554,20 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
@@ -6616,11 +6620,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
@@ -6672,7 +6676,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6696,7 +6700,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6720,7 +6724,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6733,12 +6737,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6755,17 +6759,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6782,7 +6786,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6813,7 +6817,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6835,7 +6839,7 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
@@ -6880,7 +6884,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7022,17 +7026,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7057,14 +7061,14 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
@@ -7144,23 +7148,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7218,8 +7222,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
@@ -7244,50 +7248,50 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
@@ -7334,7 +7338,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7587,7 +7591,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
@@ -7607,7 +7611,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
@@ -7617,7 +7621,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7625,7 +7629,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7633,7 +7637,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7750,20 +7754,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7784,7 +7788,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7831,7 +7835,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7980,7 +7984,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -7989,11 +7993,11 @@ msgstr "no"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8005,16 +8009,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8030,12 +8034,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -367,7 +367,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -412,7 +412,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -652,27 +652,27 @@ msgstr ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -681,17 +681,17 @@ msgstr "'%s' はサポートされないタイプのファイルです"
 msgid "(none)"
 msgstr "(none)"
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- レベル %d (タイプ: %s): %s"
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- パーティション %d"
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- ポート %d (%s)"
@@ -733,7 +733,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
@@ -749,19 +749,19 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -780,19 +780,19 @@ msgstr "<target>"
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -800,7 +800,7 @@ msgstr "AUTH TYPE"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -847,11 +847,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
@@ -872,11 +872,11 @@ msgstr "グループからメンバーを削除します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -932,11 +932,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
@@ -952,7 +952,7 @@ msgstr "クラスターメンバーにロールを追加します"
 msgid "Add rules to an ACL"
 msgstr "ACLにルールを追加します"
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr "アドレス: %s"
@@ -962,7 +962,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -991,7 +991,7 @@ msgstr "エイリアスを指定してください"
 msgid "Aliases already exists: %s"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr "エイリアス:"
 
@@ -999,7 +999,7 @@ msgstr "エイリアス:"
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
@@ -1007,12 +1007,12 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
@@ -1023,11 +1023,11 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "本当に %s しますか? （対象: クラスターメンバー %q） (yes/no) [default=no]: "
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1059,11 +1059,11 @@ msgstr "新たにストレージボリュームをインスタンスに追加し
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr "インスタンスのコンソールに接続します"
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1075,12 +1075,12 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "オートネゴシエーション: %v"
@@ -1089,20 +1089,20 @@ msgstr "オートネゴシエーション: %v"
 msgid "Auto update is only available in pull mode"
 msgstr "自動更新は pull モードのときのみ有効です"
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
@@ -1120,7 +1120,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1131,8 +1131,8 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1161,7 +1161,7 @@ msgstr "ボンディング:"
 msgid "Both --all and instance name given"
 msgstr "--all とインスタンス名を両方同時に指定することはできません"
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr "ブランド: %v"
@@ -1170,11 +1170,11 @@ msgstr "ブランド: %v"
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1194,24 +1194,24 @@ msgstr "CONTENT-TYPE"
 msgid "COUNT"
 msgstr "COUNT"
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs (%s):"
@@ -1220,21 +1220,21 @@ msgstr "CPUs (%s):"
 msgid "CREATED"
 msgstr "CREATED"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr "CREATED AT"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr "キャッシュ:"
 
@@ -1246,7 +1246,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1256,15 +1256,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr "--project と --all-project は同時に指定できません"
 
@@ -1272,11 +1272,11 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1285,7 +1285,7 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1310,12 +1310,12 @@ msgstr "設定キーを設定できません: %s"
 msgid "Cannot use metrics type certificate when using a token"
 msgstr "トークンを使っている時はメトリクスタイプの証明書を使えません"
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "カード: %s (%s)"
@@ -1325,14 +1325,14 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1346,7 +1346,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1401,17 +1401,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1486,8 +1486,8 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1496,7 +1496,7 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr "コンソールログ:"
 
@@ -1509,7 +1509,7 @@ msgstr "ストレージボリュームのタイプ、block もしくは filesyst
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
@@ -1608,21 +1608,21 @@ msgstr "イメージのコピー中: %s"
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr "コア %d"
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1661,7 +1661,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -1690,7 +1690,7 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1744,11 +1744,11 @@ msgstr "新たにインスタンスのファイルテンプレートを作成し
 msgid "Create new network ACLs"
 msgstr "新たにネットワーク ACL を作成します"
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr "新たにネットワークフォワードを作成します"
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr "新たにネットワークロードバランサーを作成します"
 
@@ -1784,7 +1784,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1798,19 +1798,19 @@ msgstr "%s を作成中"
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1818,7 +1818,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
@@ -1826,7 +1826,7 @@ msgstr "DISK USAGE"
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr "DRM:"
 
@@ -1850,7 +1850,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
@@ -1888,11 +1888,11 @@ msgstr "ストレージバケットからキーを削除します"
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
@@ -1968,15 +1968,15 @@ msgstr "警告を削除します"
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1987,20 +1987,20 @@ msgstr "警告を削除します"
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -2019,9 +2019,9 @@ msgstr "警告を削除します"
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "プロファイルのデバイスは個々のインスタンスでは取得できません"
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr "デバイス: %s"
@@ -2136,7 +2136,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2148,24 +2148,24 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
@@ -2181,7 +2181,7 @@ msgstr "進捗情報を表示しません"
 msgid "Down delay"
 msgstr "Down delay"
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
@@ -2190,7 +2190,7 @@ msgstr "ドライバ: %v (%v)"
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
@@ -2202,7 +2202,7 @@ msgstr "EXPIRES AT"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2223,7 +2223,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2266,11 +2266,11 @@ msgstr "ネットワーク ACL をYAMLで編集します"
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
@@ -2314,7 +2314,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2378,8 +2378,8 @@ msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2393,7 +2393,7 @@ msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2450,17 +2450,17 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr "失効日時"
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
@@ -2513,7 +2513,7 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
@@ -2522,12 +2522,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2542,12 +2542,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2577,7 +2577,7 @@ msgstr "クライアント %q のチャンネルの受け入れに失敗しま�
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2592,31 +2592,31 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
@@ -2626,7 +2626,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2636,17 +2636,17 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2661,17 +2661,17 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
@@ -2680,7 +2680,7 @@ msgstr "Fast モード (--columns=nsacPt と同じ)"
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -2760,12 +2760,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2788,30 +2788,30 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "クロック数: %vMhz"
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr "GPU:"
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -2823,7 +2823,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -2836,7 +2836,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -2853,12 +2853,12 @@ msgstr "クラスターグループを作成します"
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "ネットワークロードバランサーのポートを管理します"
@@ -2929,11 +2929,11 @@ msgstr "ネットワーク ACL の設定値を取得します"
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
@@ -3002,30 +3002,30 @@ msgstr "MAC ADDRESS"
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3034,12 +3034,12 @@ msgstr "sshfs からインスタンスへの I/O コピーに失敗しました:
 msgid "ID"
 msgstr "ID"
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr "ID: %d"
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
@@ -3056,7 +3056,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -3064,11 +3064,11 @@ msgstr "IP アドレス"
 msgid "IP addresses:"
 msgstr "IP アドレス:"
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -3125,7 +3125,7 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
@@ -3141,21 +3141,21 @@ msgstr "イメージの失効日（フォーマット: rfc3339）"
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3211,7 +3211,7 @@ msgstr "カスタムボリュームのインポート中: %s"
 msgid "Importing instance: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
@@ -3223,15 +3223,15 @@ msgstr "入力するデータ"
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3250,16 +3250,16 @@ msgstr "インスタンス名: %s"
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "インスタンスは以下のフィンガープリントで publish されます: %s"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "インスタンス名: %s"
@@ -3268,7 +3268,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3282,12 +3282,12 @@ msgstr "不正な引数 %q"
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3298,12 +3298,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "不正なフォーマット %s"
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3313,19 +3313,19 @@ msgstr "不正なインスタンスのパス: %q"
 msgid "Invalid key=value configuration: %s"
 msgstr "不適切な キー=値 の設定: %s"
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3352,12 +3352,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3368,17 +3368,17 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr "IsSM: %s (%s)"
@@ -3391,7 +3391,7 @@ msgstr "最初にコピーした後も常にイメージを最新の状態に保
 msgid "LAST SEEN"
 msgstr "LAST SEEN"
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
@@ -3399,12 +3399,12 @@ msgstr "LAST USED AT"
 msgid "LIMIT"
 msgstr "LIMIT"
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr "LOCATION"
@@ -3413,7 +3413,7 @@ msgstr "LOCATION"
 msgid "LXD - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
@@ -3424,26 +3424,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr "リンクを検出: %v"
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
@@ -3484,11 +3484,11 @@ msgstr "利用可能なネットワーク ACL を一覧表示します"
 msgid "List available network ACLS"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr "利用可能なネットワークフォワードを一覧表示します"
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr "利用可能なネットワークロードバランサーを一覧表示します"
 
@@ -3549,11 +3549,11 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3612,11 +3612,11 @@ msgstr "インスタンスのデバイスを一覧表示します"
 msgid "List instance file templates"
 msgstr "インスタンスのファイルテンプレートを一覧表示します"
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3850,7 +3850,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -3916,7 +3916,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr "ログ:"
 
@@ -3932,7 +3932,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -3941,7 +3941,7 @@ msgstr "MAC アドレス"
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
@@ -3954,11 +3954,11 @@ msgstr "MANAGED"
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr "MEMORY USAGE"
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
@@ -3975,7 +3975,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr "MTU"
 
@@ -4016,7 +4016,7 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
@@ -4104,23 +4104,23 @@ msgstr "ネットワーク ACL ルールを管理します"
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr "ネットワークフォワードを管理します"
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr "ネットワークロードバランサーのバックエンドを管理します"
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr "ネットワークロードバランサーを管理します"
 
@@ -4206,12 +4206,12 @@ msgstr "クラスタロールを管理します"
 msgid "Manage warnings"
 msgstr "警告を管理します"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr "VF の最大数: %d"
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
@@ -4240,19 +4240,19 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr "メモリ:"
 
@@ -4320,7 +4320,7 @@ msgstr "クラスターグループ名がありません"
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -4329,14 +4329,14 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
@@ -4356,16 +4356,16 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4428,7 +4428,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4440,12 +4440,12 @@ msgstr "作成するネットワーク名を指定する必要があります"
 msgid "Mode"
 msgstr "モード"
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr "モデル: %s"
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr "モデル: %v"
@@ -4469,17 +4469,17 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Mounted: %v"
 msgstr "モデル: %v"
@@ -4532,7 +4532,7 @@ msgstr "コピー／移動元とは異なるプロジェクトに移動します
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
@@ -4552,10 +4552,10 @@ msgstr "インスタンス名を指定する必要があります: "
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr "NAME"
@@ -4572,53 +4572,53 @@ msgstr "NETWORK ZONES"
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr "NIC:"
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr "NICs:"
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr "NO"
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr "NVIDIA 情報:"
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr "名前"
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr "名前: %v"
@@ -4668,22 +4668,22 @@ msgstr "ネットワークゾーン %s を作成しました"
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr "ネットワークロードバランサー %s を作成しました"
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -4764,11 +4764,11 @@ msgstr "このネットワークに対するデバイスがありません"
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
@@ -4789,7 +4789,7 @@ msgstr "コピー先のボリュームに対するストレージプールが指
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
@@ -4814,7 +4814,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4835,7 +4835,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -4847,7 +4847,7 @@ msgstr "プロジェクトを指定します"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "ターミナルモードを上書きします (auto, interactive, non-interactive)"
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
@@ -4856,11 +4856,11 @@ msgstr "PCI アドレス: %v"
 msgid "PEER"
 msgstr "PEER"
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr "PID"
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
@@ -4869,39 +4869,39 @@ msgstr "PID: %d"
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr "PORTS"
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr "送信パケット"
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr "パーティション:"
 
@@ -4918,7 +4918,7 @@ msgstr "インスタンスを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
@@ -4930,20 +4930,20 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr "ポートタイプ: %s"
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -4951,8 +4951,8 @@ msgstr "終了するには ctrl+c を押してください"
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4978,7 +4978,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -4988,7 +4988,7 @@ msgstr "プロセス数: %d"
 msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s"
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
@@ -5040,11 +5040,11 @@ msgstr "移動先のインスタンスに適用するプロファイル"
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr "プロファイル:"
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr "プロファイル: "
 
@@ -5063,15 +5063,15 @@ msgstr "プロジェクト %s を削除しました"
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5164,11 +5164,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
@@ -5182,20 +5182,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5204,7 +5204,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5220,7 +5220,7 @@ msgstr "ROLE"
 msgid "ROLES"
 msgstr "ROLES"
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
@@ -5235,7 +5235,7 @@ msgstr "空のインスタンスを作成"
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -5243,7 +5243,7 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
@@ -5252,46 +5252,51 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+#, fuzzy
+msgid "Remote trust token"
+msgstr "信頼済みクライアントを削除します"
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr "リムーバブルディスク: %v"
@@ -5322,7 +5327,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
@@ -5330,11 +5335,11 @@ msgstr "マッチするポートをすべて削除します"
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
@@ -5360,11 +5365,11 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove permissions from groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
@@ -5372,7 +5377,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5431,7 +5436,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
@@ -5466,7 +5471,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -5515,7 +5520,7 @@ msgstr "クラスターメンバーをリストアしています: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
@@ -5553,11 +5558,11 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr "SIZE"
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
@@ -5565,26 +5570,26 @@ msgstr "SNAPSHOTS"
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5596,7 +5601,7 @@ msgstr "STATUS"
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
@@ -5621,20 +5626,20 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 #, fuzzy
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -5652,7 +5657,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5686,7 +5691,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -5741,11 +5746,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5758,11 +5763,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5899,19 +5904,19 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -5924,12 +5929,12 @@ msgstr "クラスターグループを作成します"
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を行います"
@@ -5980,7 +5985,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -6039,7 +6044,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -6056,7 +6061,7 @@ msgstr "インスタンスのメタデータファイルを表示します"
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
@@ -6080,11 +6085,11 @@ msgstr "ネットワーク ACL ログを表示します"
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr "ネットワークフォワードの設定を表示します"
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr "ネットワークロードバランサーの設定を表示します"
 
@@ -6142,7 +6147,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -6150,11 +6155,11 @@ msgstr "デフォルトのリモートを表示します"
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
@@ -6174,7 +6179,7 @@ msgstr "信頼済みクライアントの設定を表示します"
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
@@ -6186,12 +6191,12 @@ msgstr "ストレージプールの情報を表示します"
 msgid "Show warning"
 msgstr "警告を表示します"
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr "サイズ: %s"
@@ -6204,11 +6209,11 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
@@ -6218,7 +6223,7 @@ msgstr "ソケット %d:"
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr "取得元:"
 
@@ -6231,7 +6236,7 @@ msgstr "インスタンスを起動します"
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr "状態"
 
@@ -6240,11 +6245,11 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -6332,21 +6337,21 @@ msgstr "インスタンスの状態を保存します"
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr "サポートするモード: %s"
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -6354,7 +6359,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6366,22 +6371,22 @@ msgstr "TARGET"
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6398,7 +6403,7 @@ msgstr "--mode と --target-project は同時に指定できません"
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
@@ -6475,7 +6480,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6490,7 +6495,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6541,7 +6546,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
@@ -6598,7 +6603,7 @@ msgstr ""
 "仮想マシン上にローカルな LXD サーバを簡単にセットアップするには、https://"
 "multipass.run の使用を検討してください。"
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr "スレッド:"
 
@@ -6606,7 +6611,7 @@ msgstr "スレッド:"
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
@@ -6621,7 +6626,7 @@ msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
@@ -6636,7 +6641,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -6647,12 +6652,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
@@ -6696,7 +6701,7 @@ msgstr "通信ポリシー"
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr "タイプ"
 
@@ -6704,7 +6709,7 @@ msgstr "タイプ"
 msgid "Type of certificate"
 msgstr "証明書の形式"
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6712,13 +6717,13 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
@@ -6727,11 +6732,11 @@ msgstr "タイプ: %s (ephemeral)"
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr "URL"
 
@@ -6749,17 +6754,17 @@ msgstr "USED BY"
 msgid "UUID"
 msgstr "UUID"
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
@@ -6768,23 +6773,23 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -6794,7 +6799,7 @@ msgstr "未知のファイルタイプ '%s'"
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
@@ -6816,7 +6821,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -6832,19 +6837,19 @@ msgstr "ネットワーク ACL の設定を削除します"
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
@@ -6892,12 +6897,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を削除します"
@@ -6953,7 +6958,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -6978,7 +6983,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
@@ -7003,7 +7008,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
@@ -7016,14 +7021,14 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 "ユーザからのシグナルを 3 度受信したので exit しました。リモート操作は実行し続"
 "けます"
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr "VFs: %d"
@@ -7040,17 +7045,17 @@ msgstr "VLAN フィルタリング"
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr "ベンダー: %v"
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr "ベンダ: %v (%v)"
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
@@ -7068,7 +7073,7 @@ msgstr "現在のプロジェクトを切り替えます"
 msgid "Volume Only"
 msgstr "Volume Only"
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr "WWN: %s"
@@ -7101,7 +7106,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr "YES"
 
@@ -7122,7 +7127,7 @@ msgstr "コピー元のインスタンス名を指定してください"
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr ""
@@ -7161,7 +7166,7 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -7283,15 +7288,15 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -7312,13 +7317,13 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
@@ -7385,21 +7390,21 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -7448,8 +7453,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "[<remote>:]<member> <role[,role...]>"
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
@@ -7469,17 +7474,17 @@ msgstr "[<remote>:]<network> <key>"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "[<remote>:]<network> <listen_address> <backend_name>"
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
@@ -7487,16 +7492,16 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -7504,7 +7509,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -7512,7 +7517,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
@@ -7552,7 +7557,7 @@ msgstr "[<remote>:]<network> <profile> [<device name>]"
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "[<remote>:]<network> <listen_address> [key=value...]"
@@ -7765,7 +7770,7 @@ msgstr "[<remote>:]<zone> <record> [key=value...]"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
@@ -7782,7 +7787,7 @@ msgstr "[<remote>:][<instance>] <key>=<value>..."
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
@@ -7791,7 +7796,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr "現在値"
 
@@ -7799,7 +7804,7 @@ msgstr "現在値"
 msgid "description"
 msgstr "説明"
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr "無効"
 
@@ -7807,7 +7812,7 @@ msgstr "無効"
 msgid "driver"
 msgstr "ドライバ"
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr "有効"
 
@@ -7969,7 +7974,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7978,7 +7983,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -7988,7 +7993,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8019,7 +8024,7 @@ msgstr ""
 "lxc import backup0.tar.gz\n"
 "    backup0.tar.gz を使って新しいインスタンスを作成します。"
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -8087,7 +8092,7 @@ msgstr ""
 "lxc launch ubuntu:22.04 v1 --vm\n"
 "    仮想マシンを作成し、起動します"
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8310,7 +8315,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr "n"
 
@@ -8318,11 +8323,11 @@ msgstr "n"
 msgid "name"
 msgstr "名前"
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -8334,16 +8339,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
@@ -8361,14 +8366,18 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy, c-format
+#~ msgid "Trust token for %s: "
+#~ msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
 #~ msgid ""
 #~ "lxc init ubuntu:22.04 u1\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -415,27 +415,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -444,17 +444,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -496,7 +496,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,19 +541,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -607,11 +607,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -631,11 +631,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -672,11 +672,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -747,12 +747,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -762,11 +762,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -810,12 +810,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -824,20 +824,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -864,8 +864,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -927,24 +927,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -953,21 +953,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -988,15 +988,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1039,12 +1039,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1054,13 +1054,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,17 +1129,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1210,8 +1210,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1317,21 +1317,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1447,11 +1447,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1487,7 +1487,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1501,19 +1501,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1589,11 +1589,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1669,15 +1669,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1688,20 +1688,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1720,9 +1720,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1843,24 +1843,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1885,7 +1885,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1897,7 +1897,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1915,7 +1915,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1955,11 +1955,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2056,8 +2056,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2071,7 +2071,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2117,17 +2117,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2255,31 +2255,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2299,17 +2299,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2324,17 +2324,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2407,12 +2407,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2435,30 +2435,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2498,11 +2498,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2566,11 +2566,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2638,30 +2638,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2670,12 +2670,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2692,7 +2692,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2700,11 +2700,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2756,7 +2756,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2772,21 +2772,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2847,15 +2847,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2873,16 +2873,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2905,12 +2905,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2920,12 +2920,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2935,17 +2935,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2983,17 +2983,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3014,12 +3014,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3037,26 +3037,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3097,11 +3097,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3156,11 +3156,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3195,11 +3195,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3377,7 +3377,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3402,7 +3402,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3424,11 +3424,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3557,23 +3557,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3653,12 +3653,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3687,19 +3687,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3763,7 +3763,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3772,14 +3772,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3799,16 +3799,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3883,12 +3883,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3909,15 +3909,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3977,10 +3977,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -3997,53 +3997,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4093,22 +4093,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4142,7 +4142,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4186,11 +4186,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4211,7 +4211,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4269,7 +4269,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4278,11 +4278,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4291,39 +4291,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4340,7 +4340,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4352,20 +4352,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4373,8 +4373,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4398,7 +4398,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4408,7 +4408,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4460,11 +4460,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4483,15 +4483,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4581,11 +4581,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4599,20 +4599,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4621,7 +4621,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4650,7 +4650,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4658,7 +4658,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4667,46 +4667,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4736,7 +4740,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4744,11 +4748,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4772,11 +4776,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4784,7 +4788,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4841,7 +4845,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4858,7 +4862,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4875,7 +4879,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4918,7 +4922,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4955,11 +4959,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4967,26 +4971,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -4998,7 +5002,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5023,19 +5027,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5078,7 +5082,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5121,11 +5125,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5134,11 +5138,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5242,19 +5246,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5266,11 +5270,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5314,7 +5318,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5371,7 +5375,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5387,7 +5391,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5411,11 +5415,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5473,7 +5477,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5481,11 +5485,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5505,7 +5509,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5517,12 +5521,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5535,11 +5539,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5549,7 +5553,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5562,7 +5566,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5571,11 +5575,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5663,21 +5667,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5685,7 +5689,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5697,22 +5701,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5728,7 +5732,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5800,7 +5804,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5815,7 +5819,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5866,7 +5870,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5911,7 +5915,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5919,7 +5923,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5931,7 +5935,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5942,7 +5946,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5951,12 +5955,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6000,7 +6004,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6008,19 +6012,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6029,11 +6033,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6051,17 +6055,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6070,23 +6074,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6096,7 +6100,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6117,7 +6121,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6133,19 +6137,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6193,11 +6197,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6245,7 +6249,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6268,7 +6272,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6291,7 +6295,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6304,12 +6308,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6326,17 +6330,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6353,7 +6357,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6384,7 +6388,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6404,7 +6408,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6441,7 +6445,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6558,15 +6562,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6586,13 +6590,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6657,20 +6661,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6717,8 +6721,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6738,44 +6742,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6813,7 +6817,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7017,7 +7021,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7033,7 +7037,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7041,7 +7045,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7049,7 +7053,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7057,7 +7061,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7174,20 +7178,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7208,7 +7212,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7255,7 +7259,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7404,7 +7408,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7412,11 +7416,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7428,16 +7432,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7453,11 +7457,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-05-24 12:39+0200\n"
+        "POT-Creation-Date: 2024-06-12 10:01+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -237,7 +237,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -259,7 +259,7 @@ msgid   "### This is a YAML representation of the network forward.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -386,27 +386,27 @@ msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -415,17 +415,17 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid   "- Level %d (type: %s): %s"
 msgstr  ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid   "- Partition %d"
 msgstr  ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid   "- Port %d (%s)"
 msgstr  ""
@@ -466,7 +466,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797 lxc/info.go:453
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797 lxc/info.go:452
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -482,19 +482,19 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -510,19 +510,19 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -530,7 +530,7 @@ msgstr  ""
 msgid   "AUTHENTICATION METHOD"
 msgstr  ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -576,11 +576,11 @@ msgstr  ""
 msgid   "Add a network zone record entry"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid   "Add backend to a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
@@ -600,11 +600,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -634,11 +634,11 @@ msgstr  ""
 msgid   "Add permissions to groups"
 msgstr  ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid   "Add ports to a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
@@ -654,7 +654,7 @@ msgstr  ""
 msgid   "Add rules to an ACL"
 msgstr  ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid   "Address: %s"
 msgstr  ""
@@ -664,7 +664,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -693,7 +693,7 @@ msgstr  ""
 msgid   "Aliases already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid   "Aliases:"
 msgstr  ""
 
@@ -701,7 +701,7 @@ msgstr  ""
 msgid   "All projects"
 msgstr  ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -709,12 +709,12 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid   "Architecture: %v"
 msgstr  ""
@@ -724,11 +724,11 @@ msgstr  ""
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -760,23 +760,23 @@ msgstr  ""
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid   "Attach to instance consoles"
 msgstr  ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid   "Attach to instance consoles\n"
         "\n"
         "This command allows you to interact with the boot console of an instance\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid   "Auto negotiation: %v"
 msgstr  ""
@@ -785,20 +785,20 @@ msgstr  ""
 msgid   "Auto update is only available in pull mode"
 msgstr  ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid   "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr  ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid   "Available projects:"
 msgstr  ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid   "BASE IMAGE"
 msgstr  ""
 
@@ -816,7 +816,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid   "Backups:"
 msgstr  ""
 
@@ -825,7 +825,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291 lxc/network_load_balancer.go:294 lxc/network_peer.go:280 lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293 lxc/network_load_balancer.go:296 lxc/network_peer.go:280 lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -853,7 +853,7 @@ msgstr  ""
 msgid   "Both --all and instance name given"
 msgstr  ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid   "Brand: %v"
 msgstr  ""
@@ -862,11 +862,11 @@ msgstr  ""
 msgid   "Bridge:"
 msgstr  ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -886,24 +886,24 @@ msgstr  ""
 msgid   "COUNT"
 msgstr  ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid   "CPU (%s):"
 msgstr  ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid   "CPU usage:"
 msgstr  ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid   "CPUs (%s):"
 msgstr  ""
@@ -912,21 +912,21 @@ msgstr  ""
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid   "CREATED AT"
 msgstr  ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid   "CUDA Version: %v"
 msgstr  ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid   "Cached: %s"
 msgstr  ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid   "Caches:"
 msgstr  ""
 
@@ -938,7 +938,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -947,15 +947,15 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid   "Can't specify --project with --all-projects"
 msgstr  ""
 
@@ -963,11 +963,11 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -976,7 +976,7 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
@@ -997,12 +997,12 @@ msgstr  ""
 msgid   "Cannot use metrics type certificate when using a token"
 msgstr  ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid   "Card: %s (%s)"
 msgstr  ""
@@ -1012,12 +1012,12 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -1031,7 +1031,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1085,7 +1085,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738 lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:172 lxc/network_forward.go:237 lxc/network_forward.go:441 lxc/network_forward.go:564 lxc/network_forward.go:706 lxc/network_forward.go:783 lxc/network_forward.go:849 lxc/network_load_balancer.go:174 lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444 lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710 lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850 lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:358 lxc/storage_volume.go:560 lxc/storage_volume.go:639 lxc/storage_volume.go:883 lxc/storage_volume.go:1097 lxc/storage_volume.go:1210 lxc/storage_volume.go:1678 lxc/storage_volume.go:1758 lxc/storage_volume.go:1885 lxc/storage_volume.go:2031 lxc/storage_volume.go:2135 lxc/storage_volume.go:2175 lxc/storage_volume.go:2268 lxc/storage_volume.go:2340 lxc/storage_volume.go:2492
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738 lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:174 lxc/network_forward.go:239 lxc/network_forward.go:456 lxc/network_forward.go:579 lxc/network_forward.go:721 lxc/network_forward.go:798 lxc/network_forward.go:864 lxc/network_load_balancer.go:176 lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459 lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725 lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865 lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:358 lxc/storage_volume.go:560 lxc/storage_volume.go:639 lxc/storage_volume.go:883 lxc/storage_volume.go:1097 lxc/storage_volume.go:1210 lxc/storage_volume.go:1678 lxc/storage_volume.go:1758 lxc/storage_volume.go:1885 lxc/storage_volume.go:2031 lxc/storage_volume.go:2135 lxc/storage_volume.go:2175 lxc/storage_volume.go:2268 lxc/storage_volume.go:2340 lxc/storage_volume.go:2492
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1101,7 +1101,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427 lxc/warning.go:92
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427 lxc/warning.go:92
 msgid   "Columns"
 msgstr  ""
 
@@ -1136,12 +1136,12 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272 lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686 lxc/network_acl.go:620 lxc/network_forward.go:670 lxc/network_load_balancer.go:674 lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016 lxc/storage_volume.go:1048
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272 lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686 lxc/network_acl.go:620 lxc/network_forward.go:685 lxc/network_load_balancer.go:689 lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016 lxc/storage_volume.go:1048
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid   "Console log:"
 msgstr  ""
 
@@ -1154,7 +1154,7 @@ msgstr  ""
 msgid   "Content type: %s"
 msgstr  ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid   "Control: %s (%s)"
 msgstr  ""
@@ -1231,21 +1231,21 @@ msgstr  ""
 msgid   "Copying the storage volume: %s"
 msgstr  ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid   "Core %d"
 msgstr  ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1284,7 +1284,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1313,7 +1313,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1360,11 +1360,11 @@ msgstr  ""
 msgid   "Create new network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid   "Create new network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid   "Create new network load balancers"
 msgstr  ""
 
@@ -1400,7 +1400,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1414,20 +1414,20 @@ msgstr  ""
 msgid   "Creating the instance"
 msgstr  ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438 lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985 lxc/network_acl.go:148 lxc/network_forward.go:147 lxc/network_load_balancer.go:150 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172 lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646 lxc/storage_bucket.go:507 lxc/storage_bucket.go:827 lxc/storage_volume.go:1562
+#: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438 lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985 lxc/network_acl.go:148 lxc/network_forward.go:149 lxc/network_load_balancer.go:152 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172 lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646 lxc/storage_bucket.go:507 lxc/storage_bucket.go:827 lxc/storage_volume.go:1562
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid   "DISK USAGE"
 msgstr  ""
 
@@ -1435,7 +1435,7 @@ msgstr  ""
 msgid   "DRIVER"
 msgstr  ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid   "DRM:"
 msgstr  ""
 
@@ -1459,7 +1459,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1495,11 +1495,11 @@ msgstr  ""
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid   "Delete network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid   "Delete network load balancers"
 msgstr  ""
 
@@ -1543,7 +1543,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350 lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:31 lxc/network_forward.go:88 lxc/network_forward.go:169 lxc/network_forward.go:234 lxc/network_forward.go:364 lxc/network_forward.go:433 lxc/network_forward.go:531 lxc/network_forward.go:561 lxc/network_forward.go:703 lxc/network_forward.go:765 lxc/network_forward.go:780 lxc/network_forward.go:845 lxc/network_load_balancer.go:31 lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368 lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534 lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707 lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933 lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821 lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:263 lxc/storage_volume.go:354 lxc/storage_volume.go:557 lxc/storage_volume.go:636 lxc/storage_volume.go:711 lxc/storage_volume.go:793 lxc/storage_volume.go:874 lxc/storage_volume.go:1083 lxc/storage_volume.go:1198 lxc/storage_volume.go:1345 lxc/storage_volume.go:1429 lxc/storage_volume.go:1674 lxc/storage_volume.go:1755 lxc/storage_volume.go:1870 lxc/storage_volume.go:2014 lxc/storage_volume.go:2123 lxc/storage_volume.go:2169 lxc/storage_volume.go:2266 lxc/storage_volume.go:2333 lxc/storage_volume.go:2487 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172 lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354 lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:171 lxc/network_forward.go:236 lxc/network_forward.go:379 lxc/network_forward.go:448 lxc/network_forward.go:546 lxc/network_forward.go:576 lxc/network_forward.go:718 lxc/network_forward.go:780 lxc/network_forward.go:795 lxc/network_forward.go:860 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383 lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549 lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722 lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90 lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824 lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:263 lxc/storage_volume.go:354 lxc/storage_volume.go:557 lxc/storage_volume.go:636 lxc/storage_volume.go:711 lxc/storage_volume.go:793 lxc/storage_volume.go:874 lxc/storage_volume.go:1083 lxc/storage_volume.go:1198 lxc/storage_volume.go:1345 lxc/storage_volume.go:1429 lxc/storage_volume.go:1674 lxc/storage_volume.go:1755 lxc/storage_volume.go:1870 lxc/storage_volume.go:2014 lxc/storage_volume.go:2123 lxc/storage_volume.go:2169 lxc/storage_volume.go:2266 lxc/storage_volume.go:2333 lxc/storage_volume.go:2487 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1608,7 +1608,7 @@ msgstr  ""
 msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid   "Device: %s"
 msgstr  ""
@@ -1625,7 +1625,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1637,24 +1637,24 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid   "Disk usage:"
 msgstr  ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid   "Disk:"
 msgstr  ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid   "Disks:"
 msgstr  ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid   "Display instances from all projects"
 msgstr  ""
 
@@ -1670,7 +1670,7 @@ msgstr  ""
 msgid   "Down delay"
 msgstr  ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid   "Driver: %v (%v)"
 msgstr  ""
@@ -1679,7 +1679,7 @@ msgstr  ""
 msgid   "ENTRIES"
 msgstr  ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -1691,7 +1691,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1707,7 +1707,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1747,11 +1747,11 @@ msgstr  ""
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
@@ -1795,7 +1795,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596 lxc/warning.go:235
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596 lxc/warning.go:235
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1842,7 +1842,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194 lxc/network_acl.go:467 lxc/network_forward.go:504 lxc/network_load_balancer.go:507 lxc/network_peer.go:463 lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856 lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597 lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194 lxc/network_acl.go:467 lxc/network_forward.go:519 lxc/network_load_balancer.go:522 lxc/network_peer.go:463 lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856 lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597 lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1852,7 +1852,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461 lxc/network_forward.go:498 lxc/network_load_balancer.go:501 lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997 lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721 lxc/storage_bucket.go:591 lxc/storage_volume.go:1941 lxc/storage_volume.go:1979
+#: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461 lxc/network_forward.go:513 lxc/network_load_balancer.go:516 lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997 lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721 lxc/storage_bucket.go:591 lxc/storage_volume.go:1941 lxc/storage_volume.go:1979
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1892,16 +1892,16 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346 lxc/storage_volume.go:1396
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346 lxc/storage_volume.go:1396
 msgid   "Expires at"
 msgstr  ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid   "Expires: never"
 msgstr  ""
 
@@ -1949,7 +1949,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068 lxc/image_alias.go:235
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072 lxc/image_alias.go:235
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -1957,12 +1957,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -1977,12 +1977,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2012,7 +2012,7 @@ msgstr  ""
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2027,31 +2027,31 @@ msgstr  ""
 msgid   "Failed loading profile %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -2061,7 +2061,7 @@ msgstr  ""
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -2071,17 +2071,17 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2096,17 +2096,17 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
@@ -2114,7 +2114,7 @@ msgstr  ""
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -2170,7 +2170,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:91 lxc/network_load_balancer.go:95 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1446 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2191,30 +2191,30 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid   "Frequency: %vMhz"
 msgstr  ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid   "GLOBAL"
 msgstr  ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid   "GPU:"
 msgstr  ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid   "GPUs:"
 msgstr  ""
 
@@ -2226,7 +2226,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2238,7 +2238,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2254,11 +2254,11 @@ msgstr  ""
 msgid   "Get the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid   "Get the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid   "Get the key as a network load balancer property"
 msgstr  ""
 
@@ -2322,11 +2322,11 @@ msgstr  ""
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
@@ -2394,30 +2394,30 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid   "Host interface"
 msgstr  ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2426,12 +2426,12 @@ msgstr  ""
 msgid   "ID"
 msgstr  ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid   "ID: %d"
 msgstr  ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid   "ID: %s"
 msgstr  ""
@@ -2448,7 +2448,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid   "IP addresses"
 msgstr  ""
 
@@ -2456,11 +2456,11 @@ msgstr  ""
 msgid   "IP addresses:"
 msgstr  ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid   "IPV6"
 msgstr  ""
 
@@ -2510,7 +2510,7 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid   "Image already up to date."
 msgstr  ""
 
@@ -2526,21 +2526,21 @@ msgstr  ""
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2588,7 +2588,7 @@ msgstr  ""
 msgid   "Importing instance: %s"
 msgstr  ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid   "Infiniband:"
 msgstr  ""
 
@@ -2600,15 +2600,15 @@ msgstr  ""
 msgid   "Inspect permissions"
 msgstr  ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2626,16 +2626,16 @@ msgstr  ""
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid   "Instance published with fingerprint: %s"
 msgstr  ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid   "Instance snapshots cannot be rebuilt: %s"
 msgstr  ""
@@ -2644,7 +2644,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2658,12 +2658,12 @@ msgstr  ""
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
@@ -2673,12 +2673,12 @@ msgstr  ""
 msgid   "Invalid format: %s"
 msgstr  ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2688,17 +2688,17 @@ msgstr  ""
 msgid   "Invalid key=value configuration: %s"
 msgstr  ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
@@ -2719,12 +2719,12 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -2733,17 +2733,17 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid   "IsSM: %s (%s)"
 msgstr  ""
@@ -2756,7 +2756,7 @@ msgstr  ""
 msgid   "LAST SEEN"
 msgstr  ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid   "LAST USED AT"
 msgstr  ""
 
@@ -2764,11 +2764,11 @@ msgstr  ""
 msgid   "LIMIT"
 msgstr  ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153 lxc/network_load_balancer.go:155 lxc/operation.go:177 lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155 lxc/network_load_balancer.go:157 lxc/operation.go:177 lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2776,7 +2776,7 @@ msgstr  ""
 msgid   "LXD - Command line client"
 msgstr  ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
@@ -2784,26 +2784,26 @@ msgstr  ""
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid   "Last used: never"
 msgstr  ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid   "Link detected: %v"
 msgstr  ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
@@ -2844,11 +2844,11 @@ msgstr  ""
 msgid   "List available network ACLS"
 msgstr  ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid   "List available network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid   "List available network load balancers"
 msgstr  ""
 
@@ -2902,11 +2902,11 @@ msgid   "List image aliases\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid   "List images"
 msgstr  ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -2940,11 +2940,11 @@ msgstr  ""
 msgid   "List instance file templates"
 msgstr  ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid   "List instances"
 msgstr  ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid   "List instances\n"
         "\n"
@@ -3074,7 +3074,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3112,7 +3112,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3121,7 +3121,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid   "Log:"
 msgstr  ""
 
@@ -3137,7 +3137,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid   "MAC address"
 msgstr  ""
 
@@ -3146,7 +3146,7 @@ msgstr  ""
 msgid   "MAC address: %s"
 msgstr  ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid   "MAD: %s (%s)"
 msgstr  ""
@@ -3159,11 +3159,11 @@ msgstr  ""
 msgid   "MEMBERS"
 msgstr  ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid   "MEMORY USAGE"
 msgstr  ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid   "MEMORY USAGE%"
 msgstr  ""
@@ -3180,7 +3180,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid   "MTU"
 msgstr  ""
 
@@ -3221,7 +3221,7 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid   "Manage files in instances"
 msgstr  ""
 
@@ -3291,23 +3291,23 @@ msgstr  ""
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid   "Manage network forward ports"
 msgstr  ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid   "Manage network forwards"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid   "Manage network load balancer backends"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid   "Manage network load balancer ports"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid   "Manage network load balancers"
 msgstr  ""
 
@@ -3385,12 +3385,12 @@ msgstr  ""
 msgid   "Manage warnings"
 msgstr  ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid   "Maximum number of VFs: %d"
 msgstr  ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid   "Mdev profiles:"
 msgstr  ""
 
@@ -3419,19 +3419,19 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid   "Memory (current)"
 msgstr  ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid   "Memory usage:"
 msgstr  ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid   "Memory:"
 msgstr  ""
 
@@ -3481,7 +3481,7 @@ msgstr  ""
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
-#: lxc/config_metadata.go:103 lxc/config_metadata.go:204 lxc/config_template.go:91 lxc/config_template.go:134 lxc/config_template.go:176 lxc/config_template.go:265 lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201 lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/config_metadata.go:103 lxc/config_metadata.go:204 lxc/config_template.go:91 lxc/config_template.go:134 lxc/config_template.go:176 lxc/config_template.go:265 lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201 lxc/profile.go:698 lxc/rebuild.go:60
 msgid   "Missing instance name"
 msgstr  ""
 
@@ -3489,7 +3489,7 @@ msgstr  ""
 msgid   "Missing key name"
 msgstr  ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393 lxc/network_forward.go:466 lxc/network_forward.go:612 lxc/network_forward.go:731 lxc/network_forward.go:808 lxc/network_forward.go:874 lxc/network_load_balancer.go:199 lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469 lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735 lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875 lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408 lxc/network_forward.go:481 lxc/network_forward.go:627 lxc/network_forward.go:746 lxc/network_forward.go:823 lxc/network_forward.go:889 lxc/network_load_balancer.go:201 lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750 lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890 lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -3501,7 +3501,7 @@ msgstr  ""
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446 lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815 lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158 lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193 lxc/network_forward.go:257 lxc/network_forward.go:389 lxc/network_forward.go:462 lxc/network_forward.go:608 lxc/network_forward.go:727 lxc/network_forward.go:804 lxc/network_forward.go:870 lxc/network_load_balancer.go:121 lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259 lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465 lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871 lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034 lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237 lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556 lxc/network_peer.go:665
+#: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446 lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815 lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158 lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195 lxc/network_forward.go:259 lxc/network_forward.go:404 lxc/network_forward.go:477 lxc/network_forward.go:623 lxc/network_forward.go:742 lxc/network_forward.go:819 lxc/network_forward.go:885 lxc/network_load_balancer.go:123 lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480 lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886 lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049 lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237 lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556 lxc/network_peer.go:665
 msgid   "Missing network name"
 msgstr  ""
 
@@ -3541,7 +3541,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3553,12 +3553,12 @@ msgstr  ""
 msgid   "Mode"
 msgstr  ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid   "Model: %s"
 msgstr  ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid   "Model: %v"
 msgstr  ""
@@ -3577,15 +3577,15 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid   "Mount files from instances"
 msgstr  ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid   "Mounted: %v"
 msgstr  ""
@@ -3622,7 +3622,7 @@ msgstr  ""
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
@@ -3638,7 +3638,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid   "NAME"
 msgstr  ""
 
@@ -3654,50 +3654,50 @@ msgstr  ""
 msgid   "NETWORKS"
 msgstr  ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid   "NIC:"
 msgstr  ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid   "NO"
 msgstr  ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid   "NVIDIA information:"
 msgstr  ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344 lxc/storage_volume.go:1394
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344 lxc/storage_volume.go:1394
 msgid   "Name"
 msgstr  ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid   "Name: %v"
 msgstr  ""
@@ -3747,22 +3747,22 @@ msgstr  ""
 msgid   "Network Zone %s deleted"
 msgstr  ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid   "Network load balancer %s created"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid   "Network load balancer %s deleted"
 msgstr  ""
@@ -3795,7 +3795,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid   "Network usage:"
 msgstr  ""
 
@@ -3839,11 +3839,11 @@ msgstr  ""
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid   "No matching backend found"
 msgstr  ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid   "No matching port(s) found"
 msgstr  ""
 
@@ -3864,7 +3864,7 @@ msgstr  ""
 msgid   "No value found in %q"
 msgstr  ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
@@ -3889,7 +3889,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3910,7 +3910,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -3922,7 +3922,7 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid   "PCI address: %v"
 msgstr  ""
@@ -3931,11 +3931,11 @@ msgstr  ""
 msgid   "PEER"
 msgstr  ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid   "PID"
 msgstr  ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
@@ -3944,39 +3944,39 @@ msgstr  ""
 msgid   "POOL"
 msgstr  ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid   "PORTS"
 msgstr  ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid   "Packets sent"
 msgstr  ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid   "Partitions:"
 msgstr  ""
 
@@ -3993,7 +3993,7 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -4005,24 +4005,24 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid   "Port type: %s"
 msgstr  ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:671 lxc/network_load_balancer.go:675 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017 lxc/storage_volume.go:1049
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:686 lxc/network_load_balancer.go:690 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017 lxc/storage_volume.go:1049
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4042,7 +4042,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -4052,7 +4052,7 @@ msgstr  ""
 msgid   "Processing aliases failed: %s"
 msgstr  ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid   "Product: %v (%v)"
 msgstr  ""
@@ -4104,11 +4104,11 @@ msgstr  ""
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid   "Profiles:"
 msgstr  ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid   "Profiles: "
 msgstr  ""
 
@@ -4127,15 +4127,15 @@ msgstr  ""
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid   "Project to use for the remote"
 msgstr  ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid   "Property not found"
 msgstr  ""
 
@@ -4209,11 +4209,11 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Removes the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -4227,20 +4227,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4249,7 +4249,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4265,7 +4265,7 @@ msgstr  ""
 msgid   "ROLES"
 msgstr  ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid   "Read-Only: %v"
 msgstr  ""
@@ -4278,7 +4278,7 @@ msgstr  ""
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -4286,7 +4286,7 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid   "Refresh images"
 msgstr  ""
 
@@ -4295,45 +4295,49 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898 lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901 lxc/remote.go:941
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid   "Remote trust token"
+msgstr  ""
+
+#: lxc/info.go:283
 #, c-format
 msgid   "Removable: %v"
 msgstr  ""
@@ -4363,7 +4367,7 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid   "Remove all ports that match"
 msgstr  ""
 
@@ -4371,11 +4375,11 @@ msgstr  ""
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid   "Remove backend from a load balancer"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
@@ -4399,11 +4403,11 @@ msgstr  ""
 msgid   "Remove permissions from groups"
 msgstr  ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
@@ -4411,7 +4415,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4467,7 +4471,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4484,7 +4488,7 @@ msgstr  ""
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid   "Render: %s (%s)"
 msgstr  ""
@@ -4501,7 +4505,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid   "Resources:"
 msgstr  ""
 
@@ -4542,7 +4546,7 @@ msgstr  ""
 msgid   "Restrict the certificate to one or more projects"
 msgstr  ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
@@ -4579,11 +4583,11 @@ msgstr  ""
 msgid   "SEVERITY"
 msgstr  ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid   "SNAPSHOTS"
 msgstr  ""
 
@@ -4591,25 +4595,25 @@ msgstr  ""
 msgid   "SOURCE"
 msgstr  ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987 lxc/network_peer.go:142 lxc/storage.go:648
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987 lxc/network_peer.go:142 lxc/storage.go:648
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid   "STATIC"
 msgstr  ""
 
@@ -4621,7 +4625,7 @@ msgstr  ""
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid   "STORAGE POOL"
 msgstr  ""
 
@@ -4646,19 +4650,19 @@ msgstr  ""
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -4675,7 +4679,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4697,7 +4701,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid   "Set image properties"
 msgstr  ""
 
@@ -4734,22 +4738,22 @@ msgid   "Set network configuration keys\n"
         "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid   "Set network load balancer keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid   "Set network load balancer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4837,19 +4841,19 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -4861,11 +4865,11 @@ msgstr  ""
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid   "Set the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid   "Set the key as a network load balancer property"
 msgstr  ""
 
@@ -4909,7 +4913,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -4962,7 +4966,7 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid   "Show image properties"
 msgstr  ""
 
@@ -4978,7 +4982,7 @@ msgstr  ""
 msgid   "Show instance or server configurations"
 msgstr  ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid   "Show instance or server information"
 msgstr  ""
 
@@ -5002,11 +5006,11 @@ msgstr  ""
 msgid   "Show network configurations"
 msgstr  ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid   "Show network forward configurations"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid   "Show network load balancer configurations"
 msgstr  ""
 
@@ -5062,7 +5066,7 @@ msgid   "Show the current identity\n"
         "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -5070,11 +5074,11 @@ msgstr  ""
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid   "Show the instance's last 100 log lines?"
 msgstr  ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid   "Show the resources available to the server"
 msgstr  ""
 
@@ -5094,7 +5098,7 @@ msgstr  ""
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid   "Show useful information about images"
 msgstr  ""
 
@@ -5106,12 +5110,12 @@ msgstr  ""
 msgid   "Show warning"
 msgstr  ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid   "Size: %.2fMiB"
 msgstr  ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid   "Size: %s"
 msgstr  ""
@@ -5124,11 +5128,11 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid   "Snapshots:"
 msgstr  ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
@@ -5138,7 +5142,7 @@ msgstr  ""
 msgid   "Some instances failed to %s"
 msgstr  ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid   "Source:"
 msgstr  ""
 
@@ -5151,7 +5155,7 @@ msgstr  ""
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid   "State"
 msgstr  ""
 
@@ -5160,11 +5164,11 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid   "Stateful"
 msgstr  ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -5252,21 +5256,21 @@ msgstr  ""
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid   "Supported modes: %s"
 msgstr  ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid   "Swap (current)"
 msgstr  ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -5274,7 +5278,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5286,19 +5290,19 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074 lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171 lxc/storage_volume.go:1560 lxc/warning.go:215
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078 lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981 lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171 lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -5314,7 +5318,7 @@ msgstr  ""
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
@@ -5384,7 +5388,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid   "The property %q does not exist on the load balancer %q: %v"
 msgstr  ""
@@ -5399,7 +5403,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network ACL %q: %v"
 msgstr  ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid   "The property %q does not exist on the network forward %q: %v"
 msgstr  ""
@@ -5449,7 +5453,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
@@ -5489,7 +5493,7 @@ msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "To easily setup a local LXD server in a virtual machine, consider using: https://multipass.run"
 msgstr  ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid   "Threads:"
 msgstr  ""
 
@@ -5497,7 +5501,7 @@ msgstr  ""
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid   "Timestamps:"
 msgstr  ""
 
@@ -5509,7 +5513,7 @@ msgstr  ""
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
@@ -5518,7 +5522,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777 lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777 lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5527,12 +5531,12 @@ msgstr  ""
 msgid   "Total: %s"
 msgstr  ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid   "Transceiver type: %s"
 msgstr  ""
@@ -5576,7 +5580,7 @@ msgstr  ""
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid   "Type"
 msgstr  ""
 
@@ -5584,16 +5588,16 @@ msgstr  ""
 msgid   "Type of certificate"
 msgstr  ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837 lxc/storage_volume.go:1293
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837 lxc/storage_volume.go:1293
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
@@ -5602,11 +5606,11 @@ msgstr  ""
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid   "URL"
 msgstr  ""
 
@@ -5622,17 +5626,17 @@ msgstr  ""
 msgid   "UUID"
 msgstr  ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -5641,22 +5645,22 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604 lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602 lxc/warning.go:241
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5666,7 +5670,7 @@ msgstr  ""
 msgid   "Unknown key: %s"
 msgstr  ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid   "Unknown output type %q"
 msgstr  ""
@@ -5687,7 +5691,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -5703,19 +5707,19 @@ msgstr  ""
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid   "Unset network forward keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid   "Unset network load balancer configuration keys"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
@@ -5763,11 +5767,11 @@ msgstr  ""
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid   "Unset the key as a network forward property"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid   "Unset the key as a network load balancer property"
 msgstr  ""
 
@@ -5815,7 +5819,7 @@ msgstr  ""
 msgid   "Unsupported content type for attaching to instances"
 msgstr  ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -5836,7 +5840,7 @@ msgstr  ""
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -5858,7 +5862,7 @@ msgstr  ""
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid   "Used: %v"
 msgstr  ""
@@ -5871,11 +5875,11 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid   "VFs: %d"
 msgstr  ""
@@ -5892,17 +5896,17 @@ msgstr  ""
 msgid   "VLAN:"
 msgstr  ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid   "Vendor: %v"
 msgstr  ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid   "Vendor: %v (%v)"
 msgstr  ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid   "Verb: %s (%s)"
 msgstr  ""
@@ -5919,7 +5923,7 @@ msgstr  ""
 msgid   "Volume Only"
 msgstr  ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid   "WWN: %s"
 msgstr  ""
@@ -5944,7 +5948,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid   "YES"
 msgstr  ""
 
@@ -5964,7 +5968,7 @@ msgstr  ""
 msgid   "You must specify a source instance name"
 msgstr  ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
@@ -5996,7 +6000,7 @@ msgstr  ""
 msgid   "[<remote>:] [<cert>]"
 msgstr  ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -6108,15 +6112,15 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6136,11 +6140,11 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53 lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53 lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -6204,19 +6208,19 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6260,7 +6264,7 @@ msgstr  ""
 msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
-#: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003 lxc/network.go:1214 lxc/network_forward.go:85 lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003 lxc/network.go:1214 lxc/network_forward.go:87 lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
@@ -6280,35 +6284,35 @@ msgstr  ""
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559 lxc/network_forward.go:700 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574 lxc/network_forward.go:715 lxc/network_load_balancer.go:171 lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid   "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr  ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529 lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544 lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
@@ -6344,7 +6348,7 @@ msgstr  ""
 msgid   "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid   "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr  ""
 
@@ -6540,7 +6544,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
@@ -6556,7 +6560,7 @@ msgstr  ""
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
@@ -6564,7 +6568,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid   "current"
 msgstr  ""
 
@@ -6572,7 +6576,7 @@ msgstr  ""
 msgid   "description"
 msgstr  ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid   "disabled"
 msgstr  ""
 
@@ -6580,7 +6584,7 @@ msgstr  ""
 msgid   "driver"
 msgstr  ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid   "enabled"
 msgstr  ""
 
@@ -6675,17 +6679,17 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -6703,7 +6707,7 @@ msgid   "lxc import backup0.tar.gz\n"
         "    Create a new instance using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid   "lxc info [<remote>:]<instance> [--show-log]\n"
         "    For instance information.\n"
         "\n"
@@ -6742,7 +6746,7 @@ msgid   "lxc launch ubuntu:24.04 u1\n"
         "    Create and start a virtual machine with 2 vCPUs, 8GiB of RAM and a root disk of 32GiB"
 msgstr  ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
         "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
         "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from instance configuration keys.\n"
@@ -6864,7 +6868,7 @@ msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid   "n"
 msgstr  ""
 
@@ -6872,11 +6876,11 @@ msgstr  ""
 msgid   "name"
 msgstr  ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6888,16 +6892,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 
@@ -6913,11 +6917,11 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942 lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946 lxc/image.go:1131
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -371,7 +371,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -409,7 +409,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -642,27 +642,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -671,17 +671,17 @@ msgstr ""
 msgid "(none)"
 msgstr "(geen)"
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -723,7 +723,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -739,19 +739,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -768,19 +768,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -834,11 +834,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -858,11 +858,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -899,11 +899,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -966,7 +966,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -974,12 +974,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -989,11 +989,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1025,11 +1025,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1037,12 +1037,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1051,20 +1051,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1091,8 +1091,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -1130,11 +1130,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -1154,24 +1154,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1180,21 +1180,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1215,15 +1215,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1231,11 +1231,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1266,12 +1266,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1281,13 +1281,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1356,17 +1356,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1437,8 +1437,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1447,7 +1447,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1460,7 +1460,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1544,21 +1544,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1626,7 +1626,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1674,11 +1674,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1714,7 +1714,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1728,19 +1728,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1748,7 +1748,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1756,7 +1756,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1780,7 +1780,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1816,11 +1816,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1896,15 +1896,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1915,20 +1915,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1947,9 +1947,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2041,7 +2041,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2070,24 +2070,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2103,7 +2103,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2112,7 +2112,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -2124,7 +2124,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2142,7 +2142,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2182,11 +2182,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2230,7 +2230,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2283,8 +2283,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2298,7 +2298,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2344,17 +2344,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2403,7 +2403,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2412,12 +2412,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2432,12 +2432,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2482,31 +2482,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2516,7 +2516,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2526,17 +2526,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2551,17 +2551,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2634,12 +2634,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2662,30 +2662,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2697,7 +2697,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2709,7 +2709,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2725,11 +2725,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2793,11 +2793,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2865,30 +2865,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2897,12 +2897,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2919,7 +2919,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2927,11 +2927,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2983,7 +2983,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2999,21 +2999,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3062,7 +3062,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3074,15 +3074,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3100,16 +3100,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3118,7 +3118,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3132,12 +3132,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3147,12 +3147,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3162,17 +3162,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3194,12 +3194,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3210,17 +3210,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3233,7 +3233,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3241,12 +3241,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3255,7 +3255,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3264,26 +3264,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3324,11 +3324,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3383,11 +3383,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3422,11 +3422,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3565,7 +3565,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3604,7 +3604,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3613,7 +3613,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3629,7 +3629,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3638,7 +3638,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3651,11 +3651,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3672,7 +3672,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3713,7 +3713,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3784,23 +3784,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3880,12 +3880,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3914,19 +3914,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3990,7 +3990,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3999,14 +3999,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -4026,16 +4026,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4098,7 +4098,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -4110,12 +4110,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4136,15 +4136,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -4186,7 +4186,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4204,10 +4204,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4224,53 +4224,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4320,22 +4320,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4413,11 +4413,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4463,7 +4463,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4484,7 +4484,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4496,7 +4496,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4505,11 +4505,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4518,39 +4518,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4567,7 +4567,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4579,20 +4579,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4600,8 +4600,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4625,7 +4625,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4635,7 +4635,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4687,11 +4687,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4710,15 +4710,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4808,11 +4808,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4826,20 +4826,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4848,7 +4848,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4864,7 +4864,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4877,7 +4877,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4885,7 +4885,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4894,46 +4894,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4963,7 +4967,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4971,11 +4975,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4999,11 +5003,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5011,7 +5015,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5068,7 +5072,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5085,7 +5089,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5102,7 +5106,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -5145,7 +5149,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -5182,11 +5186,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5194,26 +5198,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5225,7 +5229,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5250,19 +5254,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5279,7 +5283,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5348,11 +5352,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5361,11 +5365,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5469,19 +5473,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5493,11 +5497,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5541,7 +5545,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5598,7 +5602,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5614,7 +5618,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5638,11 +5642,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5700,7 +5704,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5708,11 +5712,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5732,7 +5736,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5744,12 +5748,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5762,11 +5766,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5776,7 +5780,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5789,7 +5793,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5798,11 +5802,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5890,21 +5894,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5912,7 +5916,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5924,22 +5928,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6027,7 +6031,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -6042,7 +6046,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6093,7 +6097,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6138,7 +6142,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6146,7 +6150,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -6158,7 +6162,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6169,7 +6173,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6178,12 +6182,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6227,7 +6231,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6235,19 +6239,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6256,11 +6260,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6278,17 +6282,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6297,23 +6301,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6323,7 +6327,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6344,7 +6348,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6360,19 +6364,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6420,11 +6424,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6472,7 +6476,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6495,7 +6499,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6518,7 +6522,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6531,12 +6535,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6553,17 +6557,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6580,7 +6584,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6611,7 +6615,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6631,7 +6635,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6668,7 +6672,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6785,15 +6789,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6813,13 +6817,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6884,20 +6888,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6944,8 +6948,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6965,44 +6969,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -7040,7 +7044,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7244,7 +7248,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7260,7 +7264,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7268,7 +7272,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7276,7 +7280,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7284,7 +7288,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7401,20 +7405,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7435,7 +7439,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7482,7 +7486,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7631,7 +7635,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7639,11 +7643,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7655,16 +7659,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7680,12 +7684,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -389,7 +389,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -431,7 +431,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -680,27 +680,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -709,17 +709,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -761,7 +761,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -777,19 +777,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -806,19 +806,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -826,7 +826,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -872,11 +872,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -896,11 +896,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -937,11 +937,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -996,7 +996,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1012,12 +1012,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1063,11 +1063,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1075,12 +1075,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1089,20 +1089,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1120,7 +1120,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1129,8 +1129,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -1168,11 +1168,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -1192,24 +1192,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1218,21 +1218,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1253,15 +1253,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1269,11 +1269,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1304,12 +1304,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1319,13 +1319,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1339,7 +1339,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1394,17 +1394,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1435,7 +1435,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1475,8 +1475,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1498,7 +1498,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1582,21 +1582,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1635,7 +1635,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1712,11 +1712,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1752,7 +1752,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1766,19 +1766,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1786,7 +1786,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1794,7 +1794,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1854,11 +1854,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1934,15 +1934,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1953,20 +1953,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1985,9 +1985,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2079,7 +2079,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2108,24 +2108,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2150,7 +2150,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2180,7 +2180,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2220,11 +2220,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2268,7 +2268,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2321,8 +2321,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2336,7 +2336,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2382,17 +2382,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2441,7 +2441,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2450,12 +2450,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2470,12 +2470,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2505,7 +2505,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2520,31 +2520,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2564,17 +2564,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2589,17 +2589,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2672,12 +2672,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2700,30 +2700,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2735,7 +2735,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,11 +2763,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2831,11 +2831,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2903,30 +2903,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2935,12 +2935,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2957,7 +2957,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2965,11 +2965,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -3021,7 +3021,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -3037,21 +3037,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3100,7 +3100,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3112,15 +3112,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3138,16 +3138,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3156,7 +3156,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3170,12 +3170,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3185,12 +3185,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3200,17 +3200,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3232,12 +3232,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3248,17 +3248,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3271,7 +3271,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3279,12 +3279,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3293,7 +3293,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3302,26 +3302,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3362,11 +3362,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3421,11 +3421,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3460,11 +3460,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3603,7 +3603,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3642,7 +3642,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3651,7 +3651,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3667,7 +3667,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3676,7 +3676,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3689,11 +3689,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3710,7 +3710,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3751,7 +3751,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3822,23 +3822,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3918,12 +3918,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3952,19 +3952,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -4028,7 +4028,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -4037,14 +4037,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -4064,16 +4064,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4136,7 +4136,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -4148,12 +4148,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4174,15 +4174,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -4224,7 +4224,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4242,10 +4242,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4262,53 +4262,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4358,22 +4358,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4407,7 +4407,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4451,11 +4451,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4501,7 +4501,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4522,7 +4522,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4534,7 +4534,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4543,11 +4543,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4556,39 +4556,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4605,7 +4605,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4617,20 +4617,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4638,8 +4638,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4673,7 +4673,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4725,11 +4725,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4748,15 +4748,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4846,11 +4846,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4864,20 +4864,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4902,7 +4902,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4915,7 +4915,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4932,46 +4932,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5009,11 +5013,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -5037,11 +5041,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5049,7 +5053,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5106,7 +5110,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5123,7 +5127,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5140,7 +5144,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -5183,7 +5187,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -5220,11 +5224,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5232,26 +5236,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5263,7 +5267,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5288,19 +5292,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5343,7 +5347,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5386,11 +5390,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5399,11 +5403,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5507,19 +5511,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5531,11 +5535,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5579,7 +5583,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5636,7 +5640,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5652,7 +5656,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5676,11 +5680,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5738,7 +5742,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5746,11 +5750,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5770,7 +5774,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5782,12 +5786,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5800,11 +5804,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5814,7 +5818,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5827,7 +5831,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5836,11 +5840,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5928,21 +5932,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5950,7 +5954,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5962,22 +5966,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5993,7 +5997,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6065,7 +6069,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -6080,7 +6084,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6131,7 +6135,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6176,7 +6180,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6184,7 +6188,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -6196,7 +6200,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6207,7 +6211,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6216,12 +6220,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6265,7 +6269,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6273,19 +6277,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6294,11 +6298,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6316,17 +6320,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6335,23 +6339,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6361,7 +6365,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6382,7 +6386,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6398,19 +6402,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6458,11 +6462,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6510,7 +6514,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6533,7 +6537,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6556,7 +6560,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6569,12 +6573,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6591,17 +6595,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6618,7 +6622,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6649,7 +6653,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6669,7 +6673,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6706,7 +6710,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6823,15 +6827,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6851,13 +6855,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6922,20 +6926,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6982,8 +6986,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -7003,44 +7007,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -7078,7 +7082,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7282,7 +7286,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7298,7 +7302,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7306,7 +7310,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7314,7 +7318,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7322,7 +7326,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7439,20 +7443,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7473,7 +7477,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7520,7 +7524,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7669,7 +7673,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7677,11 +7681,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7693,16 +7697,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7718,12 +7722,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -415,27 +415,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -444,17 +444,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -496,7 +496,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,19 +541,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -607,11 +607,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -631,11 +631,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -672,11 +672,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -747,12 +747,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -762,11 +762,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -810,12 +810,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -824,20 +824,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -864,8 +864,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -927,24 +927,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -953,21 +953,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -988,15 +988,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1039,12 +1039,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1054,13 +1054,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,17 +1129,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1210,8 +1210,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1317,21 +1317,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1447,11 +1447,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1487,7 +1487,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1501,19 +1501,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1589,11 +1589,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1669,15 +1669,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1688,20 +1688,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1720,9 +1720,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1843,24 +1843,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1885,7 +1885,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1897,7 +1897,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1915,7 +1915,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1955,11 +1955,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2056,8 +2056,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2071,7 +2071,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2117,17 +2117,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2255,31 +2255,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2299,17 +2299,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2324,17 +2324,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2407,12 +2407,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2435,30 +2435,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2498,11 +2498,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2566,11 +2566,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2638,30 +2638,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2670,12 +2670,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2692,7 +2692,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2700,11 +2700,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2756,7 +2756,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2772,21 +2772,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2847,15 +2847,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2873,16 +2873,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2905,12 +2905,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2920,12 +2920,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2935,17 +2935,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2983,17 +2983,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3014,12 +3014,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3037,26 +3037,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3097,11 +3097,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3156,11 +3156,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3195,11 +3195,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3377,7 +3377,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3402,7 +3402,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3424,11 +3424,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3557,23 +3557,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3653,12 +3653,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3687,19 +3687,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3763,7 +3763,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3772,14 +3772,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3799,16 +3799,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3883,12 +3883,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3909,15 +3909,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3977,10 +3977,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -3997,53 +3997,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4093,22 +4093,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4142,7 +4142,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4186,11 +4186,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4211,7 +4211,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4269,7 +4269,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4278,11 +4278,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4291,39 +4291,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4340,7 +4340,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4352,20 +4352,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4373,8 +4373,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4398,7 +4398,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4408,7 +4408,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4460,11 +4460,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4483,15 +4483,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4581,11 +4581,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4599,20 +4599,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4621,7 +4621,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4650,7 +4650,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4658,7 +4658,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4667,46 +4667,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4736,7 +4740,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4744,11 +4748,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4772,11 +4776,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4784,7 +4788,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4841,7 +4845,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4858,7 +4862,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4875,7 +4879,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4918,7 +4922,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4955,11 +4959,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4967,26 +4971,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -4998,7 +5002,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5023,19 +5027,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5078,7 +5082,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5121,11 +5125,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5134,11 +5138,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5242,19 +5246,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5266,11 +5270,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5314,7 +5318,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5371,7 +5375,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5387,7 +5391,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5411,11 +5415,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5473,7 +5477,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5481,11 +5485,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5505,7 +5509,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5517,12 +5521,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5535,11 +5539,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5549,7 +5553,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5562,7 +5566,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5571,11 +5575,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5663,21 +5667,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5685,7 +5689,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5697,22 +5701,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5728,7 +5732,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5800,7 +5804,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5815,7 +5819,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5866,7 +5870,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5911,7 +5915,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5919,7 +5923,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5931,7 +5935,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5942,7 +5946,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5951,12 +5955,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6000,7 +6004,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6008,19 +6012,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6029,11 +6033,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6051,17 +6055,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6070,23 +6074,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6096,7 +6100,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6117,7 +6121,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6133,19 +6137,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6193,11 +6197,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6245,7 +6249,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6268,7 +6272,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6291,7 +6295,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6304,12 +6308,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6326,17 +6330,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6353,7 +6357,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6384,7 +6388,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6404,7 +6408,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6441,7 +6445,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6558,15 +6562,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6586,13 +6590,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6657,20 +6661,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6717,8 +6721,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6738,44 +6742,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6813,7 +6817,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7017,7 +7021,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7033,7 +7037,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7041,7 +7045,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7049,7 +7053,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7057,7 +7061,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7174,20 +7178,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7208,7 +7212,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7255,7 +7259,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7404,7 +7408,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7412,11 +7416,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7428,16 +7432,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7453,11 +7457,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -380,7 +380,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -421,7 +421,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -666,27 +666,27 @@ msgstr ""
 "### Essa é uma representação yaml do membro do cluster.\n"
 "### Qualquer linha iniciando em '# será ignorada"
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -695,17 +695,17 @@ msgstr "'%s' não é um tipo de arquivo suportado"
 msgid "(none)"
 msgstr "(nenhum)"
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Nível %d (tipo: %s): %s"
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partição %d"
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -756,7 +756,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -773,19 +773,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -803,19 +803,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -823,7 +823,7 @@ msgstr "TIPO DE AUTENTICAÇÃO"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
@@ -872,11 +872,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -897,11 +897,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -939,11 +939,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -962,7 +962,7 @@ msgstr "Nome de membro do cluster"
 msgid "Add rules to an ACL"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -1001,7 +1001,7 @@ msgstr "Nome do alias ausente"
 msgid "Aliases already exists: %s"
 msgstr "Alias %s já existe"
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -1010,7 +1010,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1019,12 +1019,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
@@ -1034,11 +1034,11 @@ msgstr "Arquitetura: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1075,12 +1075,12 @@ msgstr "Desconectar volumes de armazenamento dos containers"
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1088,12 +1088,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1102,21 +1102,21 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
@@ -1134,7 +1134,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1143,8 +1143,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr "Marca: %v"
@@ -1182,11 +1182,11 @@ msgstr "Marca: %v"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1206,24 +1206,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, fuzzy, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs:"
@@ -1232,21 +1232,21 @@ msgstr "CPUs:"
 msgid "CREATED"
 msgstr "CRIADO"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr "Em cache: %s"
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 #, fuzzy
 msgid "Caches:"
 msgstr "Em cache: %s"
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1268,15 +1268,15 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 #, fuzzy
 msgid "Can't specify --project with --all-projects"
 msgstr "Não é possível especificar --fast com --columns"
@@ -1285,11 +1285,11 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1298,7 +1298,7 @@ msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Em cache: %s"
@@ -1335,13 +1335,13 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1411,17 +1411,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colunas"
@@ -1501,8 +1501,8 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1511,7 +1511,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr "Log de Console:"
 
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1610,21 +1610,21 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1663,7 +1663,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1751,12 +1751,12 @@ msgstr "Editar templates de arquivo do container"
 msgid "Create new network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Criar novas redes"
@@ -1796,7 +1796,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1811,19 +1811,19 @@ msgstr "Criando %s"
 msgid "Creating the instance"
 msgstr "Criando %s"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1865,7 +1865,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
@@ -1906,12 +1906,12 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
@@ -1992,15 +1992,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -2011,20 +2011,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -2043,9 +2043,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Em cache: %s"
@@ -2158,7 +2158,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2170,26 +2170,26 @@ msgstr "Desabilitar alocação de pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2205,7 +2205,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2214,7 +2214,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
@@ -2227,7 +2227,7 @@ msgstr "DATA DE VALIDADE"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2247,7 +2247,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2295,12 +2295,12 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2404,8 +2404,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2419,7 +2419,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2466,17 +2466,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2525,7 +2525,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2534,12 +2534,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2554,12 +2554,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2589,7 +2589,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2604,31 +2604,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2638,7 +2638,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2648,17 +2648,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2673,17 +2673,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2692,7 +2692,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2757,12 +2757,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2785,30 +2785,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2820,7 +2820,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2833,7 +2833,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -2850,12 +2850,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -2929,12 +2929,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3008,30 +3008,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3040,12 +3040,12 @@ msgstr "Copiar a imagem: %s"
 msgid "ID"
 msgstr "ID"
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3062,7 +3062,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -3070,11 +3070,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -3127,7 +3127,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -3143,21 +3143,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,7 +3207,7 @@ msgstr "Editar arquivos no container"
 msgid "Importing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3219,15 +3219,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3245,16 +3245,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3263,7 +3263,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3277,12 +3277,12 @@ msgstr "Editar arquivos no container"
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3292,12 +3292,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3307,17 +3307,17 @@ msgstr "Editar arquivos no container"
 msgid "Invalid key=value configuration: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3340,12 +3340,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3357,17 +3357,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Em cache: %s"
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3388,12 +3388,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3402,7 +3402,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3411,26 +3411,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3474,11 +3474,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Criar novas redes"
@@ -3535,11 +3535,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3575,11 +3575,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3720,7 +3720,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3759,7 +3759,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3786,7 +3786,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3795,7 +3795,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
@@ -3808,11 +3808,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3829,7 +3829,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3872,7 +3872,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
@@ -3951,27 +3951,27 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Criar novas redes"
@@ -4062,12 +4062,12 @@ msgstr "Nome de membro do cluster"
 msgid "Manage warnings"
 msgstr "Editar arquivos no container"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
@@ -4097,19 +4097,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -4181,7 +4181,7 @@ msgstr "Nome de membro do cluster"
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -4191,14 +4191,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
@@ -4220,16 +4220,16 @@ msgstr "Nome de membro do cluster"
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4296,7 +4296,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -4309,12 +4309,12 @@ msgstr "Nome de membro do cluster"
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4335,16 +4335,16 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, fuzzy, c-format
 msgid "Mounted: %v"
 msgstr "Marca: %v"
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4404,10 +4404,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4424,53 +4424,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4520,22 +4520,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4569,7 +4569,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4613,11 +4613,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4638,7 +4638,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4684,7 +4684,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4696,7 +4696,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4705,11 +4705,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4718,39 +4718,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4767,7 +4767,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4780,20 +4780,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4801,8 +4801,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4826,7 +4826,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4836,7 +4836,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4891,12 +4891,12 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 #, fuzzy
 msgid "Profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 #, fuzzy
 msgid "Profiles: "
 msgstr "Copiar perfis"
@@ -4916,15 +4916,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -5014,11 +5014,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5032,21 +5032,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5055,7 +5055,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5071,7 +5071,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -5086,7 +5086,7 @@ msgstr "Editar arquivos no container"
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5094,7 +5094,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -5103,46 +5103,51 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+#, fuzzy
+msgid "Remote trust token"
+msgstr "Adicionar novos clientes confiáveis"
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -5175,7 +5180,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5183,12 +5188,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
@@ -5216,12 +5221,12 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
@@ -5231,7 +5236,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5292,7 +5297,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5309,7 +5314,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5326,7 +5331,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -5376,7 +5381,7 @@ msgstr "Nome de membro do cluster"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -5416,11 +5421,11 @@ msgstr "Criar projetos"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5428,26 +5433,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5459,7 +5464,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5484,19 +5489,19 @@ msgstr "Criado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5515,7 +5520,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5542,7 +5547,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -5588,12 +5593,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5602,12 +5607,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5716,19 +5721,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5740,12 +5745,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -5795,7 +5800,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5856,7 +5861,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5875,7 +5880,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5902,12 +5907,12 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5973,7 +5978,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5981,11 +5986,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -6007,7 +6012,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6019,12 +6024,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -6037,11 +6042,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6051,7 +6056,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -6064,7 +6069,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -6073,11 +6078,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6166,21 +6171,21 @@ msgstr "Ignorar o estado do container"
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6188,7 +6193,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6200,23 +6205,23 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6233,7 +6238,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6307,7 +6312,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6322,7 +6327,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6373,7 +6378,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6420,7 +6425,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6428,7 +6433,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -6440,7 +6445,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6451,7 +6456,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6460,12 +6465,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6509,7 +6514,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6518,19 +6523,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6539,11 +6544,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6561,17 +6566,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
@@ -6581,23 +6586,23 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6607,7 +6612,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6632,7 +6637,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -6651,22 +6656,22 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
@@ -6721,12 +6726,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -6780,7 +6785,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6804,7 +6809,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6828,7 +6833,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6841,12 +6846,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6863,17 +6868,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
@@ -6890,7 +6895,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6921,7 +6926,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6941,7 +6946,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6982,7 +6987,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7117,16 +7122,16 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7148,13 +7153,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7223,20 +7228,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7288,8 +7293,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Editar templates de arquivo do container"
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -7309,50 +7314,50 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -7395,7 +7400,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr "Criar perfis"
@@ -7624,7 +7629,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7641,7 +7646,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
@@ -7651,7 +7656,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7659,7 +7664,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7667,7 +7672,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7784,20 +7789,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7818,7 +7823,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7865,7 +7870,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8014,7 +8019,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -8022,11 +8027,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8038,16 +8043,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8063,12 +8068,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -381,7 +381,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -422,7 +422,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -675,27 +675,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -704,17 +704,17 @@ msgstr ""
 msgid "(none)"
 msgstr "(пусто)"
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Порт %d (%s)"
@@ -756,7 +756,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -773,19 +773,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -806,20 +806,20 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -827,7 +827,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -875,11 +875,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -901,11 +901,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -942,11 +942,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -963,7 +963,7 @@ msgstr "Копирование образа: %s"
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
@@ -1011,7 +1011,7 @@ msgstr "Псевдонимы:"
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1020,12 +1020,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
@@ -1035,11 +1035,11 @@ msgstr "Архитектура: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1073,11 +1073,11 @@ msgstr "Копирование образа: %s"
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1085,12 +1085,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1099,21 +1099,21 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1131,7 +1131,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1140,8 +1140,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -1179,11 +1179,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1203,25 +1203,25 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1231,21 +1231,21 @@ msgstr ""
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1266,15 +1266,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1282,11 +1282,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1295,7 +1295,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1332,13 +1332,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1408,17 +1408,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1449,7 +1449,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Столбцы"
@@ -1489,8 +1489,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1598,21 +1598,21 @@ msgstr "Копирование образа: %s"
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1651,7 +1651,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -1682,7 +1682,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1738,12 +1738,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Копирование образа: %s"
@@ -1785,7 +1785,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1800,19 +1800,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1820,7 +1820,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1852,7 +1852,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1893,11 +1893,11 @@ msgstr "Копирование образа: %s"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
@@ -1978,15 +1978,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1997,20 +1997,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -2029,9 +2029,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2125,7 +2125,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2142,7 +2142,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2154,27 +2154,27 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
@@ -2191,7 +2191,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -2212,7 +2212,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2230,7 +2230,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2274,11 +2274,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
@@ -2327,7 +2327,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2380,8 +2380,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2395,7 +2395,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2445,17 +2445,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2509,7 +2509,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2518,12 +2518,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2538,12 +2538,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2573,7 +2573,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2588,31 +2588,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2622,7 +2622,7 @@ msgstr "Принять сертификат"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2632,17 +2632,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2657,17 +2657,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2676,7 +2676,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2741,12 +2741,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2769,30 +2769,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2817,7 +2817,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2833,12 +2833,12 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -2910,12 +2910,12 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
@@ -2988,31 +2988,31 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3021,12 +3021,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3043,7 +3043,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -3051,11 +3051,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -3108,7 +3108,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -3124,21 +3124,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3190,7 +3190,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Importing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3202,16 +3202,16 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3231,16 +3231,16 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Имя контейнера: %s"
@@ -3249,7 +3249,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3263,12 +3263,12 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3278,12 +3278,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, fuzzy, c-format
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3293,17 +3293,17 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid key=value configuration: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3326,12 +3326,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3343,17 +3343,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3366,7 +3366,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3374,12 +3374,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3388,7 +3388,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3397,26 +3397,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Архитектура: %s"
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3462,11 +3462,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Копирование образа: %s"
@@ -3524,11 +3524,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3565,12 +3565,12 @@ msgstr "Копирование образа: %s"
 msgid "List instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 #, fuzzy
 msgid "List instances"
 msgstr "Псевдонимы:"
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3714,7 +3714,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3754,7 +3754,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3763,7 +3763,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3781,7 +3781,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3790,7 +3790,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3803,11 +3803,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3824,7 +3824,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3868,7 +3868,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3945,27 +3945,27 @@ msgstr "Копирование образа: %s"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Копирование образа: %s"
@@ -4059,12 +4059,12 @@ msgstr "Копирование образа: %s"
 msgid "Manage warnings"
 msgstr "Копирование образа: %s"
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -4093,20 +4093,20 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
@@ -4178,7 +4178,7 @@ msgstr "Копирование образа: %s"
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
@@ -4189,14 +4189,14 @@ msgstr "Имя контейнера: %s"
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
@@ -4218,16 +4218,16 @@ msgstr "Имя контейнера: %s"
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4296,7 +4296,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -4309,12 +4309,12 @@ msgstr "Имя контейнера: %s"
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4335,16 +4335,16 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4405,10 +4405,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4425,53 +4425,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4521,22 +4521,22 @@ msgstr " Использование сети:"
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
@@ -4571,7 +4571,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -4617,11 +4617,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4642,7 +4642,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4668,7 +4668,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4689,7 +4689,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4701,7 +4701,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4710,11 +4710,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4723,39 +4723,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4785,20 +4785,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4806,8 +4806,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4831,7 +4831,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4841,7 +4841,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4893,11 +4893,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4916,15 +4916,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -5014,11 +5014,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5032,20 +5032,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5054,7 +5054,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5070,7 +5070,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -5085,7 +5085,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5094,7 +5094,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
@@ -5104,46 +5104,50 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -5175,7 +5179,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5183,12 +5187,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
@@ -5214,11 +5218,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
@@ -5227,7 +5231,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5288,7 +5292,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5307,7 +5311,7 @@ msgstr "Копирование образа: %s"
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5324,7 +5328,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -5371,7 +5375,7 @@ msgstr "Копирование образа: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -5411,11 +5415,11 @@ msgstr "Доступные команды:"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5423,26 +5427,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5454,7 +5458,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5479,19 +5483,19 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5510,7 +5514,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5536,7 +5540,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5579,12 +5583,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5593,12 +5597,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5706,19 +5710,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5730,12 +5734,12 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -5786,7 +5790,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5846,7 +5850,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5864,7 +5868,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5889,12 +5893,12 @@ msgstr "Копирование образа: %s"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Копирование образа: %s"
@@ -5960,7 +5964,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5968,11 +5972,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5994,7 +5998,7 @@ msgstr "Копирование образа: %s"
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6006,12 +6010,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
@@ -6025,11 +6029,11 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6039,7 +6043,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -6052,7 +6056,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -6062,11 +6066,11 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6157,21 +6161,21 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6179,7 +6183,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6191,22 +6195,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6222,7 +6226,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6294,7 +6298,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Копирование образа: %s"
@@ -6309,7 +6313,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Копирование образа: %s"
@@ -6360,7 +6364,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6406,7 +6410,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6414,7 +6418,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -6426,7 +6430,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6437,7 +6441,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6446,12 +6450,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6495,7 +6499,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6504,19 +6508,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Принять сертификат"
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6525,11 +6529,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6547,17 +6551,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6566,23 +6570,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6592,7 +6596,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6615,7 +6619,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6631,22 +6635,22 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
@@ -6700,12 +6704,12 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -6761,7 +6765,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6785,7 +6789,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6809,7 +6813,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6822,12 +6826,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6844,17 +6848,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6871,7 +6875,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6902,7 +6906,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6922,7 +6926,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6987,7 +6991,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7204,7 +7208,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7212,7 +7216,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7220,7 +7224,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7260,7 +7264,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7270,7 +7274,7 @@ msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -7399,7 +7403,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7407,7 +7411,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7415,7 +7419,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7424,7 +7428,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7515,8 +7519,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7556,9 +7560,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7566,7 +7570,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -7574,7 +7578,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -7584,8 +7588,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -7593,7 +7597,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -7601,7 +7605,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -7611,13 +7615,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -7691,7 +7695,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 #, fuzzy
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
@@ -8091,7 +8095,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -8123,7 +8127,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8139,7 +8143,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -8147,7 +8151,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -8155,7 +8159,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -8272,20 +8276,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8306,7 +8310,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -8353,7 +8357,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -8502,7 +8506,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -8510,11 +8514,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8526,16 +8530,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8551,12 +8555,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr "да"
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -258,7 +258,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -282,7 +282,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -419,27 +419,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -448,17 +448,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -500,7 +500,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -516,19 +516,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -545,19 +545,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -611,11 +611,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -676,11 +676,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -696,7 +696,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -751,12 +751,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -766,11 +766,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -814,12 +814,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -828,20 +828,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -868,8 +868,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -931,24 +931,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -957,21 +957,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -992,15 +992,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1008,11 +1008,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1043,12 +1043,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1058,13 +1058,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1133,17 +1133,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,8 +1214,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1224,7 +1224,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1237,7 +1237,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1321,21 +1321,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1403,7 +1403,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1451,11 +1451,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1491,7 +1491,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1505,19 +1505,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1525,7 +1525,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1557,7 +1557,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1593,11 +1593,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1673,15 +1673,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1692,20 +1692,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1724,9 +1724,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1835,7 +1835,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1847,24 +1847,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1889,7 +1889,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1919,7 +1919,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1959,11 +1959,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2060,8 +2060,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2075,7 +2075,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2121,17 +2121,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2180,7 +2180,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2189,12 +2189,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2209,12 +2209,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2244,7 +2244,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2259,31 +2259,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2303,17 +2303,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2328,17 +2328,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2347,7 +2347,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2411,12 +2411,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2439,30 +2439,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2502,11 +2502,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2570,11 +2570,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2642,30 +2642,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2674,12 +2674,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2696,7 +2696,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2704,11 +2704,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2776,21 +2776,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2851,15 +2851,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2877,16 +2877,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2909,12 +2909,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2924,12 +2924,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2939,17 +2939,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2971,12 +2971,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2987,17 +2987,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3018,12 +3018,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3032,7 +3032,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3041,26 +3041,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3101,11 +3101,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3160,11 +3160,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3199,11 +3199,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3381,7 +3381,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3406,7 +3406,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3415,7 +3415,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3428,11 +3428,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3449,7 +3449,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3561,23 +3561,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3657,12 +3657,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3691,19 +3691,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3767,7 +3767,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3776,14 +3776,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3803,16 +3803,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3875,7 +3875,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3887,12 +3887,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3913,15 +3913,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3963,7 +3963,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3981,10 +3981,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4001,53 +4001,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4097,22 +4097,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4146,7 +4146,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4190,11 +4190,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4215,7 +4215,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4273,7 +4273,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4282,11 +4282,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4295,39 +4295,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4344,7 +4344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4356,20 +4356,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4377,8 +4377,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4402,7 +4402,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4412,7 +4412,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4464,11 +4464,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4487,15 +4487,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4585,11 +4585,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4603,20 +4603,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4625,7 +4625,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4641,7 +4641,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4654,7 +4654,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4671,46 +4671,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4740,7 +4744,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4748,11 +4752,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4776,11 +4780,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4862,7 +4866,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4922,7 +4926,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4959,11 +4963,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4971,26 +4975,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5002,7 +5006,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5027,19 +5031,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5056,7 +5060,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5082,7 +5086,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5125,11 +5129,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5138,11 +5142,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5246,19 +5250,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5270,11 +5274,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5318,7 +5322,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5375,7 +5379,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5391,7 +5395,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5415,11 +5419,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5485,11 +5489,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5509,7 +5513,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5521,12 +5525,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5539,11 +5543,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5553,7 +5557,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5566,7 +5570,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5575,11 +5579,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5667,21 +5671,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5689,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5701,22 +5705,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5732,7 +5736,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5804,7 +5808,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5870,7 +5874,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5915,7 +5919,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5923,7 +5927,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5935,7 +5939,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5946,7 +5950,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5955,12 +5959,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6004,7 +6008,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6012,19 +6016,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6033,11 +6037,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6055,17 +6059,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6074,23 +6078,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6100,7 +6104,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6121,7 +6125,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6137,19 +6141,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6197,11 +6201,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6249,7 +6253,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6272,7 +6276,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6295,7 +6299,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6308,12 +6312,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6330,17 +6334,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6357,7 +6361,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6388,7 +6392,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6408,7 +6412,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6445,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6562,15 +6566,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6590,13 +6594,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6661,20 +6665,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6721,8 +6725,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6742,44 +6746,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6817,7 +6821,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7021,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7037,7 +7041,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7045,7 +7049,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7061,7 +7065,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7178,20 +7182,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7212,7 +7216,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7259,7 +7263,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7408,7 +7412,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7416,11 +7420,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7432,16 +7436,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7457,11 +7461,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -258,7 +258,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -282,7 +282,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -419,27 +419,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -448,17 +448,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -500,7 +500,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -516,19 +516,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -545,19 +545,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -611,11 +611,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -676,11 +676,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -696,7 +696,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -751,12 +751,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -766,11 +766,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -814,12 +814,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -828,20 +828,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -868,8 +868,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -931,24 +931,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -957,21 +957,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -992,15 +992,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1008,11 +1008,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1043,12 +1043,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1058,13 +1058,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1133,17 +1133,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,8 +1214,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1224,7 +1224,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1237,7 +1237,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1321,21 +1321,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1403,7 +1403,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1451,11 +1451,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1491,7 +1491,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1505,19 +1505,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1525,7 +1525,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1557,7 +1557,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1593,11 +1593,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1673,15 +1673,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1692,20 +1692,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1724,9 +1724,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1835,7 +1835,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1847,24 +1847,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1889,7 +1889,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1919,7 +1919,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1959,11 +1959,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2060,8 +2060,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2075,7 +2075,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2121,17 +2121,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2180,7 +2180,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2189,12 +2189,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2209,12 +2209,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2244,7 +2244,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2259,31 +2259,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2303,17 +2303,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2328,17 +2328,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2347,7 +2347,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2411,12 +2411,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2439,30 +2439,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2502,11 +2502,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2570,11 +2570,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2642,30 +2642,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2674,12 +2674,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2696,7 +2696,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2704,11 +2704,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2776,21 +2776,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2851,15 +2851,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2877,16 +2877,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2909,12 +2909,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2924,12 +2924,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2939,17 +2939,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2971,12 +2971,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2987,17 +2987,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3018,12 +3018,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3032,7 +3032,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3041,26 +3041,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3101,11 +3101,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3160,11 +3160,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3199,11 +3199,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3381,7 +3381,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3406,7 +3406,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3415,7 +3415,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3428,11 +3428,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3449,7 +3449,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3561,23 +3561,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3657,12 +3657,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3691,19 +3691,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3767,7 +3767,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3776,14 +3776,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3803,16 +3803,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3875,7 +3875,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3887,12 +3887,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3913,15 +3913,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3963,7 +3963,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3981,10 +3981,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4001,53 +4001,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4097,22 +4097,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4146,7 +4146,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4190,11 +4190,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4215,7 +4215,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4273,7 +4273,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4282,11 +4282,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4295,39 +4295,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4344,7 +4344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4356,20 +4356,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4377,8 +4377,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4402,7 +4402,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4412,7 +4412,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4464,11 +4464,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4487,15 +4487,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4585,11 +4585,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4603,20 +4603,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4625,7 +4625,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4641,7 +4641,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4654,7 +4654,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4671,46 +4671,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4740,7 +4744,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4748,11 +4752,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4776,11 +4780,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4862,7 +4866,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4922,7 +4926,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4959,11 +4963,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4971,26 +4975,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5002,7 +5006,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5027,19 +5031,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5056,7 +5060,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5082,7 +5086,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5125,11 +5129,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5138,11 +5142,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5246,19 +5250,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5270,11 +5274,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5318,7 +5322,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5375,7 +5379,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5391,7 +5395,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5415,11 +5419,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5485,11 +5489,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5509,7 +5513,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5521,12 +5525,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5539,11 +5543,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5553,7 +5557,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5566,7 +5570,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5575,11 +5579,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5667,21 +5671,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5689,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5701,22 +5705,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5732,7 +5736,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5804,7 +5808,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5870,7 +5874,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5915,7 +5919,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5923,7 +5927,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5935,7 +5939,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5946,7 +5950,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5955,12 +5959,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6004,7 +6008,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6012,19 +6016,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6033,11 +6037,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6055,17 +6059,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6074,23 +6078,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6100,7 +6104,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6121,7 +6125,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6137,19 +6141,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6197,11 +6201,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6249,7 +6253,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6272,7 +6276,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6295,7 +6299,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6308,12 +6312,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6330,17 +6334,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6357,7 +6361,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6388,7 +6392,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6408,7 +6412,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6445,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6562,15 +6566,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6590,13 +6594,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6661,20 +6665,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6721,8 +6725,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6742,44 +6746,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6817,7 +6821,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7021,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7037,7 +7041,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7045,7 +7049,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7061,7 +7065,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7178,20 +7182,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7212,7 +7216,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7259,7 +7263,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7408,7 +7412,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7416,11 +7420,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7432,16 +7436,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7457,11 +7461,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +278,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -415,27 +415,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -444,17 +444,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -496,7 +496,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -512,19 +512,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,19 +541,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -607,11 +607,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -631,11 +631,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -672,11 +672,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -747,12 +747,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -762,11 +762,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -810,12 +810,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -824,20 +824,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -864,8 +864,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -927,24 +927,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -953,21 +953,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -988,15 +988,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1039,12 +1039,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1054,13 +1054,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,17 +1129,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1210,8 +1210,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1317,21 +1317,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1447,11 +1447,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1487,7 +1487,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1501,19 +1501,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1553,7 +1553,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1589,11 +1589,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1669,15 +1669,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1688,20 +1688,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1720,9 +1720,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1843,24 +1843,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1885,7 +1885,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1897,7 +1897,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1915,7 +1915,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1955,11 +1955,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2056,8 +2056,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2071,7 +2071,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2117,17 +2117,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2185,12 +2185,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2255,31 +2255,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2299,17 +2299,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2324,17 +2324,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2407,12 +2407,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2435,30 +2435,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2498,11 +2498,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2566,11 +2566,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2638,30 +2638,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2670,12 +2670,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2692,7 +2692,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2700,11 +2700,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2756,7 +2756,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2772,21 +2772,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2847,15 +2847,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2873,16 +2873,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2905,12 +2905,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2920,12 +2920,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2935,17 +2935,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2983,17 +2983,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3014,12 +3014,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3037,26 +3037,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3097,11 +3097,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3156,11 +3156,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3195,11 +3195,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3377,7 +3377,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3402,7 +3402,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3424,11 +3424,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3557,23 +3557,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3653,12 +3653,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3687,19 +3687,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3763,7 +3763,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3772,14 +3772,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3799,16 +3799,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3883,12 +3883,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3909,15 +3909,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3977,10 +3977,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -3997,53 +3997,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4093,22 +4093,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4142,7 +4142,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4186,11 +4186,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4211,7 +4211,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4269,7 +4269,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4278,11 +4278,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4291,39 +4291,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4340,7 +4340,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4352,20 +4352,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4373,8 +4373,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4398,7 +4398,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4408,7 +4408,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4460,11 +4460,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4483,15 +4483,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4581,11 +4581,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4599,20 +4599,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4621,7 +4621,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4650,7 +4650,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4658,7 +4658,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4667,46 +4667,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4736,7 +4740,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4744,11 +4748,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4772,11 +4776,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4784,7 +4788,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4841,7 +4845,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4858,7 +4862,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4875,7 +4879,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4918,7 +4922,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4955,11 +4959,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4967,26 +4971,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -4998,7 +5002,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5023,19 +5027,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5078,7 +5082,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5121,11 +5125,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5134,11 +5138,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5242,19 +5246,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5266,11 +5270,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5314,7 +5318,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5371,7 +5375,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5387,7 +5391,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5411,11 +5415,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5473,7 +5477,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5481,11 +5485,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5505,7 +5509,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5517,12 +5521,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5535,11 +5539,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5549,7 +5553,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5562,7 +5566,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5571,11 +5575,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5663,21 +5667,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5685,7 +5689,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5697,22 +5701,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5728,7 +5732,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5800,7 +5804,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5815,7 +5819,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5866,7 +5870,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5911,7 +5915,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5919,7 +5923,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5931,7 +5935,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5942,7 +5946,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5951,12 +5955,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6000,7 +6004,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6008,19 +6012,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6029,11 +6033,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6051,17 +6055,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6070,23 +6074,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6096,7 +6100,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6117,7 +6121,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6133,19 +6137,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6193,11 +6197,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6245,7 +6249,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6268,7 +6272,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6291,7 +6295,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6304,12 +6308,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6326,17 +6330,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6353,7 +6357,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6384,7 +6388,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6404,7 +6408,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6441,7 +6445,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6558,15 +6562,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6586,13 +6590,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6657,20 +6661,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6717,8 +6721,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6738,44 +6742,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6813,7 +6817,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7017,7 +7021,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7033,7 +7037,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7041,7 +7045,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7049,7 +7053,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7057,7 +7061,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7174,20 +7178,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7208,7 +7212,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7255,7 +7259,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7404,7 +7408,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7412,11 +7416,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7428,16 +7432,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7453,11 +7457,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -258,7 +258,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -282,7 +282,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -419,27 +419,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -448,17 +448,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -500,7 +500,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -516,19 +516,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -545,19 +545,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -611,11 +611,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -676,11 +676,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -696,7 +696,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -751,12 +751,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -766,11 +766,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -814,12 +814,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -828,20 +828,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -868,8 +868,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -931,24 +931,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -957,21 +957,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -992,15 +992,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1008,11 +1008,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1043,12 +1043,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1058,13 +1058,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1133,17 +1133,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,8 +1214,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1224,7 +1224,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1237,7 +1237,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1321,21 +1321,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1403,7 +1403,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1451,11 +1451,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1491,7 +1491,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1505,19 +1505,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1525,7 +1525,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1557,7 +1557,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1593,11 +1593,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1673,15 +1673,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1692,20 +1692,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1724,9 +1724,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1835,7 +1835,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1847,24 +1847,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1889,7 +1889,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1919,7 +1919,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1959,11 +1959,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2060,8 +2060,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2075,7 +2075,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2121,17 +2121,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2180,7 +2180,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2189,12 +2189,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2209,12 +2209,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2244,7 +2244,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2259,31 +2259,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2303,17 +2303,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2328,17 +2328,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2347,7 +2347,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2411,12 +2411,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2439,30 +2439,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2502,11 +2502,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2570,11 +2570,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2642,30 +2642,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2674,12 +2674,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2696,7 +2696,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2704,11 +2704,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2776,21 +2776,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2851,15 +2851,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2877,16 +2877,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2909,12 +2909,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2924,12 +2924,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2939,17 +2939,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2971,12 +2971,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2987,17 +2987,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3018,12 +3018,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3032,7 +3032,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3041,26 +3041,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3101,11 +3101,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3160,11 +3160,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3199,11 +3199,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3381,7 +3381,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3406,7 +3406,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3415,7 +3415,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3428,11 +3428,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3449,7 +3449,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3561,23 +3561,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3657,12 +3657,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3691,19 +3691,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3767,7 +3767,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3776,14 +3776,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3803,16 +3803,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3875,7 +3875,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3887,12 +3887,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3913,15 +3913,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3963,7 +3963,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3981,10 +3981,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4001,53 +4001,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4097,22 +4097,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4146,7 +4146,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4190,11 +4190,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4215,7 +4215,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4273,7 +4273,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4282,11 +4282,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4295,39 +4295,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4344,7 +4344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4356,20 +4356,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4377,8 +4377,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4402,7 +4402,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4412,7 +4412,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4464,11 +4464,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4487,15 +4487,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4585,11 +4585,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4603,20 +4603,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4625,7 +4625,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4641,7 +4641,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4654,7 +4654,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4671,46 +4671,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4740,7 +4744,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4748,11 +4752,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4776,11 +4780,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4862,7 +4866,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4879,7 +4883,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4922,7 +4926,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4959,11 +4963,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4971,26 +4975,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5002,7 +5006,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5027,19 +5031,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5056,7 +5060,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5082,7 +5086,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5125,11 +5129,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5138,11 +5142,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5246,19 +5250,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5270,11 +5274,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5318,7 +5322,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5375,7 +5379,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5391,7 +5395,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5415,11 +5419,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5485,11 +5489,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5509,7 +5513,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5521,12 +5525,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5539,11 +5543,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5553,7 +5557,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5566,7 +5570,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5575,11 +5579,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5667,21 +5671,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5689,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5701,22 +5705,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5732,7 +5736,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5804,7 +5808,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5819,7 +5823,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5870,7 +5874,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5915,7 +5919,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5923,7 +5927,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5935,7 +5939,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5946,7 +5950,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5955,12 +5959,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6004,7 +6008,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6012,19 +6016,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6033,11 +6037,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6055,17 +6059,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6074,23 +6078,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6100,7 +6104,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6121,7 +6125,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6137,19 +6141,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6197,11 +6201,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6249,7 +6253,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6272,7 +6276,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6295,7 +6299,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6308,12 +6312,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6330,17 +6334,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6357,7 +6361,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6388,7 +6392,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6408,7 +6412,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6445,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6562,15 +6566,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6590,13 +6594,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6661,20 +6665,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6721,8 +6725,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6742,44 +6746,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6817,7 +6821,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7021,7 +7025,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7037,7 +7041,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7045,7 +7049,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7061,7 +7065,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7178,20 +7182,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7212,7 +7216,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7259,7 +7263,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7408,7 +7412,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7416,11 +7420,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7432,16 +7436,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7457,11 +7461,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -342,7 +342,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -366,7 +366,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -579,27 +579,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -608,17 +608,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -660,7 +660,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -676,19 +676,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -705,19 +705,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -771,11 +771,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -795,11 +795,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -836,11 +836,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -903,7 +903,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -911,12 +911,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -926,11 +926,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -962,11 +962,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -974,12 +974,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -988,20 +988,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -1028,8 +1028,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -1067,11 +1067,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -1091,24 +1091,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1117,21 +1117,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1152,15 +1152,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1168,11 +1168,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1203,12 +1203,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1218,13 +1218,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1293,17 +1293,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1374,8 +1374,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1384,7 +1384,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1481,21 +1481,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1611,11 +1611,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1665,19 +1665,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1685,7 +1685,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1717,7 +1717,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1753,11 +1753,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1833,15 +1833,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1852,20 +1852,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1884,9 +1884,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1995,7 +1995,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2007,24 +2007,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2049,7 +2049,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2079,7 +2079,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2119,11 +2119,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2167,7 +2167,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2220,8 +2220,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2235,7 +2235,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2281,17 +2281,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2349,12 +2349,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2369,12 +2369,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2404,7 +2404,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2419,31 +2419,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2463,17 +2463,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2488,17 +2488,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2571,12 +2571,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2599,30 +2599,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2634,7 +2634,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2646,7 +2646,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2662,11 +2662,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2730,11 +2730,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2802,30 +2802,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2834,12 +2834,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2856,7 +2856,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2864,11 +2864,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2936,21 +2936,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -3011,15 +3011,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3037,16 +3037,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3055,7 +3055,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3069,12 +3069,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -3084,12 +3084,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3099,17 +3099,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -3131,12 +3131,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3147,17 +3147,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3170,7 +3170,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3178,12 +3178,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3192,7 +3192,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3201,26 +3201,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3261,11 +3261,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3320,11 +3320,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3359,11 +3359,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3502,7 +3502,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3541,7 +3541,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3566,7 +3566,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3575,7 +3575,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3588,11 +3588,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3609,7 +3609,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3650,7 +3650,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3721,23 +3721,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3817,12 +3817,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3851,19 +3851,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3927,7 +3927,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3936,14 +3936,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3963,16 +3963,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -4035,7 +4035,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -4047,12 +4047,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -4073,15 +4073,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -4123,7 +4123,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4141,10 +4141,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4161,53 +4161,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4257,22 +4257,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4306,7 +4306,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4350,11 +4350,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4400,7 +4400,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4421,7 +4421,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4433,7 +4433,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4442,11 +4442,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4455,39 +4455,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4504,7 +4504,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4516,20 +4516,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4537,8 +4537,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4562,7 +4562,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4572,7 +4572,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4624,11 +4624,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4647,15 +4647,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4745,11 +4745,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4763,20 +4763,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4801,7 +4801,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4814,7 +4814,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4822,7 +4822,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4831,46 +4831,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4900,7 +4904,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4908,11 +4912,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4936,11 +4940,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4948,7 +4952,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -5005,7 +5009,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -5022,7 +5026,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -5039,7 +5043,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -5082,7 +5086,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -5119,11 +5123,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -5131,26 +5135,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5162,7 +5166,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5187,19 +5191,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5216,7 +5220,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5242,7 +5246,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5285,11 +5289,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5298,11 +5302,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5406,19 +5410,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5430,11 +5434,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5478,7 +5482,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5535,7 +5539,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5551,7 +5555,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5575,11 +5579,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5637,7 +5641,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5645,11 +5649,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5669,7 +5673,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5681,12 +5685,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5699,11 +5703,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5713,7 +5717,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5726,7 +5730,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5735,11 +5739,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5827,21 +5831,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5849,7 +5853,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5861,22 +5865,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5892,7 +5896,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5964,7 +5968,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5979,7 +5983,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6030,7 +6034,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6075,7 +6079,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -6083,7 +6087,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -6095,7 +6099,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6106,7 +6110,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6115,12 +6119,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6164,7 +6168,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6172,19 +6176,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6193,11 +6197,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6215,17 +6219,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6234,23 +6238,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6260,7 +6264,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6281,7 +6285,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6297,19 +6301,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6357,11 +6361,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6409,7 +6413,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6432,7 +6436,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6455,7 +6459,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6468,12 +6472,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6490,17 +6494,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6517,7 +6521,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6548,7 +6552,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6568,7 +6572,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6605,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6722,15 +6726,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6750,13 +6754,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6821,20 +6825,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6881,8 +6885,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6902,44 +6906,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6977,7 +6981,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7181,7 +7185,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7197,7 +7201,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7205,7 +7209,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7213,7 +7217,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7221,7 +7225,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7338,20 +7342,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7372,7 +7376,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7419,7 +7423,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7568,7 +7572,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7576,11 +7580,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7592,16 +7596,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7617,12 +7621,12 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-05-24 12:39+0200\n"
+"POT-Creation-Date: 2024-06-12 10:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -257,7 +257,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:570
+#: lxc/network_forward.go:585
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: lxc/network_load_balancer.go:573
+#: lxc/network_load_balancer.go:588
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -418,27 +418,27 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:321
+#: lxc/info.go:320
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1101
+#: lxc/image.go:1105
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:160
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:924
+#: lxc/file.go:935
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:825
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -447,17 +447,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:311
+#: lxc/info.go:310
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:289
+#: lxc/info.go:288
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:196
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -499,7 +499,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
-#: lxc/info.go:453
+#: lxc/info.go:452
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -515,19 +515,19 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:818 lxc/remote.go:875
+#: lxc/remote.go:821 lxc/remote.go:878
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:915
+#: lxc/remote.go:918
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:745
+#: lxc/remote.go:748
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -544,19 +544,19 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1069 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1066
+#: lxc/image.go:1070
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1075 lxc/list.go:553
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:727
+#: lxc/remote.go:730
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Accept certificate"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: lxc/network_load_balancer.go:783
+#: lxc/network_load_balancer.go:798
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:782
+#: lxc/network_load_balancer.go:797
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -675,11 +675,11 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:779 lxc/network_forward.go:780
+#: lxc/network_forward.go:794 lxc/network_forward.go:795
 msgid "Add ports to a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:962 lxc/network_load_balancer.go:963
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:200
 #, c-format
 msgid "Address: %s"
 msgstr ""
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:556
+#: lxc/remote.go:562
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:986
+#: lxc/image.go:990
 msgid "Aliases:"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:179
+#: lxc/remote.go:181
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:957 lxc/info.go:478
+#: lxc/image.go:961 lxc/info.go:477
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:126
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -765,11 +765,11 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:378
+#: lxc/console.go:383
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:131
+#: lxc/init.go:324 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:35
+#: lxc/console.go:36
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:37
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -813,12 +813,12 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:542
+#: lxc/remote.go:544
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: lxc/info.go:220
+#: lxc/info.go:219
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -827,20 +827,20 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1000
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/network_forward.go:238 lxc/network_load_balancer.go:240
+#: lxc/network_forward.go:240 lxc/network_load_balancer.go:242
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:134
+#: lxc/remote.go:136
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/list.go:561
+#: lxc/list.go:559 lxc/list.go:560
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:646 lxc/storage_volume.go:1359
+#: lxc/info.go:645 lxc/storage_volume.go:1359
 msgid "Backups:"
 msgstr ""
 
@@ -867,8 +867,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:291
-#: lxc/network_load_balancer.go:294 lxc/network_peer.go:280
+#: lxc/network.go:333 lxc/network_acl.go:382 lxc/network_forward.go:293
+#: lxc/network_load_balancer.go:296 lxc/network_peer.go:280
 #: lxc/network_zone.go:324 lxc/network_zone.go:922 lxc/storage_bucket.go:136
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: lxc/info.go:128
+#: lxc/info.go:127
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:851
+#: lxc/info.go:568 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:852
+#: lxc/info.go:569 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -930,24 +930,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:356
+#: lxc/info.go:355
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:572
+#: lxc/list.go:571
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:519
+#: lxc/info.go:518
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:523
+#: lxc/info.go:522
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:358
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -956,21 +956,21 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:556
+#: lxc/list.go:555
 msgid "CREATED AT"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:129
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:995
+#: lxc/image.go:999
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:308
 msgid "Caches:"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -991,15 +991,15 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:854
+#: lxc/remote.go:857
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:586
+#: lxc/list.go:585
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:458
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:602 lxc/storage_volume.go:1573 lxc/warning.go:224
+#: lxc/list.go:601 lxc/storage_volume.go:1573 lxc/warning.go:224
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:160
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:403 lxc/info.go:415
+#: lxc/info.go:402 lxc/info.go:414
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:112
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1057,13 +1057,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:216
+#: lxc/remote.go:218
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:447
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:599
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1132,17 +1132,17 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
-#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:64
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:44 lxc/init.go:64
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
-#: lxc/network_forward.go:172 lxc/network_forward.go:237
-#: lxc/network_forward.go:441 lxc/network_forward.go:564
-#: lxc/network_forward.go:706 lxc/network_forward.go:783
-#: lxc/network_forward.go:849 lxc/network_load_balancer.go:174
-#: lxc/network_load_balancer.go:239 lxc/network_load_balancer.go:444
-#: lxc/network_load_balancer.go:567 lxc/network_load_balancer.go:710
-#: lxc/network_load_balancer.go:786 lxc/network_load_balancer.go:850
-#: lxc/network_load_balancer.go:951 lxc/network_load_balancer.go:1013
+#: lxc/network_forward.go:174 lxc/network_forward.go:239
+#: lxc/network_forward.go:456 lxc/network_forward.go:579
+#: lxc/network_forward.go:721 lxc/network_forward.go:798
+#: lxc/network_forward.go:864 lxc/network_load_balancer.go:176
+#: lxc/network_load_balancer.go:241 lxc/network_load_balancer.go:459
+#: lxc/network_load_balancer.go:582 lxc/network_load_balancer.go:725
+#: lxc/network_load_balancer.go:801 lxc/network_load_balancer.go:865
+#: lxc/network_load_balancer.go:966 lxc/network_load_balancer.go:1028
 #: lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671
 #: lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85
 #: lxc/storage_bucket.go:185 lxc/storage_bucket.go:248
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1427
+#: lxc/image.go:1060 lxc/list.go:131 lxc/storage_volume.go:1427
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1213,8 +1213,8 @@ msgstr ""
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
 #: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
-#: lxc/network_acl.go:620 lxc/network_forward.go:670
-#: lxc/network_load_balancer.go:674 lxc/network_peer.go:610
+#: lxc/network_acl.go:620 lxc/network_forward.go:685
+#: lxc/network_load_balancer.go:689 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
 #: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
 #: lxc/storage_bucket.go:1092 lxc/storage_volume.go:1016
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/console.go:139
+#: lxc/console.go:140
 msgid "Console log:"
 msgstr ""
 
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:116
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1320,21 +1320,21 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:316
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:314
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:482
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:464
+#: lxc/remote.go:224 lxc/remote.go:466
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:475
+#: lxc/remote.go:477
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:248 lxc/file.go:474
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1450,11 +1450,11 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:233 lxc/network_forward.go:234
+#: lxc/network_forward.go:235 lxc/network_forward.go:236
 msgid "Create new network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:235 lxc/network_load_balancer.go:236
+#: lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:238
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1313
+#: lxc/image.go:968 lxc/info.go:488 lxc/storage_volume.go:1313
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1504,19 +1504,19 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: lxc/info.go:137 lxc/info.go:246
+#: lxc/info.go:136 lxc/info.go:245
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:148
+#: lxc/network_forward.go:150
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
-#: lxc/network_acl.go:148 lxc/network_forward.go:147
-#: lxc/network_load_balancer.go:150 lxc/network_peer.go:140
+#: lxc/image.go:1074 lxc/image_alias.go:237 lxc/list.go:556 lxc/network.go:985
+#: lxc/network_acl.go:148 lxc/network_forward.go:149
+#: lxc/network_load_balancer.go:152 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
 #: lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646
 #: lxc/storage_bucket.go:507 lxc/storage_bucket.go:827
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:558
+#: lxc/list.go:557
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:108
 msgid "DRM:"
 msgstr ""
 
@@ -1556,7 +1556,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:122 lxc/file.go:123
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1592,11 +1592,11 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:702 lxc/network_forward.go:703
+#: lxc/network_forward.go:717 lxc/network_forward.go:718
 msgid "Delete network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:706 lxc/network_load_balancer.go:707
+#: lxc/network_load_balancer.go:721 lxc/network_load_balancer.go:722
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1672,15 +1672,15 @@ msgstr ""
 #: lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:975 lxc/image.go:37
+#: lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
+#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
+#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37
 #: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
-#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
-#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
+#: lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354
+#: lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
+#: lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82
 #: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
@@ -1691,20 +1691,20 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:31
-#: lxc/network_forward.go:88 lxc/network_forward.go:169
-#: lxc/network_forward.go:234 lxc/network_forward.go:364
-#: lxc/network_forward.go:433 lxc/network_forward.go:531
-#: lxc/network_forward.go:561 lxc/network_forward.go:703
-#: lxc/network_forward.go:765 lxc/network_forward.go:780
-#: lxc/network_forward.go:845 lxc/network_load_balancer.go:31
-#: lxc/network_load_balancer.go:92 lxc/network_load_balancer.go:171
-#: lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:368
-#: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:534
-#: lxc/network_load_balancer.go:564 lxc/network_load_balancer.go:707
-#: lxc/network_load_balancer.go:768 lxc/network_load_balancer.go:783
-#: lxc/network_load_balancer.go:847 lxc/network_load_balancer.go:933
-#: lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:1009
+#: lxc/network_allocations.go:51 lxc/network_forward.go:33
+#: lxc/network_forward.go:90 lxc/network_forward.go:171
+#: lxc/network_forward.go:236 lxc/network_forward.go:379
+#: lxc/network_forward.go:448 lxc/network_forward.go:546
+#: lxc/network_forward.go:576 lxc/network_forward.go:718
+#: lxc/network_forward.go:780 lxc/network_forward.go:795
+#: lxc/network_forward.go:860 lxc/network_load_balancer.go:33
+#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173
+#: lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383
+#: lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549
+#: lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722
+#: lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798
+#: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948
+#: lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024
 #: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
 #: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
 #: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
@@ -1723,9 +1723,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
-#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
-#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
+#: lxc/remote.go:627 lxc/remote.go:665 lxc/remote.go:751 lxc/remote.go:824
+#: lxc/remote.go:880 lxc/remote.go:920 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:291
+#: lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:983
+#: lxc/file.go:994
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1846,24 +1846,24 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:427
+#: lxc/info.go:426
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:512
+#: lxc/info.go:511
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:422
+#: lxc/info.go:421
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:424
 msgid "Disks:"
 msgstr ""
 
-#: lxc/list.go:135
+#: lxc/list.go:134
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: lxc/info.go:105 lxc/info.go:191
+#: lxc/info.go:104 lxc/info.go:190
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:866
+#: lxc/list.go:865
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1900,7 +1900,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:74
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:171 lxc/file.go:172
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1958,11 +1958,11 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:560 lxc/network_forward.go:561
+#: lxc/network_forward.go:575 lxc/network_forward.go:576
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: lxc/network_load_balancer.go:563 lxc/network_load_balancer.go:564
+#: lxc/network_load_balancer.go:578 lxc/network_load_balancer.go:579
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1596
+#: lxc/image.go:1086 lxc/list.go:613 lxc/storage_volume.go:1596
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2059,8 +2059,8 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
-#: lxc/network_acl.go:467 lxc/network_forward.go:504
-#: lxc/network_load_balancer.go:507 lxc/network_peer.go:463
+#: lxc/network_acl.go:467 lxc/network_forward.go:519
+#: lxc/network_load_balancer.go:522 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
 #: lxc/storage_volume.go:1947 lxc/storage_volume.go:1985
@@ -2074,7 +2074,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461
-#: lxc/network_forward.go:498 lxc/network_load_balancer.go:501
+#: lxc/network_forward.go:513 lxc/network_load_balancer.go:516
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
 #: lxc/storage_bucket.go:591 lxc/storage_volume.go:1941
@@ -2120,17 +2120,17 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1346
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1346
 #: lxc/storage_volume.go:1396
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:970
+#: lxc/image.go:974
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:972
+#: lxc/image.go:976
 msgid "Expires: never"
 msgstr ""
 
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
+#: lxc/config_trust.go:411 lxc/image.go:1071 lxc/image.go:1072
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2188,12 +2188,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1237
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1249
+#: lxc/file.go:1260
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2208,12 +2208,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1276
+#: lxc/file.go:1287
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1061
+#: lxc/file.go:1072
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2243,7 +2243,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1182
+#: lxc/file.go:1193
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2258,31 +2258,31 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1187
+#: lxc/file.go:1198
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:356
+#: lxc/console.go:361
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1087
+#: lxc/file.go:1098
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1214
+#: lxc/file.go:1225
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:188
+#: lxc/remote.go:190
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:239
+#: lxc/remote.go:241
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:231
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2302,17 +2302,17 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:254
+#: lxc/remote.go:256
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:261
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1210
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2327,17 +2327,17 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:809
+#: lxc/file.go:820
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:236
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: lxc/list.go:134
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:959
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,12 +2410,12 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
-#: lxc/network_forward.go:91 lxc/network_load_balancer.go:95
+#: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:669 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2438,30 +2438,30 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:318 lxc/info.go:329
+#: lxc/info.go:317 lxc/info.go:328
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:327
+#: lxc/info.go:326
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:730
+#: lxc/remote.go:733
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:398
+#: lxc/info.go:397
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:401
+#: lxc/info.go:400
 msgid "GPUs:"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:391
+#: lxc/remote.go:159 lxc/remote.go:393
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1491 lxc/image.go:1492
+#: lxc/image.go:1498 lxc/image.go:1499
 msgid "Get image properties"
 msgstr ""
 
@@ -2501,11 +2501,11 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:366
+#: lxc/network_forward.go:381
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:371
+#: lxc/network_load_balancer.go:386
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -2569,11 +2569,11 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:363 lxc/network_forward.go:364
+#: lxc/network_forward.go:378 lxc/network_forward.go:379
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:367 lxc/network_load_balancer.go:368
+#: lxc/network_load_balancer.go:382 lxc/network_load_balancer.go:383
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2641,30 +2641,30 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:558
+#: lxc/info.go:557
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380
+#: lxc/info.go:368 lxc/info.go:379
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1310
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1299
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1111
+#: lxc/file.go:1122
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1121
+#: lxc/file.go:1132
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2673,12 +2673,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/info.go:110
+#: lxc/info.go:109
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
+#: lxc/info.go:197 lxc/info.go:264 lxc/info.go:289
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:573
 msgid "IP addresses"
 msgstr ""
 
@@ -2703,11 +2703,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:552 lxc/network.go:983
+#: lxc/list.go:551 lxc/network.go:983
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:553 lxc/network.go:984
+#: lxc/list.go:552 lxc/network.go:984
 msgid "IPV6"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1415
+#: lxc/image.go:1422
 msgid "Image already up to date."
 msgstr ""
 
@@ -2775,21 +2775,21 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:347 lxc/image.go:1373
+#: lxc/image.go:347 lxc/image.go:1377
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:419 lxc/image.go:1567
+#: lxc/image.go:419 lxc/image.go:1574
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:867
+#: lxc/image.go:871
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1413
+#: lxc/image.go:1420
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: lxc/info.go:227
+#: lxc/info.go:226
 msgid "Infiniband:"
 msgstr ""
 
@@ -2850,15 +2850,15 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:684
+#: lxc/info.go:683
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1124
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1290
+#: lxc/file.go:1301
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2876,16 +2876,16 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1044
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:347
+#: lxc/publish.go:350
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:75
+#: lxc/rebuild.go:74
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:343
+#: lxc/remote.go:345
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2908,12 +2908,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:648
+#: lxc/list.go:647
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:641
+#: lxc/list.go:640
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2923,12 +2923,12 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: lxc/snapshot.go:72
+#: lxc/snapshot.go:68
 #, c-format
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1028
+#: lxc/file.go:1039
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2938,17 +2938,17 @@ msgstr ""
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: lxc/list.go:669
+#: lxc/list.go:668
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:665
+#: lxc/list.go:664
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:655
+#: lxc/list.go:654
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:147
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:334
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2986,17 +2986,17 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:229
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:561
 msgid "LAST USED AT"
 msgstr ""
 
@@ -3017,12 +3017,12 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:146 lxc/network_load_balancer.go:149
+#: lxc/network_forward.go:148 lxc/network_load_balancer.go:151
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:598 lxc/network.go:1059 lxc/network_forward.go:153
-#: lxc/network_load_balancer.go:155 lxc/operation.go:177
+#: lxc/list.go:597 lxc/network.go:1059 lxc/network_forward.go:155
+#: lxc/network_load_balancer.go:157 lxc/operation.go:177
 #: lxc/storage_bucket.go:511 lxc/storage_volume.go:1569 lxc/warning.go:220
 msgid "LOCATION"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:377
+#: lxc/console.go:382
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3040,26 +3040,26 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:493
+#: lxc/info.go:492
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:976
+#: lxc/image.go:980
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:978
+#: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:221
+#: lxc/info.go:220
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: lxc/info.go:223
+#: lxc/info.go:222
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:87 lxc/network_forward.go:88
+#: lxc/network_forward.go:89 lxc/network_forward.go:90
 msgid "List available network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:92
+#: lxc/network_load_balancer.go:93 lxc/network_load_balancer.go:94
 msgid "List available network load balancers"
 msgstr ""
 
@@ -3159,11 +3159,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1030
+#: lxc/image.go:1034
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1035
 msgid ""
 "List images\n"
 "\n"
@@ -3198,11 +3198,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:47
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:48
 #, c-format
 msgid ""
 "List instances\n"
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:661 lxc/remote.go:662
+#: lxc/remote.go:664 lxc/remote.go:665
 msgid "List the available remotes"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:481 lxc/storage_volume.go:1302
+#: lxc/info.go:480 lxc/storage_volume.go:1302
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:711
 msgid "Log:"
 msgstr ""
 
@@ -3405,7 +3405,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:562
+#: lxc/info.go:561
 msgid "MAC address"
 msgstr ""
 
@@ -3414,7 +3414,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/info.go:234
+#: lxc/info.go:233
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -3427,11 +3427,11 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: lxc/list.go:563
+#: lxc/list.go:562
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:564
+#: lxc/list.go:563
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:565
 msgid "MTU"
 msgstr ""
 
@@ -3489,7 +3489,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:82 lxc/file.go:83
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3560,23 +3560,23 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:764 lxc/network_forward.go:765
+#: lxc/network_forward.go:779 lxc/network_forward.go:780
 msgid "Manage network forward ports"
 msgstr ""
 
-#: lxc/network_forward.go:30 lxc/network_forward.go:31
+#: lxc/network_forward.go:32 lxc/network_forward.go:33
 msgid "Manage network forwards"
 msgstr ""
 
-#: lxc/network_load_balancer.go:767 lxc/network_load_balancer.go:768
+#: lxc/network_load_balancer.go:782 lxc/network_load_balancer.go:783
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: lxc/network_load_balancer.go:932 lxc/network_load_balancer.go:933
+#: lxc/network_load_balancer.go:947 lxc/network_load_balancer.go:948
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:31
+#: lxc/network_load_balancer.go:32 lxc/network_load_balancer.go:33
 msgid "Manage network load balancers"
 msgstr ""
 
@@ -3656,12 +3656,12 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: lxc/info.go:138 lxc/info.go:247
+#: lxc/info.go:137 lxc/info.go:246
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/info.go:149
+#: lxc/info.go:148
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -3690,19 +3690,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:530
+#: lxc/info.go:529
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:534
+#: lxc/info.go:533
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:545
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:367
+#: lxc/info.go:366
 msgid "Memory:"
 msgstr ""
 
@@ -3766,7 +3766,7 @@ msgstr ""
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
 #: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
-#: lxc/profile.go:698 lxc/rebuild.go:59
+#: lxc/profile.go:698 lxc/rebuild.go:60
 msgid "Missing instance name"
 msgstr ""
 
@@ -3775,14 +3775,14 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:197 lxc/network_forward.go:393
-#: lxc/network_forward.go:466 lxc/network_forward.go:612
-#: lxc/network_forward.go:731 lxc/network_forward.go:808
-#: lxc/network_forward.go:874 lxc/network_load_balancer.go:199
-#: lxc/network_load_balancer.go:396 lxc/network_load_balancer.go:469
-#: lxc/network_load_balancer.go:615 lxc/network_load_balancer.go:735
-#: lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:875
-#: lxc/network_load_balancer.go:976 lxc/network_load_balancer.go:1038
+#: lxc/network_forward.go:199 lxc/network_forward.go:408
+#: lxc/network_forward.go:481 lxc/network_forward.go:627
+#: lxc/network_forward.go:746 lxc/network_forward.go:823
+#: lxc/network_forward.go:889 lxc/network_load_balancer.go:201
+#: lxc/network_load_balancer.go:411 lxc/network_load_balancer.go:484
+#: lxc/network_load_balancer.go:630 lxc/network_load_balancer.go:750
+#: lxc/network_load_balancer.go:826 lxc/network_load_balancer.go:890
+#: lxc/network_load_balancer.go:991 lxc/network_load_balancer.go:1053
 msgid "Missing listen address"
 msgstr ""
 
@@ -3802,16 +3802,16 @@ msgstr ""
 #: lxc/network.go:159 lxc/network.go:244 lxc/network.go:396 lxc/network.go:446
 #: lxc/network.go:531 lxc/network.go:636 lxc/network.go:747 lxc/network.go:815
 #: lxc/network.go:1030 lxc/network.go:1100 lxc/network.go:1158
-#: lxc/network.go:1242 lxc/network_forward.go:117 lxc/network_forward.go:193
-#: lxc/network_forward.go:257 lxc/network_forward.go:389
-#: lxc/network_forward.go:462 lxc/network_forward.go:608
-#: lxc/network_forward.go:727 lxc/network_forward.go:804
-#: lxc/network_forward.go:870 lxc/network_load_balancer.go:121
-#: lxc/network_load_balancer.go:195 lxc/network_load_balancer.go:259
-#: lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:465
-#: lxc/network_load_balancer.go:611 lxc/network_load_balancer.go:731
-#: lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:871
-#: lxc/network_load_balancer.go:972 lxc/network_load_balancer.go:1034
+#: lxc/network.go:1242 lxc/network_forward.go:119 lxc/network_forward.go:195
+#: lxc/network_forward.go:259 lxc/network_forward.go:404
+#: lxc/network_forward.go:477 lxc/network_forward.go:623
+#: lxc/network_forward.go:742 lxc/network_forward.go:819
+#: lxc/network_forward.go:885 lxc/network_load_balancer.go:123
+#: lxc/network_load_balancer.go:197 lxc/network_load_balancer.go:261
+#: lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:480
+#: lxc/network_load_balancer.go:626 lxc/network_load_balancer.go:746
+#: lxc/network_load_balancer.go:822 lxc/network_load_balancer.go:886
+#: lxc/network_load_balancer.go:987 lxc/network_load_balancer.go:1049
 #: lxc/network_peer.go:110 lxc/network_peer.go:180 lxc/network_peer.go:237
 #: lxc/network_peer.go:355 lxc/network_peer.go:426 lxc/network_peer.go:556
 #: lxc/network_peer.go:665
@@ -3874,7 +3874,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:590
+#: lxc/file.go:598
 msgid "Missing target directory"
 msgstr ""
 
@@ -3886,12 +3886,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: lxc/info.go:269
+#: lxc/info.go:268
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: lxc/info.go:129
+#: lxc/info.go:128
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -3912,15 +3912,15 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:285
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:974 lxc/file.go:975
+#: lxc/file.go:985 lxc/file.go:986
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/info.go:283 lxc/info.go:293
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Mounted: %v"
 msgstr ""
@@ -3962,7 +3962,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:918 lxc/network_load_balancer.go:1082
+#: lxc/network_forward.go:933 lxc/network_load_balancer.go:1097
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -3980,10 +3980,10 @@ msgstr ""
 
 #: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
+#: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:727 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4000,53 +4000,53 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:410
+#: lxc/info.go:409
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:413
+#: lxc/info.go:412
 msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
+#: lxc/project.go:481 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:90 lxc/info.go:176 lxc/info.go:263
+#: lxc/info.go:89 lxc/info.go:175 lxc/info.go:262
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:375
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: lxc/info.go:126
+#: lxc/info.go:125
 msgid "NVIDIA information:"
 msgstr ""
 
-#: lxc/info.go:131
+#: lxc/info.go:130
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1344
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1344
 #: lxc/storage_volume.go:1394
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:139
+#: lxc/remote.go:141
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1284
+#: lxc/info.go:463 lxc/network.go:833 lxc/storage_volume.go:1284
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:305
+#: lxc/info.go:304
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4096,22 +4096,22 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:346
+#: lxc/network_forward.go:361
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:748
+#: lxc/network_forward.go:763
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: lxc/network_load_balancer.go:350
+#: lxc/network_load_balancer.go:365
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: lxc/network_load_balancer.go:752
+#: lxc/network_load_balancer.go:767
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4145,7 +4145,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:587 lxc/network.go:850
+#: lxc/info.go:586 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4189,11 +4189,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/network_load_balancer.go:906
+#: lxc/network_load_balancer.go:921
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:929 lxc/network_load_balancer.go:1093
+#: lxc/network_forward.go:944 lxc/network_load_balancer.go:1108
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:378
+#: lxc/info.go:377
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:326
+#: lxc/remote.go:328
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:685 lxc/storage_volume.go:1398
+#: lxc/info.go:684 lxc/storage_volume.go:1398
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4272,7 +4272,7 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/info.go:101 lxc/info.go:187
+#: lxc/info.go:100 lxc/info.go:186
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
@@ -4281,11 +4281,11 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:567
+#: lxc/list.go:566
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:484
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4294,39 +4294,39 @@ msgstr ""
 msgid "POOL"
 msgstr ""
 
-#: lxc/network_forward.go:149 lxc/network_load_balancer.go:151
+#: lxc/network_forward.go:151 lxc/network_load_balancer.go:153
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:565
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:568 lxc/project.go:500
+#: lxc/list.go:567 lxc/project.go:500
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:559 lxc/storage_volume.go:1586 lxc/warning.go:212
+#: lxc/list.go:558 lxc/storage_volume.go:1586 lxc/warning.go:212
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:726
+#: lxc/remote.go:729
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1069 lxc/remote.go:728
+#: lxc/image.go:1073 lxc/remote.go:731
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:571 lxc/network.go:853
+#: lxc/info.go:570 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:572 lxc/network.go:854
+#: lxc/info.go:571 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:287
+#: lxc/info.go:286
 msgid "Partitions:"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:180
+#: lxc/remote.go:182
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4355,20 +4355,20 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:458
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:212
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: lxc/info.go:195
+#: lxc/info.go:194
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1091
+#: lxc/file.go:1102
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:671
-#: lxc/network_load_balancer.go:675 lxc/network_peer.go:611
+#: lxc/network_acl.go:621 lxc/network_forward.go:686
+#: lxc/network_load_balancer.go:690 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1093 lxc/storage_volume.go:1017
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:499
+#: lxc/info.go:498
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4411,7 +4411,7 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: lxc/info.go:97 lxc/info.go:183
+#: lxc/info.go:96 lxc/info.go:182
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1008
+#: lxc/image.go:1012
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1010
 msgid "Profiles: "
 msgstr ""
 
@@ -4486,15 +4486,15 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:106
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:981
+#: lxc/image.go:985
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1526
+#: lxc/image.go:1533
 msgid "Property not found"
 msgstr ""
 
@@ -4584,11 +4584,11 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:105
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:959
+#: lxc/image.go:963
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4602,20 +4602,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:241 lxc/file.go:242
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:756
+#: lxc/file.go:416 lxc/file.go:767
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:690 lxc/file.go:856
+#: lxc/file.go:701 lxc/file.go:867
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
+#: lxc/image.go:505 lxc/image.go:904 lxc/image.go:1444
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:292
+#: lxc/info.go:281 lxc/info.go:291
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:249 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,7 +4661,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1349 lxc/image.go:1350
+#: lxc/image.go:1353 lxc/image.go:1354
 msgid "Refresh images"
 msgstr ""
 
@@ -4670,46 +4670,50 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1382
+#: lxc/image.go:1386
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:778
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
-#: lxc/remote.go:938
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901
+#: lxc/remote.go:941
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:297
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:850
+#: lxc/remote.go:853
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
+#: lxc/remote.go:776 lxc/remote.go:849 lxc/remote.go:945
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:291
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:284
+#: lxc/remote.go:102
+msgid "Remote trust token"
+msgstr ""
+
+#: lxc/info.go:283
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4739,7 +4743,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:846 lxc/network_load_balancer.go:1010
+#: lxc/network_forward.go:861 lxc/network_load_balancer.go:1025
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4747,11 +4751,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/network_load_balancer.go:847
+#: lxc/network_load_balancer.go:862
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: lxc/network_load_balancer.go:846
+#: lxc/network_load_balancer.go:861
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -4775,11 +4779,11 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:844 lxc/network_forward.go:845
+#: lxc/network_forward.go:859 lxc/network_forward.go:860
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: lxc/network_load_balancer.go:1008 lxc/network_load_balancer.go:1009
+#: lxc/network_load_balancer.go:1023 lxc/network_load_balancer.go:1024
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -4787,7 +4791,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:821
+#: lxc/remote.go:823 lxc/remote.go:824
 msgid "Remove remotes"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:747 lxc/remote.go:748
+#: lxc/remote.go:750 lxc/remote.go:751
 msgid "Rename remotes"
 msgstr ""
 
@@ -4861,7 +4865,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: lxc/info.go:121
+#: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
@@ -4878,7 +4882,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:496
 msgid "Resources:"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:43
+#: lxc/console.go:44
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -4958,11 +4962,11 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1072
+#: lxc/image.go:1076
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:569
+#: lxc/list.go:568
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -4970,26 +4974,26 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/info.go:136 lxc/info.go:245
+#: lxc/info.go:135 lxc/info.go:244
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1219
+#: lxc/file.go:1230
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1220
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:189 lxc/list.go:570 lxc/network.go:987
+#: lxc/cluster.go:189 lxc/list.go:569 lxc/network.go:987
 #: lxc/network_peer.go:142 lxc/storage.go:648
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:729
+#: lxc/remote.go:732
 msgid "STATIC"
 msgstr ""
 
@@ -5001,7 +5005,7 @@ msgstr ""
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: lxc/list.go:555
+#: lxc/list.go:554
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -5026,19 +5030,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:456
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:592
+#: lxc/remote.go:595
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5055,7 +5059,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:995
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5081,7 +5085,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1542 lxc/image.go:1543
+#: lxc/image.go:1549 lxc/image.go:1550
 msgid "Set image properties"
 msgstr ""
 
@@ -5124,11 +5128,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:432
+#: lxc/network_forward.go:447
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:433
+#: lxc/network_forward.go:448
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5137,11 +5141,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:435
+#: lxc/network_load_balancer.go:450
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:436
+#: lxc/network_load_balancer.go:451
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -5245,19 +5249,19 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5269,11 +5273,11 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:440
+#: lxc/network_forward.go:455
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:443
+#: lxc/network_load_balancer.go:458
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -5317,7 +5321,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:982
+#: lxc/file.go:993
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1433 lxc/image.go:1434
+#: lxc/image.go:1440 lxc/image.go:1441
 msgid "Show image properties"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: lxc/info.go:32 lxc/info.go:33
+#: lxc/info.go:31 lxc/info.go:32
 msgid "Show instance or server information"
 msgstr ""
 
@@ -5414,11 +5418,11 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:168 lxc/network_forward.go:169
+#: lxc/network_forward.go:170 lxc/network_forward.go:171
 msgid "Show network forward configurations"
 msgstr ""
 
-#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:173
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -5476,7 +5480,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:623 lxc/remote.go:624
+#: lxc/remote.go:626 lxc/remote.go:627
 msgid "Show the default remote"
 msgstr ""
 
@@ -5484,11 +5488,11 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:43
+#: lxc/info.go:42
 msgid "Show the instance's last 100 log lines?"
 msgstr ""
 
-#: lxc/info.go:44
+#: lxc/info.go:43
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -5508,7 +5512,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:896 lxc/image.go:897
+#: lxc/image.go:900 lxc/image.go:901
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5520,12 +5524,12 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:956
+#: lxc/image.go:960
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:294
+#: lxc/info.go:275 lxc/info.go:293
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5538,11 +5542,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:599 lxc/storage_volume.go:1323
+#: lxc/info.go:598 lxc/storage_volume.go:1323
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:361
+#: lxc/info.go:360
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5552,7 +5556,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:999
+#: lxc/image.go:1003
 msgid "Source:"
 msgstr ""
 
@@ -5565,7 +5569,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:555
 msgid "State"
 msgstr ""
 
@@ -5574,11 +5578,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:633
+#: lxc/info.go:632
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:466
+#: lxc/info.go:465
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5666,21 +5670,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:204
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:208
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:537
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:541
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5688,7 +5692,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:876 lxc/remote.go:877
+#: lxc/remote.go:879 lxc/remote.go:880
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5700,22 +5704,22 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
-#: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1078
+#: lxc/image_alias.go:236 lxc/list.go:570 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1560 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1395
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1395
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1021
+#: lxc/file.go:1032
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1015
+#: lxc/file.go:1026
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5731,7 +5735,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:125
+#: lxc/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5803,7 +5807,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/network_load_balancer.go:409
+#: lxc/network_load_balancer.go:424
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -5818,7 +5822,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:421
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5869,7 +5873,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:346
+#: lxc/info.go:345
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5914,7 +5918,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:318
 msgid "Threads:"
 msgstr ""
 
@@ -5922,7 +5926,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:964
 msgid "Timestamps:"
 msgstr ""
 
@@ -5934,7 +5938,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:209
+#: lxc/console.go:210
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5945,7 +5949,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
-#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:337 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5954,12 +5958,12 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:216
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:555
+#: lxc/info.go:554
 msgid "Type"
 msgstr ""
 
@@ -6011,19 +6015,19 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:45
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:962 lxc/info.go:272 lxc/info.go:474 lxc/network.go:837
 #: lxc/storage_volume.go:1293
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:473
+#: lxc/info.go:472
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6032,11 +6036,11 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1073
+#: lxc/image.go:1077
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:725
+#: lxc/cluster.go:184 lxc/remote.go:728
 msgid "URL"
 msgstr ""
 
@@ -6054,17 +6058,17 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: lxc/info.go:132
+#: lxc/info.go:131
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:197
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:211 lxc/remote.go:245
+#: lxc/remote.go:213 lxc/remote.go:247
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6073,23 +6077,23 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1242
+#: lxc/file.go:1253
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1604
-#: lxc/warning.go:243
+#: lxc/image.go:1092 lxc/list.go:622 lxc/storage_volume.go:1602
+#: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:158
+#: lxc/console.go:159
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:796
+#: lxc/file.go:807
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6099,7 +6103,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:108
+#: lxc/console.go:109
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6120,7 +6124,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1597 lxc/image.go:1598
+#: lxc/image.go:1604 lxc/image.go:1605
 msgid "Unset image properties"
 msgstr ""
 
@@ -6136,19 +6140,19 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:530
+#: lxc/network_forward.go:545
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:531
+#: lxc/network_forward.go:546
 msgid "Unset network forward keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:533
+#: lxc/network_load_balancer.go:548
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: lxc/network_load_balancer.go:534
+#: lxc/network_load_balancer.go:549
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -6196,11 +6200,11 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:534
+#: lxc/network_forward.go:549
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: lxc/network_load_balancer.go:537
+#: lxc/network_load_balancer.go:552
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -6248,7 +6252,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:704
+#: lxc/info.go:703
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6271,7 +6275,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:967
+#: lxc/image.go:971
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6307,12 +6311,12 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:71
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
-#: lxc/info.go:140 lxc/info.go:249
+#: lxc/info.go:139 lxc/info.go:248
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -6329,17 +6333,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:301
+#: lxc/info.go:300
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: lxc/info.go:93 lxc/info.go:179
+#: lxc/info.go:92 lxc/info.go:178
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: lxc/info.go:238
+#: lxc/info.go:237
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -6356,7 +6360,7 @@ msgstr ""
 msgid "Volume Only"
 msgstr ""
 
-#: lxc/info.go:279
+#: lxc/info.go:278
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -6387,7 +6391,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
+#: lxc/project.go:483 lxc/remote.go:689 lxc/remote.go:694 lxc/remote.go:699
 msgid "YES"
 msgstr ""
 
@@ -6407,7 +6411,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:120
+#: lxc/rebuild.go:119
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6444,7 +6448,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/list.go:46
+#: lxc/image.go:1032 lxc/list.go:45
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6561,15 +6565,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
+#: lxc/image.go:377 lxc/image.go:899 lxc/image.go:1439
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1490 lxc/image.go:1596
+#: lxc/image.go:1497 lxc/image.go:1603
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1541
+#: lxc/image.go:1548
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6589,13 +6593,13 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:321 lxc/image.go:1348
+#: lxc/image.go:321 lxc/image.go:1352
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
 #: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
 #: lxc/config_device.go:662 lxc/config_metadata.go:53
-#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:35
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -6660,20 +6664,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:170
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:120
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:240
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:973
+#: lxc/file.go:984
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6720,8 +6724,8 @@ msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
 #: lxc/network.go:369 lxc/network.go:590 lxc/network.go:787 lxc/network.go:1003
-#: lxc/network.go:1214 lxc/network_forward.go:85
-#: lxc/network_load_balancer.go:89 lxc/network_peer.go:78
+#: lxc/network.go:1214 lxc/network_forward.go:87
+#: lxc/network_load_balancer.go:91 lxc/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -6741,44 +6745,44 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:167 lxc/network_forward.go:559
-#: lxc/network_forward.go:700 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:562 lxc/network_load_balancer.go:704
+#: lxc/network_forward.go:169 lxc/network_forward.go:574
+#: lxc/network_forward.go:715 lxc/network_load_balancer.go:171
+#: lxc/network_load_balancer.go:577 lxc/network_load_balancer.go:719
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:845
+#: lxc/network_load_balancer.go:860
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: lxc/network_load_balancer.go:781
+#: lxc/network_load_balancer.go:796
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:362 lxc/network_forward.go:529
-#: lxc/network_load_balancer.go:366 lxc/network_load_balancer.go:532
+#: lxc/network_forward.go:377 lxc/network_forward.go:544
+#: lxc/network_load_balancer.go:381 lxc/network_load_balancer.go:547
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:431 lxc/network_load_balancer.go:434
+#: lxc/network_forward.go:446 lxc/network_load_balancer.go:449
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_load_balancer.go:946
+#: lxc/network_load_balancer.go:961
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:778
+#: lxc/network_forward.go:793
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:843 lxc/network_load_balancer.go:1007
+#: lxc/network_forward.go:858 lxc/network_load_balancer.go:1022
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6816,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network_forward.go:232 lxc/network_load_balancer.go:234
+#: lxc/network_forward.go:234 lxc/network_load_balancer.go:236
 msgid "[<remote>:]<network> [<listen_address>] [key=value...]"
 msgstr ""
 
@@ -7020,7 +7024,7 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:30
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
@@ -7036,7 +7040,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:88
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7044,7 +7048,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:715
+#: lxc/project.go:488 lxc/remote.go:718
 msgid "current"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:945
+#: lxc/image.go:949
 msgid "disabled"
 msgstr ""
 
@@ -7060,7 +7064,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:951
 msgid "enabled"
 msgstr ""
 
@@ -7177,20 +7181,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:977
+#: lxc/file.go:988
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:244
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7211,7 +7215,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:35
+#: lxc/info.go:34
 msgid ""
 "lxc info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -7258,7 +7262,7 @@ msgid ""
 "disk of 32GiB"
 msgstr ""
 
-#: lxc/list.go:122
+#: lxc/list.go:121
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -7407,7 +7411,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:455
 msgid "n"
 msgstr ""
 
@@ -7415,11 +7419,11 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
+#: lxc/image.go:939 lxc/image.go:944 lxc/image.go:1134
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:446
+#: lxc/remote.go:448
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7431,16 +7435,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1131
+#: lxc/file.go:1142
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1090
+#: lxc/file.go:1101
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1043
+#: lxc/file.go:1054
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7456,11 +7460,11 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:457
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
-#: lxc/image.go:1127
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:941 lxc/image.go:946
+#: lxc/image.go:1131
 msgid "yes"
 msgstr ""

--- a/shared/api/certificate.go
+++ b/shared/api/certificate.go
@@ -52,6 +52,12 @@ type CertificatesPost struct {
 	// Example: blah
 	Password string `json:"password" yaml:"password"`
 
+	// Trust token (used to add an untrusted client)
+	// Example: blah
+	//
+	// API extension: explicit_trust_token
+	TrustToken string `json:"trust_token" yaml:"trust_token"`
+
 	// Whether to create a certificate add token
 	// Example: true
 	//

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -87,6 +87,12 @@ type ClusterPut struct {
 	//
 	// API extension: clustering_join
 	ClusterPassword string `json:"cluster_password" yaml:"cluster_password"`
+
+	// The cluster join token for the cluster you're trying to join
+	// Example: blah
+	//
+	// API extension: explicit_trust_token
+	ClusterToken string `json:"cluster_token" yaml:"cluster_token"`
 }
 
 // ClusterMembersPost represents the fields required to request a join token to add a member to the cluster.

--- a/shared/api/init.go
+++ b/shared/api/init.go
@@ -78,8 +78,4 @@ type InitClusterPreseed struct {
 	// The path to the cluster certificate
 	// Example: /tmp/cluster.crt
 	ClusterCertificatePath string `json:"cluster_certificate_path" yaml:"cluster_certificate_path"`
-
-	// A cluster join token
-	// Example: BASE64-TOKEN
-	ClusterToken string `json:"cluster_token" yaml:"cluster_token"`
 }

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -407,6 +407,7 @@ var APIExtensions = []string{
 	"container_syscall_intercept_finit_module",
 	"device_usb_serial",
 	"network_allocate_external_ips",
+	"explicit_trust_token",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -289,6 +289,102 @@ EOF
   )
 }
 
+spawn_lxd_and_join_cluster_with_token() {
+  # shellcheck disable=SC2039,SC3043
+  local LXD_NETNS
+
+  set -e
+  ns="${1}"
+  bridge="${2}"
+  cert="${3}"
+  index="${4}"
+  target="${5}"
+  LXD_DIR="${6}"
+  if [ -d "${7}" ]; then
+    token="$(LXD_DIR=${7} lxc cluster add --quiet "node${index}")"
+  else
+    token="${7}"
+  fi
+  driver="dir"
+  port="8443"
+  if [ "$#" -ge  "8" ]; then
+    driver="${8}"
+  fi
+  if [ "$#" -ge  "9" ]; then
+    port="${9}"
+  fi
+
+  echo "==> Spawn additional cluster node in ${ns} with storage driver ${driver}"
+  secret="${LXD_SECRET:-"sekret"}"
+
+  LXD_NETNS="${ns}" spawn_lxd "${LXD_DIR}" false
+  (
+    set -e
+
+    # If a custom cluster port was given, we need to first set the REST
+    # API address.
+    if [ "${port}" != "8443" ]; then
+      lxc config set core.https_address "10.1.1.10${index}:8443"
+    fi
+
+    cat > "${LXD_DIR}/preseed.yaml" <<EOF
+cluster:
+  enabled: true
+  server_name: node${index}
+  server_address: 10.1.1.10${index}:${port}
+  cluster_address: 10.1.1.10${target}:8443
+  cluster_certificate: "$cert"
+  cluster_token: ${token}
+  member_config:
+EOF
+    # Declare the pool only if the driver is not ceph, because
+    # the ceph pool doesn't need to be created on the joining
+    # node (it's shared with the bootstrap one).
+    if [ "${driver}" != "ceph" ]; then
+      cat >> "${LXD_DIR}/preseed.yaml" <<EOF
+  - entity: storage-pool
+    name: data
+    key: source
+    value: ""
+EOF
+      if [ "${driver}" = "zfs" ]; then
+        cat >> "${LXD_DIR}/preseed.yaml" <<EOF
+  - entity: storage-pool
+    name: data
+    key: zfs.pool_name
+    value: lxdtest-$(basename "${TEST_DIR}")-${ns}
+  - entity: storage-pool
+    name: data
+    key: size
+    value: 1GiB
+EOF
+      fi
+      if [ "${driver}" = "lvm" ]; then
+        cat >> "${LXD_DIR}/preseed.yaml" <<EOF
+  - entity: storage-pool
+    name: data
+    key: lvm.vg_name
+    value: lxdtest-$(basename "${TEST_DIR}")-${ns}
+  - entity: storage-pool
+    name: data
+    key: size
+    value: 1GiB
+EOF
+      fi
+      if [ "${driver}" = "btrfs" ]; then
+        cat >> "${LXD_DIR}/preseed.yaml" <<EOF
+  - entity: storage-pool
+    name: data
+    key: size
+    value: 1GiB
+EOF
+      fi
+    fi
+
+    lxd init --preseed < "${LXD_DIR}/preseed.yaml"
+  )
+}
+
 respawn_lxd_cluster_member() {
   # shellcheck disable=SC2039,SC2034,SC3043
   local LXD_NETNS

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -220,11 +220,12 @@ test_clustering_membership() {
   LXD_DIR="${LXD_ONE_DIR}" lxc network create net1 --target node2
 
   # Spawn a third node, using the non-leader node2 as join target.
+  # Join this node using by explicitly specifying a token instead of a password.
   setup_clustering_netns 3
   LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_THREE_DIR}"
   ns3="${prefix}3"
-  spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 2 "${LXD_THREE_DIR}"
+  spawn_lxd_and_join_cluster_with_token "${ns3}" "${bridge}" "${cert}" 3 2 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}"
 
   # Spawn a fourth node, this will be a non-database node.
   setup_clustering_netns 4

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -1,7 +1,20 @@
 test_remote_url() {
+  # Add remotes using password.
   # shellcheck disable=2153
   for url in "${LXD_ADDR}" "https://${LXD_ADDR}"; do
     lxc_remote remote add test "${url}" --accept-certificate --password foo
+    lxc_remote info test:
+    lxc_remote config trust list | awk '/@/ {print $8}' | while read -r line ; do
+      lxc_remote config trust remove "\"${line}\""
+    done
+    lxc_remote remote remove test
+  done
+
+  # Add remotes by setting the token explicitly.
+  # shellcheck disable=2153
+  for url in "${LXD_ADDR}" "https://${LXD_ADDR}"; do
+    token="$(lxc config trust add --name foo -q)"
+    lxc_remote remote add test "${url}" --accept-certificate --token "${token}"
     lxc_remote info test:
     lxc_remote config trust list | awk '/@/ {print $8}' | while read -r line ; do
       lxc_remote config trust remove "\"${line}\""


### PR DESCRIPTION
Partially includes changes from Incus https://github.com/lxc/incus/pull/62.

This PR contains a subset of https://github.com/canonical/lxd/pull/13567 that allows to explicitly specify a trust token when creating a certificate or joining an existing cluster.

This extends the current behavior of using trust passwords by having a separate field in the API struct that is dedicated for using tokens.