### PR TITLE
Device: Fix TPM name errors

### DIFF
--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -13,6 +13,7 @@ import (
 	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
+	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/lxd/subprocess"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
@@ -97,7 +98,7 @@ func (d *tpm) Start() (*deviceConfig.RunConfig, error) {
 		return nil, fmt.Errorf("Failed to validate environment: %w", err)
 	}
 
-	tpmDevPath := filepath.Join(d.inst.Path(), fmt.Sprintf("tpm.%s", d.name))
+	tpmDevPath := filepath.Join(d.inst.Path(), fmt.Sprintf("tpm.%s", filesystem.PathNameEncode(d.name)))
 
 	if !shared.PathExists(tpmDevPath) {
 		err := os.Mkdir(tpmDevPath, 0700)
@@ -212,8 +213,9 @@ func (d *tpm) startVM() (*deviceConfig.RunConfig, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
-	tpmDevPath := filepath.Join(d.inst.Path(), fmt.Sprintf("tpm.%s", d.name))
-	socketPath := filepath.Join(tpmDevPath, fmt.Sprintf("swtpm-%s.sock", d.name))
+	escapedDeviceName := filesystem.PathNameEncode(d.name)
+	tpmDevPath := filepath.Join(d.inst.Path(), fmt.Sprintf("tpm.%s", escapedDeviceName))
+	socketPath := filepath.Join(tpmDevPath, fmt.Sprintf("swtpm-%s.sock", escapedDeviceName))
 	runConf := deviceConfig.RunConfig{
 		TPMDevice: []deviceConfig.RunConfigItem{
 			{Key: "devName", Value: d.name},
@@ -280,7 +282,7 @@ func (d *tpm) startVM() (*deviceConfig.RunConfig, error) {
 
 	revert.Add(func() { _ = proc.Stop() })
 
-	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
+	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", escapedDeviceName))
 
 	err = proc.Save(pidPath)
 	if err != nil {

--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -115,8 +115,9 @@ func (d *tpm) Start() (*deviceConfig.RunConfig, error) {
 }
 
 func (d *tpm) startContainer() (*deviceConfig.RunConfig, error) {
-	tpmDevPath := filepath.Join(d.inst.Path(), fmt.Sprintf("tpm.%s", d.name))
-	logFileName := fmt.Sprintf("tpm.%s.log", d.name)
+	escapedDeviceName := filesystem.PathNameEncode(d.name)
+	tpmDevPath := filepath.Join(d.inst.Path(), fmt.Sprintf("tpm.%s", escapedDeviceName))
+	logFileName := fmt.Sprintf("tpm.%s.log", escapedDeviceName)
 	logPath := filepath.Join(d.inst.LogPath(), logFileName)
 
 	proc, err := subprocess.NewProcess("swtpm", []string{"chardev", "--tpm2", "--tpmstate", fmt.Sprintf("dir=%s", tpmDevPath), "--vtpm-proxy"}, logPath, "")
@@ -135,7 +136,7 @@ func (d *tpm) startContainer() (*deviceConfig.RunConfig, error) {
 	// Stop the TPM emulator if anything goes wrong.
 	revert.Add(func() { _ = proc.Stop() })
 
-	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
+	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", escapedDeviceName))
 
 	err = proc.Save(pidPath)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2183,7 +2183,7 @@ func (d *qemu) deviceStart(dev device.Device, instanceRunning bool) (*deviceConf
 }
 
 func (d *qemu) deviceAttachPath(deviceName string) (mountTag string, err error) {
-	deviceID := qemuHostDriveDeviceID(deviceName, "virtio-fs")
+	deviceID := qemuDeviceNameOrID(qemuDeviceIDPrefix, deviceName, "-virtio-fs", qemuDeviceIDMaxLength)
 	mountTag = d.generateQemuDeviceName(deviceName)
 
 	// Detect virtiofsd path.
@@ -2310,7 +2310,7 @@ func (d *qemu) deviceAttachBlockDevice(mount deviceConfig.MountEntryItem) error 
 }
 
 func (d *qemu) deviceDetachPath(deviceName string) error {
-	deviceID := qemuHostDriveDeviceID(deviceName, "virtio-fs")
+	deviceID := qemuDeviceNameOrID(qemuDeviceIDPrefix, deviceName, "-virtio-fs", qemuDeviceIDMaxLength)
 
 	// Check if the agent is running.
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -892,8 +892,9 @@ type qemuTPMOpts struct {
 }
 
 func qemuTPM(opts *qemuTPMOpts) []cfgSection {
-	chardev := fmt.Sprintf("qemu_tpm-chardev_%s", opts.devName)
-	tpmdev := fmt.Sprintf("qemu_tpm-tpmdev_%s", opts.devName)
+	chardev := qemuDeviceNameOrID("qemu_tpm-chardev_", opts.devName, "", qemuDeviceIDMaxLength)
+	tpmdev := qemuDeviceNameOrID("qemu_tpm-tpmdev_", opts.devName, "", qemuDeviceIDMaxLength)
+	device := qemuDeviceNameOrID(qemuDeviceIDPrefix, opts.devName, "", qemuDeviceIDMaxLength)
 
 	return []cfgSection{{
 		name: fmt.Sprintf(`chardev "%s"`, chardev),
@@ -908,7 +909,7 @@ func qemuTPM(opts *qemuTPMOpts) []cfgSection {
 			{key: "chardev", value: chardev},
 		},
 	}, {
-		name: fmt.Sprintf(`device "dev-lxd_%s"`, opts.devName),
+		name: fmt.Sprintf(`device "%s"`, device),
 		entries: []cfgEntry{
 			{key: "driver", value: "tpm-crb"},
 			{key: "tpmdev", value: tpmdev},


### PR DESCRIPTION
This fixes TPM failing due to the device ID being trimmed if too long, that caused any references to that device to be incorrect after trimming.
To reproduce the issue:
1.`LONG_DEVICE_NAME="device-with-very-long-name-and---4-qemu-property-handling-test_"`
2.`lxc init ubuntu:n vm --vm`
3.`lxc config device add vm "${LONG_DEVICE_NAME}" tpm`
4.`lxc start vm`
This also allows using `/` in TPM names