### PR TITLE
Storage: Add Dell PowerFlex SDC operation mode

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -126,6 +126,7 @@ macOS
 macvlan
 manpages
 Mbit
+MDM
 MiB
 Mibit
 MicroCeph
@@ -199,6 +200,7 @@ runtime
 SATA
 scalable
 scriptlet
+SDC
 SDN
 SDS
 SDT

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -5467,7 +5467,7 @@ This option is required only if {config:option}`storage-powerflex-pool-conf:powe
 :shortdesc: "How volumes are mapped to the local server"
 :type: "string"
 The mode gets discovered automatically if the system provides the necessary kernel modules.
-Currently, only `nvme` is supported.
+This can be either `nvme` or `sdc`.
 ```
 
 ```{config:option} powerflex.pool storage-powerflex-pool-conf

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/checkpoint-restore/go-criu/v6 v6.3.0
 	github.com/checkpoint-restore/go-criu/v7 v7.1.0
+	github.com/dell/goscaleio v1.14.1
 	github.com/digitalocean/go-qemu v0.0.0-20230711162256-2e3d0186973e
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dell/goscaleio v1.14.1 h1:SCHGLoOBKxQZ8EodChOLoIghcyhepbO5MLPRd4YQZ5c=
+github.com/dell/goscaleio v1.14.1/go.mod h1:h7SCmReARG/szFWBMQGETGkZObknhS45lQipQbtdmJ8=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/digitalocean/go-libvirt v0.0.0-20240610184155-f66fb3c0f6d7 h1:KMOLn19gbh7KbPEgu76ZIf/b2CnnYhC2GFLgLiN/YkA=

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -6154,7 +6154,7 @@
 					{
 						"powerflex.mode": {
 							"defaultdesc": "the discovered mode",
-							"longdesc": "The mode gets discovered automatically if the system provides the necessary kernel modules.\nCurrently, only `nvme` is supported.",
+							"longdesc": "The mode gets discovered automatically if the system provides the necessary kernel modules.\nThis can be either `nvme` or `sdc`.",
 							"shortdesc": "How volumes are mapped to the local server",
 							"type": "string"
 						}

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -18,6 +18,11 @@ const powerFlexDefaultUser = "admin"
 // powerFlexDefaultSize represents the default PowerFlex volume size.
 const powerFlexDefaultSize = "8GiB"
 
+const (
+	powerFlexModeNVMe = "nvme"
+	powerFlexModeSDC  = "sdc"
+)
+
 var powerFlexLoaded bool
 var powerFlexVersion string
 
@@ -89,7 +94,7 @@ func (d *powerflex) FillConfig() error {
 
 	if d.config["powerflex.mode"] == "" {
 		if d.loadNVMeModules() {
-			d.config["powerflex.mode"] = "nvme"
+			d.config["powerflex.mode"] = powerFlexModeNVMe
 		}
 	}
 
@@ -128,7 +133,7 @@ func (d *powerflex) Create() error {
 	client := d.client()
 
 	// Discover one of the storage pools SDS services.
-	if d.config["powerflex.mode"] == "nvme" {
+	if d.config["powerflex.mode"] == powerFlexModeNVMe {
 		if d.config["powerflex.sdt"] == "" {
 			pool, err := d.resolvePool()
 			if err != nil {
@@ -251,7 +256,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 	// on the other cluster members too. This can be done here since Validate
 	// gets executed on every cluster member when receiving the cluster
 	// notification to finally create the pool.
-	if d.config["powerflex.mode"] == "nvme" && !d.loadNVMeModules() {
+	if d.config["powerflex.mode"] == powerFlexModeNVMe && !d.loadNVMeModules() {
 		return fmt.Errorf("NVMe/TCP is not supported")
 	}
 

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dell/goscaleio"
+
 	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
@@ -32,6 +34,10 @@ type powerflex struct {
 	// Holds the low level HTTP client for the PowerFlex API.
 	// Use powerflex.client() to retrieve the client struct.
 	httpClient *powerFlexClient
+
+	// Holds the SDC GUID of this specific host.
+	// Use powerflex.getHostGUID() to retrieve the actual value.
+	sdcGUID string
 }
 
 // load is used to run one-time action per-driver rather than per-pool.
@@ -92,9 +98,14 @@ func (d *powerflex) FillConfig() error {
 		d.config["powerflex.user.name"] = powerFlexDefaultUser
 	}
 
+	// Try to discover the PowerFlex operation mode.
+	// First try if the NVMe/TCP kernel modules can be loaed.
+	// Second try if the SDC kernel module is setup.
 	if d.config["powerflex.mode"] == "" {
 		if d.loadNVMeModules() {
 			d.config["powerflex.mode"] = powerFlexModeNVMe
+		} else if goscaleio.DrvCfgIsSDCInstalled() {
+			d.config["powerflex.mode"] = powerFlexModeSDC
 		}
 	}
 
@@ -125,15 +136,11 @@ func (d *powerflex) Create() error {
 		return fmt.Errorf("The powerflex.gateway cannot be empty")
 	}
 
-	// Fail if no PowerFlex mode can be discovered.
-	if d.config["powerflex.mode"] == "" {
-		return fmt.Errorf("Failed to discover PowerFlex mode")
-	}
-
 	client := d.client()
 
-	// Discover one of the storage pools SDS services.
-	if d.config["powerflex.mode"] == powerFlexModeNVMe {
+	switch d.config["powerflex.mode"] {
+	case powerFlexModeNVMe:
+		// Discover one of the storage pools SDT services.
 		if d.config["powerflex.sdt"] == "" {
 			pool, err := d.resolvePool()
 			if err != nil {
@@ -155,6 +162,19 @@ func (d *powerflex) Create() error {
 
 			d.config["powerflex.sdt"] = relations[0].IPList[0].IP
 		}
+
+	case powerFlexModeSDC:
+		if d.config["powerflex.sdt"] != "" {
+			return fmt.Errorf("The powerflex.sdt config key is specific to the NVMe/TCP mode")
+		}
+
+		if !goscaleio.DrvCfgIsSDCInstalled() {
+			return fmt.Errorf("PowerFlex SDC is not available on the host")
+		}
+
+	default:
+		// Fail if no PowerFlex mode can be discovered.
+		return fmt.Errorf("Failed to discover PowerFlex mode")
 	}
 
 	return nil
@@ -214,12 +234,12 @@ func (d *powerflex) Validate(config map[string]string) error {
 		"powerflex.domain": validate.Optional(validate.IsAny),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.mode)
 		// The mode gets discovered automatically if the system provides the necessary kernel modules.
-		// Currently, only `nvme` is supported.
+		// This can be either `nvme` or `sdc`.
 		// ---
 		//  type: string
 		//  defaultdesc: the discovered mode
 		//  shortdesc: How volumes are mapped to the local server
-		"powerflex.mode": validate.Optional(validate.IsOneOf("nvme")),
+		"powerflex.mode": validate.Optional(validate.IsOneOf("nvme", "sdc")),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.sdt)
 		//
 		// ---

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -835,7 +835,7 @@ func (d *powerflex) mapVolume(vol Volume) (revert.Hook, error) {
 	var hostID string
 
 	switch d.config["powerflex.mode"] {
-	case "nvme":
+	case powerFlexModeNVMe:
 		unlock, err := locking.Lock(d.state.ShutdownCtx, "nvme")
 		if err != nil {
 			return nil, err
@@ -884,7 +884,7 @@ func (d *powerflex) mapVolume(vol Volume) (revert.Hook, error) {
 		reverter.Add(func() { _ = client.deleteHostVolumeMapping(hostID, volumeID) })
 	}
 
-	if d.config["powerflex.mode"] == "nvme" {
+	if d.config["powerflex.mode"] == powerFlexModeNVMe {
 		// Connect to the NVMe/TCP subsystem.
 		// We have to connect after the first mapping was established.
 		// PowerFlex does not offer any discovery log entries until a volume gets mapped to the host.
@@ -975,7 +975,7 @@ func (d *powerflex) getMappedDevPath(vol Volume, mapVolume bool) (string, revert
 
 		var prefix string
 		switch d.config["powerflex.mode"] {
-		case "nvme":
+		case powerFlexModeNVMe:
 			prefix = "nvme-eui."
 		}
 
@@ -1033,7 +1033,7 @@ func (d *powerflex) unmapVolume(vol Volume) error {
 
 	var host *powerFlexSDC
 	switch d.config["powerflex.mode"] {
-	case "nvme":
+	case powerFlexModeNVMe:
 		nqn := d.getHostNQN()
 		host, err = client.getNVMeHostByNQN(nqn)
 		if err != nil {
@@ -1064,7 +1064,7 @@ func (d *powerflex) unmapVolume(vol Volume) error {
 		}
 	}
 
-	if d.config["powerflex.mode"] == "nvme" {
+	if d.config["powerflex.mode"] == powerFlexModeNVMe {
 		mappings, err := client.getHostVolumeMappings(host.ID)
 		if err != nil {
 			return err

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -821,15 +821,7 @@ func (d *powerflex) getVolumeType(vol Volume) powerFlexVolumeType {
 }
 
 // createNVMeHost creates this NVMe host in PowerFlex.
-// The operation is idempotent and locked using lock name powerflex.host.
 func (d *powerflex) createNVMeHost() (string, revert.Hook, error) {
-	unlock, err := locking.Lock(d.state.ShutdownCtx, "powerflex.host")
-	if err != nil {
-		return "", nil, err
-	}
-
-	defer unlock()
-
 	var hostID string
 	nqn := d.getHostNQN()
 
@@ -866,15 +858,7 @@ func (d *powerflex) createNVMeHost() (string, revert.Hook, error) {
 }
 
 // deleteNVMeHost deletes this NVMe host in PowerFlex.
-// The operation is idempotent and locked using lock name powerflex.host.
 func (d *powerflex) deleteNVMeHost() error {
-	unlock, err := locking.Lock(d.state.ShutdownCtx, "powerflex.host")
-	if err != nil {
-		return err
-	}
-
-	defer unlock()
-
 	client := d.client()
 	nqn := d.getHostNQN()
 	host, err := client.getNVMeHostByNQN(nqn)

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -550,9 +550,7 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 		return err
 	}
 
-	if cleanup != nil {
-		defer cleanup()
-	}
+	defer cleanup()
 
 	oldSizeBytes, err := BlockDiskSizeBytes(devPath)
 	if err != nil {


### PR DESCRIPTION
### Overview

This adds the SDC operation mode to the Dell PowerFlex storage driver.
To discover the presence of the SDC and to request further information from it, Dell's `goscaleio` library is added to LXD in order to able to import already existing utility functions. It's license is Apache-2.0.
Using this library we don't have to perform any actions against the SDC ourselves. The library is making use of the SDC's `/dev/scini` device using syscalls.

In addition it refactors the map/unmap functions to be generic so that both the `nvme` and `sdc` operation modes are supported. 
Furthermore constants are used to identify either `nvme` or `sdc` operation mode.

An extension to the test suite is added with https://github.com/canonical/lxd-ci/pull/212.

### Limitation

Using the `sdc` mode currently is limited to images with only three partitions (e.g. `ubuntu:jammy`). Launching images with more than 3 partitions (e.g. `ubuntu:noble`) is causing the kernel error `sysfs: cannot create duplicate filename '/dev/block/*:*'` (triggered by SDC) which breaks the underlying volume for consumption by LXD.
