### PR TITLE
Support local unix socket in lxd-migrate - from Incus

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -155,8 +155,9 @@ func ConnectLXDUnix(path string, args *ConnectionArgs) (InstanceServer, error) {
 // ConnectLXDUnixWithContext lets you connect to a remote LXD daemon over a local unix socket with context.Context.
 //
 // If the path argument is empty, then $LXD_SOCKET will be used, if
-// unset $LXD_DIR/unix.socket will be used and if that one isn't set
-// either, then the path will default to /var/lib/lxd/unix.socket.
+// unset $LXD_DIR/unix.socket will be used, if that one isn't set
+// either, then the path will default to /var/snap/lxd/common/lxd/unix.socket
+// if the file exists and is writable or /var/lib/lxd/unix.socket otherwise.
 func ConnectLXDUnixWithContext(ctx context.Context, path string, args *ConnectionArgs) (InstanceServer, error) {
 	logger.Debug("Connecting to a local LXD over a Unix socket")
 
@@ -185,16 +186,19 @@ func ConnectLXDUnixWithContext(ctx context.Context, path string, args *Connectio
 		eventListeners:     make(map[string][]*EventListener),
 	}
 
-	// Determine the socket path
+	// Determine the socket path.
 	if path == "" {
 		path = os.Getenv("LXD_SOCKET")
 		if path == "" {
 			lxdDir := os.Getenv("LXD_DIR")
-			if lxdDir == "" {
-				lxdDir = "/var/lib/lxd"
+			if lxdDir != "" {
+				path = filepath.Join(lxdDir, "unix.socket")
+			} else {
+				path = "/var/snap/lxd/common/lxd/unix.socket"
+				if !shared.PathIsWritable(path) {
+					path = "/var/lib/lxd/unix.socket"
+				}
 			}
-
-			path = filepath.Join(lxdDir, "unix.socket")
 		}
 	}
 

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -111,6 +111,19 @@ func (c *cmdMigrateData) render() string {
 }
 
 func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
+	// Detect local server.
+	local, err := c.connectLocal()
+	if err == nil {
+		useLocal, err := c.global.asker.AskBool("The local LXD server is the target [default=yes]: ", "yes")
+		if err != nil {
+			return nil, "", err
+		}
+
+		if useLocal {
+			return local, "", nil
+		}
+	}
+
 	// Server address
 	serverURL, err := c.global.asker.AskString("Please provide LXD server URL: ", "", nil)
 	if err != nil {

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -123,7 +123,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 	}
 
 	args := lxd.ConnectionArgs{
-		UserAgent:          fmt.Sprintf("LXC-MIGRATE %s", version.Version),
+		UserAgent:          fmt.Sprintf("LXD-MIGRATE %s", version.Version),
 		InsecureSkipVerify: true,
 	}
 

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -190,7 +190,7 @@ func (c *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 	}
 
 	// Attempt to connect using the system CA
-	args.UserAgent = fmt.Sprintf("LXC-MIGRATE %s", version.Version)
+	args.UserAgent = fmt.Sprintf("LXD-MIGRATE %s", version.Version)
 	instanceServer, err := lxd.ConnectLXD(url, &args)
 
 	var certificate *x509.Certificate

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -142,6 +142,13 @@ func transferRootfs(ctx context.Context, dst lxd.InstanceServer, op lxd.Operatio
 	return nil
 }
 
+func (c *cmdMigrate) connectLocal() (lxd.InstanceServer, error) {
+	args := lxd.ConnectionArgs{}
+	args.UserAgent = fmt.Sprintf("LXD-MIGRATE %s", version.Version)
+
+	return lxd.ConnectLXDUnix("", &args)
+}
+
 func (c *cmdMigrate) connectTarget(url string, certPath string, keyPath string, authType string, token string) (lxd.InstanceServer, string, error) {
 	args := lxd.ConnectionArgs{
 		AuthType: authType,

--- a/shared/util_unix.go
+++ b/shared/util_unix.go
@@ -5,6 +5,8 @@ package shared
 import (
 	"os"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
@@ -12,4 +14,8 @@ func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
 	uid := int(fInfo.Sys().(*syscall.Stat_t).Uid)
 	gid := int(fInfo.Sys().(*syscall.Stat_t).Gid)
 	return mode, uid, gid
+}
+
+func PathIsWritable(path string) bool {
+	return unix.Access(path, unix.W_OK) == nil
 }

--- a/shared/util_unix.go
+++ b/shared/util_unix.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// GetOwnerMode retrieves the file mode, user ID, and group ID for the given file.
 func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
 	mode := fInfo.Mode()
 	uid := int(fInfo.Sys().(*syscall.Stat_t).Uid)
@@ -16,6 +17,7 @@ func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
 	return mode, uid, gid
 }
 
+// PathIsWritable returns true if the given path is writable and false otherwise.
 func PathIsWritable(path string) bool {
 	return unix.Access(path, unix.W_OK) == nil
 }

--- a/shared/util_windows.go
+++ b/shared/util_windows.go
@@ -9,3 +9,7 @@ import (
 func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
 	return fInfo.Mode(), -1, -1
 }
+
+func PathIsWritable(path string) bool {
+	return true
+}

--- a/shared/util_windows.go
+++ b/shared/util_windows.go
@@ -6,10 +6,13 @@ import (
 	"os"
 )
 
+// GetOwnerMode retrieves the file mode for the given file. User ID and group ID are always
+// returnd as -1 on Windows OS.
 func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
 	return fInfo.Mode(), -1, -1
 }
 
+// PathIsWritable returns true for any given path on Windows OS.
 func PathIsWritable(path string) bool {
 	return true
 }


### PR DESCRIPTION
If tool `lxd-migrate` is capable of connection to a local LXD unix socket, first offer the user option to use the socket.

In addition, go client function for connecting to a LXD unix socket is expanded to check for snapped LXD unix socket.