### PR TITLE
doc: Use more direct HTTP links where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You should consider using LXD if you want to containerize different environments
 
 See [Getting started](https://documentation.ubuntu.com/lxd/en/latest/getting_started/) in the LXD documentation for installation instructions and first steps.
 
-- Release announcements: [`https://discourse.ubuntu.com/c/lxd/news/`](https://discourse.ubuntu.com/c/lxd/news/)
+- Release announcements: [`https://discourse.ubuntu.com/c/lxd/news/`](https://discourse.ubuntu.com/c/lxd/news/143)
 - Release tarballs: [`https://github.com/canonical/lxd/releases/`](https://github.com/canonical/lxd/releases/)
 - Documentation: [`https://documentation.ubuntu.com/lxd/en/latest/`](https://documentation.ubuntu.com/lxd/en/latest/)
 
@@ -104,7 +104,7 @@ You can file bug reports and feature requests at: [`https://github.com/canonical
 
 ### Forum
 
-A discussion forum is available at: [`https://discourse.ubuntu.com/c/lxd/`](https://discourse.ubuntu.com/c/lxd/)
+A discussion forum is available at: [`https://discourse.ubuntu.com/c/lxd/`](https://discourse.ubuntu.com/c/lxd/126)
 
 ### IRC
 
@@ -121,7 +121,7 @@ See the [full service description](https://ubuntu.com/legal/ubuntu-pro-descripti
 
 The official documentation is available at: [`https://documentation.ubuntu.com/lxd/en/latest/`](https://documentation.ubuntu.com/lxd/en/latest/)
 
-You can find additional resources on the [website](https://canonical.com/lxd), on [YouTube](https://www.youtube.com/channel/UCuP6xPt0WTeZu32CkQPpbvA) and in the [Tutorials section](https://discourse.ubuntu.com/c/lxd/tutorials/) in the forum.
+You can find additional resources on the [website](https://canonical.com/lxd), on [YouTube](https://www.youtube.com/channel/UCuP6xPt0WTeZu32CkQPpbvA) and in the [Tutorials section](https://discourse.ubuntu.com/c/lxd/tutorials/146) in the forum.
 
 <!-- Include end support -->
 

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -133,7 +133,7 @@ Note that the generated certificates are not automatically trusted. You must sti
 (authentication-openid)=
 ## OpenID Connect authentication
 
-LXD supports using [OpenID Connect](https://openid.net/connect/) to authenticate users through an {abbr}`OIDC (OpenID Connect)` Identity Provider.
+LXD supports using [OpenID Connect](https://openid.net/developers/how-connect-works/) to authenticate users through an {abbr}`OIDC (OpenID Connect)` Identity Provider.
 
 To configure LXD to use OIDC authentication, set the [`oidc.*`](server-options-oidc) server configuration options.
 Your OIDC provider must be configured to enable the [Device Authorization Grant](https://oauth.net/2/device-flow/) type.

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -110,7 +110,7 @@ against the local or global database, you can use the `lxd sql` command (run
 You should only need to do that in order to recover from broken updates or bugs.
 Please consult the LXD team first (creating a [GitHub
 issue](https://github.com/canonical/lxd/issues/new) or
-[forum](https://discourse.ubuntu.com/c/lxd/) post).
+[forum](https://discourse.ubuntu.com/c/lxd/126) post).
 
 ### Running custom queries at LXD daemon startup
 

--- a/doc/howto/instances_troubleshoot.md
+++ b/doc/howto/instances_troubleshoot.md
@@ -56,7 +56,7 @@ To troubleshoot the problem, complete the following steps:
 1. Try starting your instance again.
    If the error occurs again, compare the logs to check if it is the same error.
 
-   If it is, and if you cannot figure out the source of the error from the log information, open a question in the [forum](https://discourse.ubuntu.com/c/lxd/).
+   If it is, and if you cannot figure out the source of the error from the log information, open a question in the [forum](https://discourse.ubuntu.com/c/lxd/126).
    Make sure to include the log files you collected.
 
 ## Troubleshooting examples

--- a/doc/howto/move_instances.md
+++ b/doc/howto/move_instances.md
@@ -79,7 +79,7 @@ When {config:option}`instance-migration:migration.stateful` is enabled in LXD, v
 (live-migration-containers)=
 ### Live migration for containers
 
-For containers, there is limited support for live migration using [{abbr}`CRIU (Checkpoint/Restore in Userspace)`](https://criu.org/).
+For containers, there is limited support for live migration using [{abbr}`CRIU (Checkpoint/Restore in Userspace)`](https://criu.org/Main_Page).
 However, because of extensive kernel dependencies, only very basic containers (non-`systemd` containers without a network device) can be migrated reliably.
 In most real-world scenarios, you should stop the container, move it over and then start it again.
 

--- a/doc/howto/network_bridge_firewalld.md
+++ b/doc/howto/network_bridge_firewalld.md
@@ -121,7 +121,7 @@ sudo ufw route allow in on lxdbr0 from "${CIDR6}"
 
 Running LXD and Docker on the same host can cause connectivity issues.
 A common reason for these issues is that Docker sets the global FORWARD policy to `drop`, which prevents LXD from forwarding traffic and thus causes the instances to lose network connectivity.
-See [Docker on a router](https://docs.docker.com/network/iptables/#docker-on-a-router) for detailed information.
+See [Docker on a router](https://docs.docker.com/network/packet-filtering-firewalls/#docker-on-a-router) for detailed information.
 
 There are different ways of working around this problem:
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -92,16 +92,16 @@ LXD (<a href="#" title="Listen" onclick="document.getElementById('player').play(
 LXD is free software and released under [AGPL-3.0-only](https://www.gnu.org/licenses/agpl-3.0.en.html) (it may contain some contributions that are licensed under the Apache-2.0 license, see [License and copyright](contributing)).
 It’s an open source project that warmly welcomes community projects, contributions, suggestions, fixes and constructive feedback.
 
-The LXD project is sponsored by [Canonical Ltd](https://www.canonical.com).
+The LXD project is sponsored by [Canonical Ltd](https://canonical.com/).
 
 - [Code of Conduct](https://github.com/canonical/lxd/blob/main/CODE_OF_CONDUCT.md)
 - [Contribute to the project](contributing.md)
-- [Release announcements](https://discourse.ubuntu.com/c/lxd/news/)
+- [Release announcements](https://discourse.ubuntu.com/c/lxd/news/143)
 - [Release tarballs](https://github.com/canonical/lxd/releases/)
 - [Get support](support.md)
 - [Watch tutorials and announcements on YouTube](https://www.youtube.com/c/LXDvideos)
 - [Discuss on IRC](https://web.libera.chat/#lxd) (see [Getting started with IRC](https://discourse.ubuntu.com/t/getting-started-with-irc/37907) if needed)
-- [Ask and answer questions on the forum](https://discourse.ubuntu.com/c/lxd/)
+- [Ask and answer questions on the forum](https://discourse.ubuntu.com/c/lxd/126)
 
 ```{filtered-toctree}
 :hidden:

--- a/doc/reference/storage_powerflex.md
+++ b/doc/reference/storage_powerflex.md
@@ -1,7 +1,7 @@
 (storage-powerflex)=
 # Dell PowerFlex - `powerflex`
 
-[Dell PowerFlex](https://www.dell.com/en-us/dt/storage/powerflex.htm) is a software-defined storage solution from [Dell Technologies](https://dell.com). Among other things it offers the consumption of redundant block storage across the network.
+[Dell PowerFlex](https://www.dell.com/en-us/shop/powerflex/sf/powerflex) is a software-defined storage solution from [Dell Technologies](https://www.dell.com/). Among other things it offers the consumption of redundant block storage across the network.
 
 LXD offers access to PowerFlex storage clusters by making use of the NVMe/TCP transport protocol.
 In addition, PowerFlex offers copy-on-write snapshots, thin provisioning and other features.

--- a/doc/tutorial/first_steps.md
+++ b/doc/tutorial/first_steps.md
@@ -37,7 +37,7 @@ If you prefer a different installation method, or use a Linux distribution that 
           sudo apt install snapd
 
       ```{note}
-      For other Linux distributions, see the [installation instructions](https://snapcraft.io/docs/core/install) in the Snapcraft documentation.
+      For other Linux distributions, see the [installation instructions](https://snapcraft.io/docs/installing-snapd) in the Snapcraft documentation.
       ```
 
 1. Enter the following command to install LXD:


### PR DESCRIPTION
The link checker conveniently tells us when it follows temporary or permanent redirects. I went through the list of those and update our doc to use more direct links where applicable. There are some temporary/permanent redirects left in place, mostly due to redirecting to localized landing pages.