### PR TITLE
test: Flush routes on lo interface left over from liblxc ipvlan bug

### DIFF
--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -75,18 +75,21 @@ test_container_devices_nic_bridged_filtering() {
   else
     macHex=$(echo "${ctAMAC}" |sed "s/://g")
     macDec=$(printf "%d" 0x"${macHex}")
+    macHex=$(printf "0x%x" "${macDec}")
 
     for table in "in" "fwd"
     do
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep -e "iifname \"${ctAHost}\" ether saddr != ${ctAMAC} drop"; then
+      rules=$(nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0")
+
+      if ! echo "${rules}" | grep -e "iifname \"${ctAHost}\" ether saddr != ${ctAMAC} drop"; then
         echo "MAC filter not applied as part of mac_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep -e "iifname \"${ctAHost}\" arp saddr ether != ${ctAMAC} drop"; then
+      if ! echo "${rules}" | grep -e "iifname \"${ctAHost}\" arp saddr ether != ${ctAMAC} drop"; then
         echo "MAC ARP filter not applied as part of mac_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" icmpv6 type 136 @nh,528,48 != ${macDec} drop"; then
+      if ! echo "${rules}" | grep -P "iifname \"${ctAHost}\" icmpv6 type 136 @nh,528,48 != (${macHex}|${macDec}) drop"; then
         echo "MAC NDP filter not applied as part of mac_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
@@ -315,31 +318,35 @@ test_container_devices_nic_bridged_filtering() {
     fi
   else
     macDec=$(printf "%d" 0x"${macHex}")
+    macHex=$(printf "0x%x" "${macDec}")
+    ipv6Hex="0x20010db8000000000000000000000002"
     ipv6Dec="42540766411282592856903984951653826562"
+
+    rules=$(nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0")
 
     for table in "in" "fwd"
     do
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" ether saddr != ${ctAMAC} drop"; then
+      if ! echo "${rules}" | grep "iifname \"${ctAHost}\" ether saddr != ${ctAMAC} drop"; then
         echo "MAC filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" arp saddr ether != ${ctAMAC} drop"; then
+      if ! echo "${rules}" | grep "iifname \"${ctAHost}\" arp saddr ether != ${ctAMAC} drop"; then
         echo "MAC ARP filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" icmpv6 type 136 @nh,528,48 != ${macDec} drop"; then
+      if ! echo "${rules}" | grep -P "iifname \"${ctAHost}\" icmpv6 type 136 @nh,528,48 != (${macHex}|${macDec}) drop"; then
         echo "MAC NDP filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" icmpv6 type 136 @nh,384,128 != ${ipv6Dec} drop"; then
+      if ! echo "${rules}" | grep -P "iifname \"${ctAHost}\" icmpv6 type 136 @nh,384,128 != (${ipv6Hex}|${ipv6Dec}) drop"; then
         echo "IPv6 NDP filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" ip6 saddr != 2001:db8::2 drop"; then
+      if ! echo "${rules}" | grep "iifname \"${ctAHost}\" ip6 saddr != 2001:db8::2 drop"; then
         echo "IPv6 filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep -e "iifname \"${ctAHost}\" icmpv6 type 134 drop"; then
+      if ! echo "${rules}" | grep -e "iifname \"${ctAHost}\" icmpv6 type 134 drop"; then
         echo "IPv6 RA filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
@@ -495,29 +502,34 @@ test_container_devices_nic_bridged_filtering() {
         false
     fi
   else
+    macHex=$(echo "${ctAMAC}" |sed "s/://g")
     macDec=$(printf "%d" 0x"${macHex}")
+    macHex=$(printf "0x%x" "${macDec}")
+    ipv6Hex="0x20010db8000000000000000000000002"
     ipv6Dec="42540766411282592856903984951653826562"
+
+    rules=$(nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0")
 
     for table in "in" "fwd"
     do
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" ether saddr != ${ctAMAC} drop"; then
+      if ! echo "${rules}" | grep "iifname \"${ctAHost}\" ether saddr != ${ctAMAC} drop"; then
         echo "MAC filter not applied as part of ipv4_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" arp saddr ether != ${ctAMAC} drop"; then
+      if ! echo "${rules}" | grep "iifname \"${ctAHost}\" arp saddr ether != ${ctAMAC} drop"; then
         echo "MAC ARP filter not applied as part of ipv4_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
 
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" icmpv6 type 136 @nh,528,48 != ${macDec} drop"; then
+      if ! echo "${rules}" | grep -P "iifname \"${ctAHost}\" icmpv6 type 136 @nh,528,48 != (${macHex}|${macDec}) drop"; then
         echo "MAC NDP filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" icmpv6 type 136 @nh,384,128 != ${ipv6Dec} drop"; then
+      if ! echo "${rules}" | grep -P "iifname \"${ctAHost}\" icmpv6 type 136 @nh,384,128 != (${ipv6Hex}|${ipv6Dec}) drop"; then
         echo "IPv6 NDP filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" ip6 saddr != 2001:db8::2 drop"; then
+      if ! echo "${rules}" | grep "iifname \"${ctAHost}\" ip6 saddr != 2001:db8::2 drop"; then
         echo "IPv6 filter not applied as part of ipv6_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
@@ -577,19 +589,22 @@ test_container_devices_nic_bridged_filtering() {
   else
     macHex=$(echo "${ctAMAC}" |sed "s/://g")
     macDec=$(printf "%d" 0x"${macHex}")
+    macHex=$(printf "0x%x" "${macDec}")
+
+    rules=$(nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0")
 
     for table in "in" "fwd"
     do
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" ether saddr != ${ctAMAC} drop"; then
+      if ! echo "${rules}" | grep "iifname \"${ctAHost}\" ether saddr != ${ctAMAC} drop"; then
         echo "MAC filter not applied as part of mac_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" arp saddr ether != ${ctAMAC} drop"; then
+      if ! echo "${rules}" | grep "iifname \"${ctAHost}\" arp saddr ether != ${ctAMAC} drop"; then
         echo "MAC ARP filter not applied as part of mac_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi
 
-      if ! nft -nn list chain bridge lxd "${table}.${ctPrefix}A.eth0" | grep "iifname \"${ctAHost}\" icmpv6 type 136 @nh,528,48 != ${macDec} drop"; then
+      if ! echo "${rules}" | grep -P "iifname \"${ctAHost}\" icmpv6 type 136 @nh,528,48 != (${macHex}|${macDec}) drop"; then
         echo "MAC NDP filter not applied as part of mac_filtering in nftables (${table}.${ctPrefix}A.eth0)"
         false
       fi

--- a/test/suites/container_devices_nic_ipvlan.sh
+++ b/test/suites/container_devices_nic_ipvlan.sh
@@ -36,6 +36,8 @@ test_container_devices_nic_ipvlan() {
   fi
 
   lxc stop "${ctName}" --force
+  ip -4 route flush dev lo
+  ip -6 route flush dev lo
 
   # Check that MTU is inherited from parent device when not specified on device.
   ip link set "${ctName}" mtu 1405
@@ -66,6 +68,9 @@ test_container_devices_nic_ipvlan() {
 
   # Check IPVLAN ontop of VLAN parent.
   lxc stop -f "${ctName}"
+  ip -4 route flush dev lo
+  ip -6 route flush dev lo
+
   lxc config device set "${ctName}" eth0 vlan 1234
   lxc start "${ctName}"
 
@@ -99,4 +104,6 @@ test_container_devices_nic_ipvlan() {
   lxc delete "${ctName}" -f
   lxc delete "${ctName}2" -f
   ip link delete "${ctName}" type dummy
+  ip -4 route flush dev lo
+  ip -6 route flush dev lo
 }


### PR DESCRIPTION
Later versions appear to be setting up routes on container start, but leaving them behind on container stop.

LXD doesn't use liblxc's route management in later versions so this is just to get the test suite passing.