### PR TITLE
storage: Allow `lost+found` subdirectory when storage pool source is root of the filesystem

### DIFF
--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -9,6 +10,7 @@ import (
 
 	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -87,7 +89,22 @@ func (d *dir) Create() error {
 	}
 
 	if !isEmpty {
-		return fmt.Errorf("Source path %q isn't empty", sourcePath)
+		// If directory is not empty, the "lost+found" subdirectory is acceptable when
+		// the source path is the root of a mounted filesystem.
+		if !filesystem.IsMountPoint(sourcePath) {
+			return fmt.Errorf("Source path %q isn't empty", sourcePath)
+		}
+
+		entries, err := os.ReadDir(sourcePath)
+		if err != nil {
+			return fmt.Errorf("Failed to read directory content of source path %q", sourcePath)
+		}
+
+		for _, e := range entries {
+			if e.Name() != "lost+found" {
+				return fmt.Errorf("Source path %q isn't empty", sourcePath)
+			}
+		}
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -71,13 +71,13 @@ func (d *dir) Create() error {
 	sourcePath := shared.HostPath(d.config["source"])
 
 	if !shared.PathExists(sourcePath) {
-		return fmt.Errorf("Source path '%s' doesn't exist", sourcePath)
+		return fmt.Errorf("Source path %q doesn't exist", sourcePath)
 	}
 
 	// Check that if within LXD_DIR, we're at our expected spot.
 	cleanSource := filepath.Clean(sourcePath)
 	if strings.HasPrefix(cleanSource, shared.VarPath()) && cleanSource != GetPoolMountPath(d.name) {
-		return fmt.Errorf("Source path '%s' is within the LXD directory", cleanSource)
+		return fmt.Errorf("Source path %q is within the LXD directory", cleanSource)
 	}
 
 	// Check that the path is currently empty.
@@ -87,7 +87,7 @@ func (d *dir) Create() error {
 	}
 
 	if !isEmpty {
-		return fmt.Errorf("Source path '%s' isn't empty", sourcePath)
+		return fmt.Errorf("Source path %q isn't empty", sourcePath)
 	}
 
 	return nil

--- a/test/main.sh
+++ b/test/main.sh
@@ -350,6 +350,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_storage_driver_btrfs "btrfs storage driver"
     run_test test_storage_driver_ceph "ceph storage driver"
     run_test test_storage_driver_cephfs "cephfs storage driver"
+    run_test test_storage_driver_dir "dir storage driver"
     run_test test_storage_driver_zfs "zfs storage driver"
     run_test test_storage_buckets "storage buckets"
     run_test test_storage_volume_import "storage volume import"

--- a/test/suites/storage_driver_dir.sh
+++ b/test/suites/storage_driver_dir.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+test_storage_driver_dir() {
+  do_dir_on_empty_fs
+}
+
+do_dir_on_empty_fs() {
+  # shellcheck disable=2039,3043
+  local lxd_backend
+
+  lxd_backend=$(storage_backend "${LXD_DIR}")
+  if [ "${lxd_backend}" != "dir" ]; then
+    return
+  fi
+
+  # Create and mount 32MiB ext4 filesystem.
+  tmp_file=$(mktemp "${TEST_DIR}/disk.XXXXXX")
+  dd if=/dev/zero of="${tmp_file}" bs=1M count=64
+  mkfs.ext4 "${tmp_file}"
+
+  mount_point=$(mktemp -d "${TEST_DIR}/mountpoint.XXXXXX")
+  sudo mount -o loop "${tmp_file}" "${mount_point}"
+
+  if [ ! -d "${mount_point}/lost+found" ]; then
+    echo "Error: Expected ${mount_point}/lost+found subdirectory to exist"
+    return 1
+  fi
+
+  # Create storage pool in the root path of the mounted filesystem where lost+found subdirectory exists.
+  lxc storage create s1 dir source="${mount_point}"
+  lxc storage delete s1
+
+  # Create storage pool in the non-root path of the mounted filesystem where lost+found subdirectory exists.
+  sudo mkdir -p "${mount_point}/dir/lost+found"
+  if lxc storage create s1 dir source="${mount_point}/dir"; then
+    echo "Error: Storage pool creation should have failed: Directory '${mount_point}/dir' is not empty"
+    return 1
+  fi
+
+  # Cleanup.
+  sudo umount "${mount_point}"
+  rm -rf "${mount_point}"
+  rm -f "${tmp_file}"
+}


### PR DESCRIPTION
Allow `lost+found` subdirectory when storage pool's source is a root of the mounted filesystem.

Fixes #13630