### PR TITLE
Instance: Allow devpts in AppArmor profile for unprivileged containers

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -479,6 +479,8 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   ### Configuration: unprivileged containers
   pivot_root,
 
+  mount fstype=devpts,
+
   # Allow unlimited modification of mount propagation
   mount options=(rw,slave) -> /{,**},
   mount options=(rw,rslave) -> /{,**},


### PR DESCRIPTION
In core24 AppArmor includes security fixes and our ruleset, although the source code remains unchanged become stricter.

devpts was always available for unprivileged containers because of AppArmor bugs like [1]. Let's now allow it explicitly.

[1] https://bugs.launchpad.net/apparmor/+bug/1597017