### PR TITLE
Fix image not being transfered from the host when security.devlxd.images is enabled

### DIFF
--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -73,6 +73,8 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 			if err == nil {
 				return resp, nil
 			}
+
+			return nil, fmt.Errorf("GetImageFile (download): %v", err)
 		}
 	}
 


### PR DESCRIPTION
This is just a demo showcasing the issue with `security.devlxd.images` which is blocked due to the missing request context fields (`trusted`, `protocol`, `username`) and to open discussion regarding image access over devlxd socket.

---

Enabling `security.devlxd.images` allows LXD server running within a container to fetch the already cached image from the host (if the image with a given fingerprint exists on the host).

If request fails, for example because the image is not found, the LXD on container will proceed to download an image from the actual server.

However, the requests are blocked because fields in request context are not populated. This PR simply sets `trusted=true` and `protocol=unix`. The `username` field can be anything just not empty, to prevent failure when parsing request details (function `requestDetails()`). 

The request will pass if protocol is `unix`, as communication over unix is considered trusted with admin privilege. This brings us to another question, whether `devlxd` is allowed to access all images from all projects in the first place (as discussed on the meeting).

cc @tomponline @markylaing 