### PR TITLE
Device: Support long device names for host path passthrough to VMs

### DIFF
--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -28,6 +28,7 @@ type eventsServe struct {
 	d   *Daemon
 }
 
+// Render starts event socket.
 func (r *eventsServe) Render(w http.ResponseWriter) error {
 	return eventsSocket(r.d, r.req, w)
 }

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/canonical/lxd/lxd/events"
+	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -115,9 +116,10 @@ func eventsProcess(event api.Event) {
 	}
 
 	type deviceEvent struct {
-		Action string            `json:"action"`
-		Config map[string]string `json:"config"`
-		Name   string            `json:"name"`
+		Action string                    `json:"action"`
+		Config map[string]string         `json:"config"`
+		Name   string                    `json:"name"`
+		Mount  instancetype.VMAgentMount `json:"mount"`
 	}
 
 	e := deviceEvent{}
@@ -143,6 +145,9 @@ func eventsProcess(event api.Event) {
 
 	// Attempt to perform the mount.
 	mntSource := fmt.Sprintf("lxd_%s", e.Name)
+	if e.Mount.Source != "" {
+		mntSource = e.Mount.Source
+	}
 
 	_ = os.MkdirAll(e.Config["path"], 0755)
 	_, err = shared.RunCommand("mount", "-t", "virtiofs", mntSource, e.Config["path"])

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -850,15 +850,15 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 
 // vmVirtfsProxyHelperPaths returns the path for PID file to use with virtfs-proxy-helper process.
 func (d *disk) vmVirtfsProxyHelperPaths() string {
-	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
+	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", filesystem.PathNameEncode(d.name)))
 
 	return pidPath
 }
 
 // vmVirtiofsdPaths returns the path for the socket and PID file to use with virtiofsd process.
 func (d *disk) vmVirtiofsdPaths() (sockPath string, pidPath string) {
-	sockPath = filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("virtio-fs.%s.sock", d.name))
-	pidPath = filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("virtio-fs.%s.pid", d.name))
+	sockPath = filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("virtio-fs.%s.sock", filesystem.PathNameEncode(d.name)))
+	pidPath = filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("virtio-fs.%s.pid", filesystem.PathNameEncode(d.name)))
 
 	return sockPath, pidPath
 }
@@ -1114,7 +1114,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				// virtfs-proxy-helper 9p share. The 9p share will only be used as a fallback.
 				err = func() error {
 					sockPath, pidPath := d.vmVirtiofsdPaths()
-					logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", d.name))
+					logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", filesystem.PathNameEncode(d.name)))
 					_ = os.Remove(logPath) // Remove old log if needed.
 
 					revertFunc, unixListener, err := DiskVMVirtiofsdStart(d.state.OS.ExecPath, d.inst, sockPath, pidPath, logPath, mount.DevPath, rawIDMaps)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4384,7 +4384,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	isRunning := d.IsRunning()
 
 	// Use the device interface to apply update changes.
-	err = d.devicesUpdate(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
+	devlxdEvents, err := d.devicesUpdate(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
 	if err != nil {
 		return err
 	}
@@ -4819,41 +4819,9 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 			}
 		}
 
-		// Device changes
-		for k, m := range removeDevices {
-			msg := map[string]any{
-				"action": "removed",
-				"name":   k,
-				"config": m,
-			}
-
-			err = d.devlxdEventSend("device", msg)
-			if err != nil {
-				return err
-			}
-		}
-
-		for k, m := range updateDevices {
-			msg := map[string]any{
-				"action": "updated",
-				"name":   k,
-				"config": m,
-			}
-
-			err = d.devlxdEventSend("device", msg)
-			if err != nil {
-				return err
-			}
-		}
-
-		for k, m := range addDevices {
-			msg := map[string]any{
-				"action": "added",
-				"name":   k,
-				"config": m,
-			}
-
-			err = d.devlxdEventSend("device", msg)
+		// Device events.
+		for _, event := range devlxdEvents {
+			err = d.devlxdEventSend("device", event)
 			if err != nil {
 				return err
 			}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2351,9 +2351,8 @@ func (d *qemu) deviceDetachBlockDevice(deviceName string) error {
 		return err
 	}
 
-	escapedDeviceName := filesystem.PathNameEncode(deviceName)
-	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
-	blockDevName := d.generateQemuDeviceName(escapedDeviceName)
+	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, filesystem.PathNameEncode(deviceName))
+	blockDevName := d.generateQemuDeviceName(deviceName)
 
 	err = monitor.RemoveFDFromFDSet(blockDevName)
 	if err != nil {
@@ -3954,8 +3953,6 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		directCache = false
 	}
 
-	escapedDeviceName := filesystem.PathNameEncode(driveConf.DevName)
-
 	blockDev := map[string]any{
 		"aio": aioMode,
 		"cache": map[string]any{
@@ -3964,7 +3961,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		},
 		"discard":   "unmap", // Forward as an unmap request. This is the same as `discard=on` in the qemu config file.
 		"driver":    "file",
-		"node-name": d.generateQemuDeviceName(escapedDeviceName),
+		"node-name": d.generateQemuDeviceName(driveConf.DevName),
 		"read-only": false,
 	}
 
@@ -4071,6 +4068,8 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 	if qemuDev == nil {
 		qemuDev = map[string]string{}
 	}
+
+	escapedDeviceName := filesystem.PathNameEncode(driveConf.DevName)
 
 	qemuDev["id"] = fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
 	qemuDevDrive, ok := blockDev["node-name"].(string)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8914,9 +8914,10 @@ func hashIfLonger(name string, maxLength int) string {
 }
 
 // Block node names and device tags may only be up to 31 characters long, so use a hash if longer.
+// Also escapes / to -, and - to --.
 func (d *qemu) generateQemuDeviceName(name string) string {
 	maxNameLength := qemuDeviceNameMaxLength - len(qemuDeviceNamePrefix)
-	name = hashIfLonger(name, maxNameLength)
+	name = hashIfLonger(filesystem.PathNameEncode(name), maxNameLength)
 
 	// Apply the lxd_ prefix.
 	return fmt.Sprintf("%s%s", qemuDeviceNamePrefix, name)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2187,7 +2187,7 @@ func (d *qemu) deviceAttachPath(deviceName string) (mountTag string, err error) 
 	mountTag = d.generateQemuDeviceName(deviceName)
 
 	// Detect virtiofsd path.
-	virtiofsdSockPath := filepath.Join(d.DevicesPath(), fmt.Sprintf("virtio-fs.%s.sock", deviceName))
+	virtiofsdSockPath := filepath.Join(d.DevicesPath(), fmt.Sprintf("virtio-fs.%s.sock", filesystem.PathNameEncode(deviceName)))
 	if !shared.PathExists(virtiofsdSockPath) {
 		return "", fmt.Errorf("Virtiofsd isn't running")
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2180,8 +2180,7 @@ func (d *qemu) deviceStart(dev device.Device, instanceRunning bool) (*deviceConf
 }
 
 func (d *qemu) deviceAttachPath(deviceName string) (mountTag string, err error) {
-	escapedDeviceName := filesystem.PathNameEncode(deviceName)
-	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
+	deviceID := qemuHostDriveDeviceID(deviceName, "virtio-fs")
 	mountTag = d.generateQemuDeviceName(deviceName)
 
 	// Detect virtiofsd path.
@@ -2308,8 +2307,7 @@ func (d *qemu) deviceAttachBlockDevice(mount deviceConfig.MountEntryItem) error 
 }
 
 func (d *qemu) deviceDetachPath(deviceName string) error {
-	escapedDeviceName := filesystem.PathNameEncode(deviceName)
-	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
+	deviceID := qemuHostDriveDeviceID(deviceName, "virtio-fs")
 	mountTag := d.generateQemuDeviceName(deviceName)
 
 	// Check if the agent is running.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2143,12 +2143,14 @@ func (d *qemu) deviceStart(dev device.Device, instanceRunning bool) (*deviceConf
 				}
 			}
 
-			for _, mount := range runConf.Mounts {
+			for i, mount := range runConf.Mounts {
 				if mount.FSType == "9p" {
-					err = d.deviceAttachPath(dev.Name())
+					mountTag, err := d.deviceAttachPath(dev.Name())
 					if err != nil {
 						return nil, err
 					}
+
+					runConf.Mounts[i].Opts = append(runConf.Mounts[i].Opts, fmt.Sprintf("mountTag=%s", mountTag))
 				} else {
 					err = d.deviceAttachBlockDevice(mount)
 					if err != nil {
@@ -2177,15 +2179,15 @@ func (d *qemu) deviceStart(dev device.Device, instanceRunning bool) (*deviceConf
 	return runConf, nil
 }
 
-func (d *qemu) deviceAttachPath(deviceName string) error {
+func (d *qemu) deviceAttachPath(deviceName string) (mountTag string, err error) {
 	escapedDeviceName := filesystem.PathNameEncode(deviceName)
 	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
-	mountTag := d.generateQemuDeviceName(deviceName)
+	mountTag = d.generateQemuDeviceName(deviceName)
 
 	// Detect virtiofsd path.
 	virtiofsdSockPath := filepath.Join(d.DevicesPath(), fmt.Sprintf("virtio-fs.%s.sock", deviceName))
 	if !shared.PathExists(virtiofsdSockPath) {
-		return fmt.Errorf("Virtiofsd isn't running")
+		return "", fmt.Errorf("Virtiofsd isn't running")
 	}
 
 	reverter := revert.New()
@@ -2194,37 +2196,37 @@ func (d *qemu) deviceAttachPath(deviceName string) error {
 	// Check if the agent is running.
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
 	if err != nil {
-		return fmt.Errorf("Failed to connect to QMP monitor: %w", err)
+		return "", fmt.Errorf("Failed to connect to QMP monitor: %w", err)
 	}
 
 	// Open a file descriptor to the socket file through O_PATH to avoid acessing the file descriptor to the sockfs inode.
 	socketFile, err := os.OpenFile(virtiofsdSockPath, unix.O_PATH|unix.O_CLOEXEC, 0)
 	if err != nil {
-		return fmt.Errorf("Failed to open device socket file %q: %w", virtiofsdSockPath, err)
+		return "", fmt.Errorf("Failed to open device socket file %q: %w", virtiofsdSockPath, err)
 	}
 
 	shortPath := fmt.Sprintf("/dev/fd/%d", socketFile.Fd())
 
 	addr, err := net.ResolveUnixAddr("unix", shortPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	virtiofsSock, err := net.DialUnix("unix", nil, addr)
 	if err != nil {
-		return fmt.Errorf("Error connecting to virtiofs socket %q: %w", virtiofsdSockPath, err)
+		return "", fmt.Errorf("Error connecting to virtiofs socket %q: %w", virtiofsdSockPath, err)
 	}
 
 	defer func() { _ = virtiofsSock.Close() }() // Close file after device has been added.
 
 	virtiofsFile, err := virtiofsSock.File()
 	if err != nil {
-		return fmt.Errorf("Error opening virtiofs socket %q: %w", virtiofsdSockPath, err)
+		return "", fmt.Errorf("Error opening virtiofs socket %q: %w", virtiofsdSockPath, err)
 	}
 
 	err = monitor.SendFile(virtiofsdSockPath, virtiofsFile)
 	if err != nil {
-		return fmt.Errorf("Failed to send virtiofs file descriptor: %w", err)
+		return "", fmt.Errorf("Failed to send virtiofs file descriptor: %w", err)
 	}
 
 	reverter.Add(func() { _ = monitor.CloseFile(virtiofsdSockPath) })
@@ -2245,7 +2247,7 @@ func (d *qemu) deviceAttachPath(deviceName string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to add the character device: %w", err)
+		return "", fmt.Errorf("Failed to add the character device: %w", err)
 	}
 
 	reverter.Add(func() { _ = monitor.RemoveCharDevice(mountTag) })
@@ -2278,11 +2280,11 @@ func (d *qemu) deviceAttachPath(deviceName string) error {
 
 	err = monitor.AddDevice(qemuDev)
 	if err != nil {
-		return fmt.Errorf("Failed to add the virtiofs device: %w", err)
+		return "", fmt.Errorf("Failed to add the virtiofs device: %w", err)
 	}
 
 	reverter.Success()
-	return nil
+	return mountTag, nil
 }
 
 func (d *qemu) deviceAttachBlockDevice(mount deviceConfig.MountEntryItem) error {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -108,6 +108,9 @@ const qemuPCIDeviceIDStart = 4
 // qemuDeviceIDPrefix used as part of the name given QEMU devices generated from user added devices.
 const qemuDeviceIDPrefix = "dev-lxd_"
 
+// qemuDeviceNameMaxLength used to indicate the maximum length of a qemu device ID.
+const qemuDeviceIDMaxLength = 64
+
 // qemuDeviceNamePrefix used as part of the name given QEMU blockdevs, netdevs and device tags generated from user added devices.
 const qemuDeviceNamePrefix = "lxd_"
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8890,19 +8890,31 @@ func (d *qemu) deviceDetachUSB(usbDev deviceConfig.USBDeviceItem) error {
 	return nil
 }
 
+// hashIfLonger returns a full or partial hash of a name as to fit it within a size limit.
+func hashIfLonger(name string, maxLength int) string {
+	if len(name) <= maxLength {
+		return name
+	}
+
+	// If the name is too long, hash it as SHA-256 (32 bytes).
+	// Then encode the SHA-256 binary hash as Base64 Raw URL format and trim down if needed.
+	hash := sha256.New()
+	hash.Write([]byte(name))
+	binaryHash := hash.Sum(nil)
+
+	// Raw URL avoids the use of "+" character and the padding "=" character which QEMU doesn't allow.
+	hashedName := base64.RawURLEncoding.EncodeToString(binaryHash)
+	if len(hashedName) > maxLength {
+		hashedName = hashedName[0:maxLength]
+	}
+
+	return hashedName
+}
+
 // Block node names and device tags may only be up to 31 characters long, so use a hash if longer.
 func (d *qemu) generateQemuDeviceName(name string) string {
 	maxNameLength := qemuDeviceNameMaxLength - len(qemuDeviceNamePrefix)
-	if len(name) > maxNameLength {
-		// If the name is too long, hash it as SHA-256 (32 bytes).
-		// Then encode the SHA-256 binary hash as Base64 Raw URL format and trim down to 27 chars.
-		// Raw URL avoids the use of "+" character and the padding "=" character which QEMU doesn't allow.
-		hash := sha256.New()
-		hash.Write([]byte(name))
-		binaryHash := hash.Sum(nil)
-		name = base64.RawURLEncoding.EncodeToString(binaryHash)
-		name = name[0:maxNameLength]
-	}
+	name = hashIfLonger(name, maxNameLength)
 
 	// Apply the lxd_ prefix.
 	return fmt.Sprintf("%s%s", qemuDeviceNamePrefix, name)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5604,7 +5604,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	isRunning := d.IsRunning()
 
 	// Use the device interface to apply update changes.
-	err = d.devicesUpdate(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
+	devlxdEvents, err := d.devicesUpdate(d, removeDevices, addDevices, updateDevices, oldExpandedDevices, isRunning, userRequested)
 	if err != nil {
 		return err
 	}
@@ -5838,41 +5838,9 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 			}
 		}
 
-		// Device changes
-		for k, m := range removeDevices {
-			msg := map[string]any{
-				"action": "removed",
-				"name":   k,
-				"config": m,
-			}
-
-			err = d.devlxdEventSend("device", msg)
-			if err != nil {
-				return err
-			}
-		}
-
-		for k, m := range updateDevices {
-			msg := map[string]any{
-				"action": "updated",
-				"name":   k,
-				"config": m,
-			}
-
-			err = d.devlxdEventSend("device", msg)
-			if err != nil {
-				return err
-			}
-		}
-
-		for k, m := range addDevices {
-			msg := map[string]any{
-				"action": "added",
-				"name":   k,
-				"config": m,
-			}
-
-			err = d.devlxdEventSend("device", msg)
+		// Device events.
+		for _, event := range devlxdEvents {
+			err = d.devlxdEventSend("device", event)
 			if err != nil {
 				return err
 			}

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -754,7 +754,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				protocol: "9p",
 			},
 			`# Config drive (9p)
-			[fsdev "qemu_config"]
+			[fsdev "dev-qemu_config-drive-9p"]
 			fsdriver = "local"
 			security_model = "none"
 			readonly = "on"
@@ -765,7 +765,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			bus = "qemu_pcie0"
 			addr = "00.5"
 			mount_tag = "config"
-			fsdev = "qemu_config"`,
+			fsdev = "dev-qemu_config-drive-9p"`,
 		}, {
 			qemuDriveConfigOpts{
 				dev:      qemuDevOpts{"pcie", "qemu_pcie1", "10.2", true},
@@ -773,7 +773,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				protocol: "virtio-fs",
 			},
 			`# Config drive (virtio-fs)
-			[chardev "qemu_config"]
+			[chardev "dev-qemu_config-drive-virtio-fs"]
 			backend = "socket"
 			path = "/dev/virtio-fs"
 
@@ -783,7 +783,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			addr = "10.2"
 			multifunction = "on"
 			tag = "config"
-			chardev = "qemu_config"`,
+			chardev = "dev-qemu_config-drive-virtio-fs"`,
 		}, {
 			qemuDriveConfigOpts{
 				dev:      qemuDevOpts{"ccw", "devBus", "busAddr", false},
@@ -791,14 +791,14 @@ func TestQemuConfigTemplates(t *testing.T) {
 				protocol: "virtio-fs",
 			},
 			`# Config drive (virtio-fs)
-			[chardev "qemu_config"]
+			[chardev "dev-qemu_config-drive-virtio-fs"]
 			backend = "socket"
 			path = "/var/virtio-fs"
 
 			[device "dev-qemu_config-drive-virtio-fs"]
 			driver = "vhost-user-fs-ccw"
 			tag = "config"
-			chardev = "qemu_config"`,
+			chardev = "dev-qemu_config-drive-virtio-fs"`,
 		}, {
 			qemuDriveConfigOpts{
 				dev:      qemuDevOpts{"ccw", "devBus", "busAddr", true},
@@ -806,7 +806,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				protocol: "9p",
 			},
 			`# Config drive (9p)
-			[fsdev "qemu_config"]
+			[fsdev "dev-qemu_config-drive-9p"]
 			fsdriver = "local"
 			security_model = "none"
 			readonly = "on"
@@ -816,7 +816,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			driver = "virtio-9p-ccw"
 			multifunction = "on"
 			mount_tag = "config"
-			fsdev = "qemu_config"`,
+			fsdev = "dev-qemu_config-drive-9p"`,
 		}, {
 			qemuDriveConfigOpts{
 				dev:      qemuDevOpts{"ccw", "devBus", "busAddr", true},
@@ -844,7 +844,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				proxyFD:  5,
 			},
 			`# stub drive (9p)
-			[fsdev "lxd_stub"]
+			[fsdev "dev-lxd_stub-9p"]
 			fsdriver = "proxy"
 			sock_fd = "5"
 			readonly = "off"
@@ -855,7 +855,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			addr = "00.5"
 			multifunction = "on"
 			mount_tag = "mtag"
-			fsdev = "lxd_stub"`,
+			fsdev = "dev-lxd_stub-9p"`,
 		}, {
 			qemuDriveDirOpts{
 				dev:      qemuDevOpts{"pcie", "qemu_pcie1", "10.2", false},
@@ -865,7 +865,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				protocol: "virtio-fs",
 			},
 			`# vfs drive (virtio-fs)
-			[chardev "lxd_vfs"]
+			[chardev "dev-lxd_vfs-virtio-fs"]
 			backend = "socket"
 			path = "/dev/virtio"
 
@@ -874,7 +874,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			bus = "qemu_pcie1"
 			addr = "10.2"
 			tag = "vtag"
-			chardev = "lxd_vfs"`,
+			chardev = "dev-lxd_vfs-virtio-fs"`,
 		}, {
 			qemuDriveDirOpts{
 				dev:      qemuDevOpts{"ccw", "devBus", "busAddr", true},
@@ -884,7 +884,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				protocol: "virtio-fs",
 			},
 			`# vfs drive (virtio-fs)
-			[chardev "lxd_vfs"]
+			[chardev "dev-lxd_vfs-virtio-fs"]
 			backend = "socket"
 			path = "/dev/vio"
 
@@ -892,7 +892,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			driver = "vhost-user-fs-ccw"
 			multifunction = "on"
 			tag = "vtag"
-			chardev = "lxd_vfs"`,
+			chardev = "dev-lxd_vfs-virtio-fs"`,
 		}, {
 			qemuDriveDirOpts{
 				dev:      qemuDevOpts{"ccw", "devBus", "busAddr", false},
@@ -903,7 +903,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				proxyFD:  3,
 			},
 			`# stub2 drive (9p)
-			[fsdev "lxd_stub2"]
+			[fsdev "dev-lxd_stub2-9p"]
 			fsdriver = "proxy"
 			sock_fd = "3"
 			readonly = "on"
@@ -911,7 +911,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[device "dev-lxd_stub2-9p"]
 			driver = "virtio-9p-ccw"
 			mount_tag = "mtag2"
-			fsdev = "lxd_stub2"`,
+			fsdev = "dev-lxd_stub2-9p"`,
 		}, {
 			qemuDriveDirOpts{
 				dev:      qemuDevOpts{"ccw", "devBus", "busAddr", true},

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -11,7 +11,9 @@ import (
 
 // qemuHostDriveDeviceID returns the device ID to use for a host drive share.
 func qemuHostDriveDeviceID(deviceName string, protocol string) string {
-	return fmt.Sprintf("%s%s-%s", qemuDeviceIDPrefix, filesystem.PathNameEncode(deviceName), protocol)
+	suffix := "-" + protocol
+	maxNameLength := qemuDeviceIDMaxLength - (len(qemuDeviceIDPrefix) + len(suffix))
+	return fmt.Sprintf("%s%s%s", qemuDeviceIDPrefix, hashIfLonger(filesystem.PathNameEncode(deviceName), maxNameLength), suffix)
 }
 
 type cfgEntry struct {

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -664,7 +664,7 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 		}
 
 		driveSection = cfgSection{
-			name:    fmt.Sprintf(`fsdev "%s"`, opts.name),
+			name:    fmt.Sprintf(`fsdev "%s"`, opts.id),
 			comment: opts.comment,
 			entries: []cfgEntry{
 				{key: "fsdriver", value: opts.fsdriver},
@@ -680,11 +680,11 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 
 		extraDeviceEntries = []cfgEntry{
 			{key: "mount_tag", value: opts.mountTag},
-			{key: "fsdev", value: opts.name},
+			{key: "fsdev", value: opts.id},
 		}
 	} else if opts.protocol == "virtio-fs" {
 		driveSection = cfgSection{
-			name:    fmt.Sprintf(`chardev "%s"`, opts.name),
+			name:    fmt.Sprintf(`chardev "%s"`, opts.id),
 			comment: opts.comment,
 			entries: []cfgEntry{
 				{key: "backend", value: "socket"},
@@ -697,7 +697,7 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 
 		extraDeviceEntries = []cfgEntry{
 			{key: "tag", value: opts.mountTag},
-			{key: "chardev", value: opts.name},
+			{key: "chardev", value: opts.id},
 		}
 	} else {
 		return []cfgSection{}


### PR DESCRIPTION
- Aligns naming differences between host drive passthrough at boot time and hotplug - this allows a virtiofs share added at boot time to be hot unplugged later.
- Adds escaping and hashing to host drive device names to allow LXD disk device names to be long and contain `/` characters.
- Updates devlxd events and lxd-agent event handler to support passing `mount_tag` info so that lxd-agent doesn't assume the mount tag is the device name.

Unfortunately due to the historic setup of these devices it has been impossible to maintain complete backward compatibility with the mount tag formats. For short and simple names they remain the same, but for longer ones or ones with `/` the mount tag has changed necessarily to support that functionality.

Closes #13596