### PR TITLE
Storage: Use validated image fingerprint from DB record in EnsureImage

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3588,14 +3588,14 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 	}
 
 	// Try and load any existing volume config on this storage pool so we can compare filesystems if needed.
-	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
+	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage)
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
 
 	// Create the new image volume. No config for an image volume so set to nil.
 	// Pool config values will be read by the underlying driver if needed.
-	imgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, nil)
+	imgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, nil)
 
 	// If an existing DB row was found, check if filesystem is the same as the current pool's filesystem.
 	// If not we need to delete the existing cached image volume and re-create using new filesystem.
@@ -3610,7 +3610,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 		}
 
 		// Add existing image volume's config to imgVol.
-		imgVol = b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, imgDBVol.Config)
+		imgVol = b.GetVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, imgDBVol.Config)
 
 		// Check if the volume's block backed mode differs from the pool's current setting for new volumes.
 		blockModeChanged := tmpImgVol.IsBlockBacked() != imgVol.IsBlockBacked()
@@ -3628,7 +3628,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 				l.Debug("Block volume filesystem of pool has changed since cached image volume created, regenerating image volume")
 			}
 
-			err = b.DeleteImage(fingerprint, op)
+			err = b.DeleteImage(image.Fingerprint, op)
 			if err != nil {
 				return err
 			}
@@ -3640,7 +3640,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 
 	if imgDBVol == nil {
 		// Instantiate a new volume including its own UUID.
-		imgVol = b.GetNewVolume(drivers.VolumeTypeImage, contentType, fingerprint, nil)
+		imgVol = b.GetNewVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, nil)
 	}
 
 	// Check if we already have a suitable volume on storage device.
@@ -3671,14 +3671,14 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 				// If the driver cannot resize the existing image volume to the new policy size
 				// then delete the image volume and try to recreate using the new policy settings.
 				l.Debug("Volume size of pool has changed since cached image volume created and cached volume cannot be resized, regenerating image volume")
-				err = b.DeleteImage(fingerprint, op)
+				err = b.DeleteImage(image.Fingerprint, op)
 				if err != nil {
 					return err
 				}
 
 				// Reset img volume variables as we just deleted the old one.
 				imgDBVol = nil
-				imgVol = b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, nil)
+				imgVol = b.GetVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, nil)
 			} else if err != nil {
 				return err
 			} else {
@@ -3698,20 +3698,20 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 	}
 
 	volFiller := drivers.VolumeFiller{
-		Fingerprint: fingerprint,
-		Fill:        b.imageFiller(fingerprint, op),
+		Fingerprint: image.Fingerprint,
+		Fill:        b.imageFiller(image.Fingerprint, op),
 	}
 
 	revert := revert.New()
 	defer revert.Fail()
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, api.ProjectDefaultName, fingerprint, "", drivers.VolumeTypeImage, false, imgVol.Config(), time.Now().UTC(), time.Time{}, contentType, false, false)
+	err = VolumeDBCreate(b, api.ProjectDefaultName, image.Fingerprint, "", drivers.VolumeTypeImage, false, imgVol.Config(), time.Now().UTC(), time.Time{}, contentType, false, false)
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage) })
+	revert.Add(func() { _ = VolumeDBDelete(b, api.ProjectDefaultName, image.Fingerprint, drivers.VolumeTypeImage) })
 
 	err = b.driver.CreateVolume(imgVol, &volFiller, op)
 	if err != nil {
@@ -3725,7 +3725,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 		imgVol.Config()["volatile.rootfs.size"] = fmt.Sprintf("%d", volFiller.Size)
 
 		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			return tx.UpdateStoragePoolVolume(ctx, api.ProjectDefaultName, fingerprint, cluster.StoragePoolVolumeTypeImage, b.id, "", imgVol.Config())
+			return tx.UpdateStoragePoolVolume(ctx, api.ProjectDefaultName, image.Fingerprint, cluster.StoragePoolVolumeTypeImage, b.id, "", imgVol.Config())
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
This should fix the alert from https://github.com/canonical/lxd/security/code-scanning/289

However I don't believe this was a genuine security issue, as although the raw input from the request was ending up at the filesystem path, it would not have been able to proceed unless the raw input matched the fingerprint of an existing image because of an earlier check for an existing image record.

However it is better practice to use the fingerprint from the DB record once it has been loaded.