### PR TITLE
Device: Allow zfs storage pools in degraded state

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -2284,7 +2285,7 @@ func (d *disk) getParentBlocks(path string) ([]string, error) {
 				continue
 			}
 
-			if fields[1] != "ONLINE" {
+			if !slices.Contains([]string{"ONLINE", "DEGRADED"}, fields[1]) {
 				continue
 			}
 


### PR DESCRIPTION
This PR fixes the issue which caused failure to start instances when backed by zfs pools in degraded state.

As per https://openzfs.github.io/openzfs-docs/man/master/7/zpoolconcepts.7.html#Device_Failure_and_Recovery, if pools are in degraded state then sufficient replicas exist for continued functioning. As such, we should allow instances to be backed by pools with status of `DEGRADED`.

Closes #13641