### PR TITLE
Disable VM CPU auto pinning (stable-5.21)

### DIFF
--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -51,6 +51,7 @@ import (
 	"github.com/canonical/lxd/lxd/resources"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -680,6 +681,11 @@ func deviceEventListener(stateFunc func() *state.State) {
 			s := stateFunc()
 
 			if !s.OS.CGInfo.Supports(cgroup.CPUSet, nil) {
+				continue
+			}
+
+			// VMs are currently not auto CPU pinned.
+			if e[0] != string(api.InstanceTypeContainer) {
 				continue
 			}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7464,8 +7464,38 @@ func (d *qemu) CGroup() (*cgroup.CGroup, error) {
 	return nil, instance.ErrNotImplemented
 }
 
-// SetAffinity is not implemented for VMs.
+// SetAffinity sets affinity for QEMU processes according with a set provided.
 func (d *qemu) SetAffinity(set []string) error {
+	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
+	if err != nil {
+		// this is not an error path, really. Instance can be stopped, for example.
+		d.logger.Debug("Failed connecting to the QMP monitor. Instance is not running?", logger.Ctx{"name": d.Name(), "err": err})
+		return nil
+	}
+
+	// Get the list of PIDs from the VM.
+	pids, err := monitor.GetCPUs()
+	if err != nil {
+		return fmt.Errorf("Failed to get VM instance's QEMU process list: %w", err)
+	}
+
+	// Confirm nothing weird is going on.
+	if len(set) != len(pids) {
+		return fmt.Errorf("QEMU has different count of vCPUs (%v) than configured (%v)", pids, set)
+	}
+
+	for i, pid := range pids {
+		affinitySet := unix.CPUSet{}
+		cpuCoreIndex, _ := strconv.Atoi(set[i])
+		affinitySet.Set(cpuCoreIndex)
+
+		// Apply the pin.
+		err := unix.SchedSetaffinity(pid, &affinitySet)
+		if err != nil {
+			return fmt.Errorf("Failed to set QEMU process affinity: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Restores the previously reverted `SetAffinity` implementation for qemu driver so we can easily cherry-pick fixes from main in the future for this.

And instead adds logic to prevent auto pinning for VMs in the `deviceEventListener` which also stops the logging of the `level=debug msg="Scheduler: virtual-machine v1 changed: re-balancing"` message.

We can take this out later once needed.