### PR TITLE
Workaround microceph rgw default enable (stable-5.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -356,7 +356,7 @@ jobs:
           sudo microceph disk add --wipe "${ephemeral_disk}"
           sudo rm -rf /etc/ceph
           sudo ln -s /var/snap/microceph/current/conf/ /etc/ceph
-          sudo microceph enable rgw
+          sudo microceph enable rgw || true # workaround to ignore already enabled rgw
           sudo microceph.ceph osd pool create cephfs_meta 32
           sudo microceph.ceph osd pool create cephfs_data 32
           sudo microceph.ceph fs new cephfs cephfs_meta cephfs_data


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>
(cherry picked from commit 499912adcce3c4be65ab7cd7946d4414070e1497)