### PR TITLE
lxc: Always allow specifying a password when adding remotes

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -558,7 +558,9 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 		if c.flagAuthType == api.AuthenticationMethodTLS {
 			req := api.CertificatesPost{}
 
-			if d.(lxd.InstanceServer).HasExtension("explicit_trust_token") {
+			// If the password flag isn't provided and the server supports the explicit_trust_token extension,
+			// use the token instead and prompt for it if not present.
+			if d.(lxd.InstanceServer).HasExtension("explicit_trust_token") && c.flagPassword == "" {
 				// Prompt for trust token.
 				if c.flagToken == "" {
 					c.flagToken, err = c.global.asker.AskString(fmt.Sprintf(i18n.G("Trust token for %s: "), server), "", nil)


### PR DESCRIPTION
This fixes a regression introduced in #13567.

If the client talks to an older LXD that has the `explicit_trust_token` extension, let the provided password take priority and don't ask for the token if not provided.

See the following table:

Client Version | Server Version | Command | Result
-- | -- | -- | --
6.1 | 6.1 | lxc remote add | Ask for trust token
6.1 | 6.1 | lxc remote add --password | Err: not authorized (Token field not set in request body. We cannot check if the server still supports passwords.)
6.1 | 6.1 | lxc remote add --token | Continue without any prompts
6.1 | 5.21 (with `explicit_trust_token`) | lxc remote add | Ask for admin password
6.1 | 5.21 (with `explicit_trust_token`) | lxc remote add --password | Continue without any prompt
6.1 | 5.21 (with `explicit_trust_token`) | lxc remote add --token | Continue without any prompt
6.1 | 5.20 | lxc remote add | Ask for admin password
6.1 | 5.20 | lxc remote add --password | Continue without any prompt
6.1 | 5.20 | lxc remote add --token | Ask for admin password

