### PR TITLE
Makefile: the toolchain directive should be better supported now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,6 @@ ifneq "$(LXD_OFFLINE)" ""
 endif
 	go get -t -v -d -u ./...
 	go mod tidy -go=$(GOMIN)
-	go get toolchain@none
 
 	@echo "Dependencies updated"
 


### PR DESCRIPTION
Even Go 1.21 has improved support for it since 1.21.11 (https://github.com/golang/go/issues/62278)