### PR TITLE
Storage: Fix regression in Ceph RBD migration

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -698,7 +698,7 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 		return nil
 	}
 
-	// Handle simple rsync and block_and_rsync through generic.
+	// Handle simple RSYNC and BLOCK_AND_RSYNC through the generic function.
 	if shared.ValueInSlice(volTargetArgs.MigrationType.FSType, []migration.MigrationFSType{migration.MigrationFSType_RSYNC, migration.MigrationFSType_BLOCK_AND_RSYNC}) || volTargetArgs.MigrationType.FSType == migration.MigrationFSType_RBD_AND_RSYNC && vol.contentType == ContentTypeFS {
 		_, err := genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
 		if err != nil {
@@ -713,8 +713,9 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 	revert := revert.New()
 	defer revert.Fail()
 
-	// Migrate (receive) the VMs filesystem volume too.
-	// This will fall back to the generic way of refreshing.
+	// Migrate (receive) the VM's filesystem volume too.
+	// In case of the RBD_AND_RSYNC migration type this falls back to the generic function.
+	// In case of the RBD migration type this is using the Ceph RBD block export/import functions.
 	if vol.IsVMBlock() {
 		// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
 		fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
@@ -724,7 +725,7 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 
 		fsVolCopy := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), fsVolSnapshots...)
 
-		// Migrate the VMs filesystem volume and record the cleanup hooks.
+		// Migrate the VM's filesystem volume and record the cleanup hooks.
 		// This allows cleaning up any changes made during the generic migration.
 		cleanup, err := d.createVolumeFromMigration(fsVolCopy, conn, volTargetArgs, preFiller, op)
 		if err != nil {


### PR DESCRIPTION
A PR from yesterday (https://github.com/canonical/lxd/pull/13612) has broken Ceph RBD pool backed VM migrations that use the `RBD_AND_RSYNC` migration type.
This migration type is special as the VM's block vol is transferred using the Ceph RBD export/import diff methods whilst the VM's filesystem vol is transferred via the generic methods.

In https://github.com/canonical/lxd/pull/13612 we have effectively removed the option to use the generic method as part of `RBD_AND_RSYNC` when transferring a VM's filesystem vol.

If the content type is `filesystem` and the migration type is `RBD_AND_RSYNC` the lower level `createVolumeFromMigration()` still has to trigger the generic function to receive the VM's filesystem vol.