### PR TITLE
VM: Correct QEMU device ID max length

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -109,7 +109,7 @@ const qemuPCIDeviceIDStart = 4
 const qemuDeviceIDPrefix = "dev-lxd_"
 
 // qemuDeviceNameMaxLength used to indicate the maximum length of a qemu device ID.
-const qemuDeviceIDMaxLength = 64
+const qemuDeviceIDMaxLength = 63
 
 // qemuDeviceNamePrefix used as part of the name given QEMU blockdevs, netdevs and device tags generated from user added devices.
 const qemuDeviceNamePrefix = "lxd_"


### PR DESCRIPTION
I don't think this is currently causing any bugs, but the correct limit for QEMU IDs is 63, not 64. If longer than that, QEMU truncates the ID internally.