### PR TITLE
VM: Avoid QEMU device ID trimming

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -108,6 +108,9 @@ const qemuPCIDeviceIDStart = 4
 // qemuDeviceIDPrefix used as part of the name given QEMU devices generated from user added devices.
 const qemuDeviceIDPrefix = "dev-lxd_"
 
+// qemuDeviceNameMaxLength used to indicate the maximum length of a qemu device ID.
+const qemuDeviceIDMaxLength = 64
+
 // qemuDeviceNamePrefix used as part of the name given QEMU blockdevs, netdevs and device tags generated from user added devices.
 const qemuDeviceNamePrefix = "lxd_"
 

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -631,6 +631,7 @@ func qemuDriveFirmware(opts *qemuDriveFirmwareOpts) []cfgSection {
 type qemuHostDriveOpts struct {
 	dev           qemuDevOpts
 	name          string
+	namePrefix    string
 	nameSuffix    string
 	comment       string
 	fsdriver      string

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -657,7 +657,7 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 	var extraDeviceEntries []cfgEntry
 	var driveSection cfgSection
 	deviceOpts := qemuDevEntriesOpts{dev: opts.dev}
-	nameWithPrefix := fmt.Sprintf("%s%s", opts.namePrefix, opts.name) // Use the lxd_ prefix to specify a user named device.
+	nameWithPrefix := generateQemuDirDriveName(opts.name, opts.namePrefix, "")
 
 	if opts.protocol == "9p" {
 		var readonly string
@@ -710,7 +710,7 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 	return []cfgSection{
 		driveSection,
 		{
-			name:    fmt.Sprintf(`device "dev-%s%s-%s"`, opts.name, opts.nameSuffix, opts.protocol),
+			name:    fmt.Sprintf(`device "%s"`, generateQemuDirDriveName(opts.name, fmt.Sprintf("%s%s", "dev-", opts.namePrefix), opts.nameSuffix)),
 			entries: append(qemuDeviceEntries(&deviceOpts), extraDeviceEntries...),
 		},
 	}

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -643,6 +643,16 @@ type qemuHostDriveOpts struct {
 	protocol      string
 }
 
+// generateQemuDeviceID generates QEMU device IDs.
+// QEMU device IDs may only be up to 64 characters long, so use a hash if longer.
+func generateQemuDirDriveName(name string, prefix string, suffix string) string {
+	// Calculate max length before applying prefix and suffix.
+	maxNameLength := qemuDeviceIDMaxLength - (len(prefix) + len(suffix))
+	name = hashIfLonger(name, maxNameLength)
+
+	return fmt.Sprintf("%s%s%s", prefix, name, suffix)
+}
+
 func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 	var extraDeviceEntries []cfgEntry
 	var driveSection cfgSection

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -647,6 +647,7 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 	var extraDeviceEntries []cfgEntry
 	var driveSection cfgSection
 	deviceOpts := qemuDevEntriesOpts{dev: opts.dev}
+	nameWithPrefix := fmt.Sprintf("%s%s", opts.namePrefix, opts.name) // Use the lxd_ prefix to specify a user named device.
 
 	if opts.protocol == "9p" {
 		var readonly string
@@ -657,7 +658,7 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 		}
 
 		driveSection = cfgSection{
-			name:    fmt.Sprintf(`fsdev "%s"`, opts.name),
+			name:    fmt.Sprintf(`fsdev "%s"`, nameWithPrefix),
 			comment: opts.comment,
 			entries: []cfgEntry{
 				{key: "fsdriver", value: opts.fsdriver},
@@ -673,11 +674,11 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 
 		extraDeviceEntries = []cfgEntry{
 			{key: "mount_tag", value: opts.mountTag},
-			{key: "fsdev", value: opts.name},
+			{key: "fsdev", value: nameWithPrefix},
 		}
 	} else if opts.protocol == "virtio-fs" {
 		driveSection = cfgSection{
-			name:    fmt.Sprintf(`chardev "%s"`, opts.name),
+			name:    fmt.Sprintf(`chardev "%s"`, nameWithPrefix),
 			comment: opts.comment,
 			entries: []cfgEntry{
 				{key: "backend", value: "socket"},
@@ -690,7 +691,7 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 
 		extraDeviceEntries = []cfgEntry{
 			{key: "tag", value: opts.mountTag},
-			{key: "chardev", value: opts.name},
+			{key: "chardev", value: nameWithPrefix},
 		}
 	} else {
 		return []cfgSection{}

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -739,16 +739,18 @@ type qemuDriveDirOpts struct {
 
 func qemuDriveDir(opts *qemuDriveDirOpts) []cfgSection {
 	return qemuHostDrive(&qemuHostDriveOpts{
-		dev: opts.dev,
-		// Devices use "lxd_" prefix indicating that this is a user named device.
-		name:     fmt.Sprintf("lxd_%s", opts.devName),
-		comment:  fmt.Sprintf("%s drive (%s)", opts.devName, opts.protocol),
-		mountTag: opts.mountTag,
-		protocol: opts.protocol,
-		fsdriver: "proxy",
-		readonly: opts.readonly,
-		path:     opts.path,
-		sockFd:   fmt.Sprintf("%d", opts.proxyFD),
+		dev:  opts.dev,
+		name: opts.devName,
+		// Devices use "lxd_" prefix indicating that this is a user named device
+		namePrefix: qemuDeviceNamePrefix,
+		nameSuffix: fmt.Sprintf("-%s", opts.protocol),
+		comment:    fmt.Sprintf("%s drive (%s)", opts.devName, opts.protocol),
+		mountTag:   opts.mountTag,
+		protocol:   opts.protocol,
+		fsdriver:   "proxy",
+		readonly:   opts.readonly,
+		path:       opts.path,
+		sockFd:     fmt.Sprintf("%d", opts.proxyFD),
 	})
 }
 

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -727,7 +727,7 @@ func qemuDriveConfig(opts *qemuDriveConfigOpts) []cfgSection {
 		dev: opts.dev,
 		// Devices use "qemu_" prefix indicating that this is a internally named device.
 		name:          "qemu_config",
-		nameSuffix:    "-drive",
+		nameSuffix:    fmt.Sprintf("-drive-%s", opts.protocol),
 		comment:       fmt.Sprintf("Config drive (%s)", opts.protocol),
 		mountTag:      "config",
 		protocol:      opts.protocol,


### PR DESCRIPTION
This fixes the duplicate ID problem on qemu when adding a div drive device.
The problem occurs because QEMU trimms down long device IDs to 64 characters internally and that may result in other references to that device mismatching the device ID or even duplicate IDs if a dir drive device ID is big enough that the suffix that differentiates the tags of the 9p entry and the virtiofs entry are removed in the trimming process.
As an example, `dev-lxd_{long_device_name}-virtio-fs` and `dev-lxd_{long_device_name}-9p` would be used in separate `qem.conf` entries for the same device named `{long_device_name}`. This can generate duplicate IDs when both those ids get trimmed down to `dev-lxd_{trimmed_long_device_name}`, losing the protocol suffixes.
This PR proposes hashing the device name when the device name is big enough that the QEMU ID has to be trimmed (but not in any other case). This results is device IDs like `dev-lxd_{device_name_hash}-virtio-fs`