### PR TITLE
Revert "test/lint: Disable licence check."

### DIFF
--- a/test/lint/licenses.sh
+++ b/test/lint/licenses.sh
@@ -1,9 +1,5 @@
 #!/bin/sh -eu
 
-# FIXME: Re-enable when https://github.com/canonical/lxd/issues/13048 is resolved.
-# Note: Skipping here because `make static-analysis` calls `run-parts` on all files in this directory.
-return 0
-
 # Check LXD doesn't include non-permissive licenses (except for itself).
 mv COPYING COPYING.tmp
 cp client/COPYING COPYING


### PR DESCRIPTION
This reverts commit f8180dec5cba69ec066e7444a65ae021a3941cbb.

It's possible now that we require Go 1.22+. Fixes #13048