### PR TITLE
Populate source image type when fetching an image

### DIFF
--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -409,7 +409,6 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 	}
 
 	// Prepare the body
-	var ioErr error
 	var body io.Reader
 	var contentType string
 	if args.RootfsFile == nil {
@@ -546,10 +545,6 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 	}
 
 	defer func() { _ = resp.Body.Close() }()
-
-	if ioErr != nil {
-		return nil, err
-	}
 
 	// Handle errors
 	response, _, err := lxdParseResponse(resp)

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -87,7 +87,12 @@ func (r *ProtocolLXD) GetImageSecret(fingerprint string) (string, error) {
 
 	opAPI := op.Get()
 
-	return opAPI.Metadata["secret"].(string), nil
+	secret, ok := opAPI.Metadata["secret"].(string)
+	if !ok {
+		return "", fmt.Errorf("Failed to extract image secret from operation metadata")
+	}
+
+	return secret, nil
 }
 
 // GetPrivateImage is similar to GetImage but allows passing a secret download token.
@@ -602,7 +607,11 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 			}
 
 			// Extract the fingerprint
-			fingerprint := op.Metadata["fingerprint"].(string)
+			fingerprint, ok := op.Metadata["fingerprint"].(string)
+			if !ok {
+				rop.err = remoteOperationError("Failed to extract fingerprint from operation metadata", errors)
+				return
+			}
 
 			// Add the aliases
 			for _, entry := range req.Aliases {

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -145,6 +145,7 @@ func (c *ClusterTx) imageFill(ctx context.Context, id int, image *api.Image, cre
 	_, source, err := c.GetImageSource(ctx, id)
 	if err == nil {
 		image.UpdateSource = &source
+		image.UpdateSource.ImageType = image.Type
 	}
 
 	return nil


### PR DESCRIPTION
Instead of introducing a breaking change by separating the image type which is only used when new image needs to be downloaded, populate the source image type when fetching an image.

Fixes #13586