### PR TITLE
shared/cert: Set Not Before in self-signed cert to now-1minute

### DIFF
--- a/shared/cert.go
+++ b/shared/cert.go
@@ -408,6 +408,7 @@ func GenerateMemCert(client bool, addHosts bool) ([]byte, []byte, error) {
 	return cert, key, nil
 }
 
+// ReadCert reads a X.509 certificate from the filesystem, do PEM decoding and return its parsed content.
 func ReadCert(fpath string) (*x509.Certificate, error) {
 	cf, err := os.ReadFile(fpath)
 	if err != nil {
@@ -422,10 +423,12 @@ func ReadCert(fpath string) (*x509.Certificate, error) {
 	return x509.ParseCertificate(certBlock.Bytes)
 }
 
+// CertFingerprint returns the SHA256 fingerprint of a X.509 certificate.
 func CertFingerprint(cert *x509.Certificate) string {
 	return fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
 }
 
+// CertFingerprintStr returns the certificate fingerprint of a X.509 certificate provided as string.
 func CertFingerprintStr(c string) (string, error) {
 	pemCertificate, _ := pem.Decode([]byte(c))
 	if pemCertificate == nil {
@@ -440,6 +443,7 @@ func CertFingerprintStr(c string) (string, error) {
 	return CertFingerprint(cert), nil
 }
 
+// GetRemoteCertificate returns the unverified peer certificate found at a remote address.
 func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, error) {
 	// Setup a permissive TLS config
 	tlsConfig, err := GetTLSConfig(nil)

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -328,7 +328,7 @@ func GenerateMemCert(client bool, addHosts bool) ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("Failed to generate key: %w", err)
 	}
 
-	validFrom := time.Now()
+	validFrom := time.Now().Add(-time.Minute)
 	validTo := validFrom.Add(10 * 365 * 24 * time.Hour)
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)


### PR DESCRIPTION
In the following made up conditions:

* a remote LXD server `s` has its time set to `13:42:00`
* a client `foo` has its time set to `13:42:15` (15s in advance of `s`)
* a remote add token is created for `foo`
* `foo` uses the token and since it's brand new, it creates its self-signed cert and save its current time in the Not Before field: 13:42:15
* `s` inspect `foo`'s cert and refuses it because it is in future

In the above situation, the fact that a token was used make it easier to trip on a time delta between the client and server because the cert is create on the spot before being sent to the server.

Having the client set a Not Before time slightly in the past should make it easier to interact with remote servers that are slightly "in the past".

Fixes #13388.