### PR TITLE
lxc: Add validation for non-empty remote address

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -289,6 +289,10 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 		addr = args[1]
 	}
 
+	if len(addr) == 0 {
+		return fmt.Errorf(i18n.G("Remote address must not be empty"))
+	}
+
 	// Validate the server name.
 	if strings.Contains(server, ":") {
 		return fmt.Errorf(i18n.G("Remote names may not contain colons"))

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1060,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1721,8 +1721,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2412,7 +2412,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3980,7 +3980,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4007,7 +4007,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4672,37 +4672,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4990,7 +4994,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5031,11 +5035,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5246,7 +5250,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5689,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5999,7 +6003,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6042,7 +6046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6393,7 +6397,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7050,7 +7054,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7410,7 +7414,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7422,7 +7426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7459,7 +7463,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -774,15 +774,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -1096,7 +1096,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1363,7 +1363,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1638,12 +1638,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1682,7 +1682,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -2065,8 +2065,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2805,7 +2805,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -3313,7 +3313,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3397,7 +3397,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3798,7 +3798,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4511,7 +4511,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4538,7 +4538,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4844,11 +4844,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4892,7 +4892,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5224,37 +5224,41 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5353,7 +5357,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5417,7 +5421,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5572,7 +5576,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5613,11 +5617,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5844,7 +5848,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6103,7 +6107,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -6327,7 +6331,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6648,7 +6652,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6692,7 +6696,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -7081,7 +7085,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -8363,7 +8367,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -8727,7 +8731,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8739,7 +8743,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8776,7 +8780,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -816,7 +816,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1067,7 +1067,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1333,12 +1333,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1736,8 +1736,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2437,7 +2437,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2475,7 +2475,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3378,7 +3378,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4045,7 +4045,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4072,7 +4072,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4374,11 +4374,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4420,7 +4420,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4740,37 +4740,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4860,7 +4864,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4918,7 +4922,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5064,7 +5068,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5105,11 +5109,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5327,7 +5331,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5574,7 +5578,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5787,7 +5791,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6098,7 +6102,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6141,7 +6145,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6509,7 +6513,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7166,7 +7170,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7526,7 +7530,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7538,7 +7542,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7575,7 +7579,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,15 +757,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -1062,7 +1062,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1244,7 +1244,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1588,12 +1588,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1632,7 +1632,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1997,8 +1997,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2703,7 +2703,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2741,7 +2741,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3203,7 +3203,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3285,7 +3285,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3664,7 +3664,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4370,7 +4370,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4599,7 +4599,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4670,11 +4670,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4716,7 +4716,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5042,30 +5042,34 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
@@ -5073,7 +5077,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5164,7 +5168,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5223,7 +5227,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5415,11 +5419,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5886,7 +5890,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -6100,7 +6104,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6414,7 +6418,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6459,7 +6463,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6829,7 +6833,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7630,7 +7634,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7990,7 +7994,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8002,7 +8006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8039,7 +8043,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -764,17 +764,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -817,7 +817,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -984,7 +984,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -1099,7 +1099,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1282,7 +1282,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1357,7 +1357,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1641,12 +1641,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1685,7 +1685,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -2089,8 +2089,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2838,7 +2838,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2896,7 +2896,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -3358,7 +3358,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3441,7 +3441,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3885,7 +3885,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4598,7 +4598,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr "NOM"
@@ -4625,7 +4625,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr "NON"
 
@@ -4867,7 +4867,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4943,11 +4943,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4992,7 +4992,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5327,37 +5327,41 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
+msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5457,7 +5461,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5521,7 +5525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5693,7 +5697,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5737,11 +5741,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5970,7 +5974,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6234,7 +6238,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6461,7 +6465,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6788,7 +6792,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6833,7 +6837,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr "URL"
 
@@ -7223,7 +7227,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr "OUI"
 
@@ -8619,7 +8623,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -9002,7 +9006,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -9015,7 +9019,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9052,7 +9056,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr "o"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1064,7 +1064,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1725,8 +1725,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2416,7 +2416,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4011,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4311,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4676,37 +4676,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4792,7 +4796,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4849,7 +4853,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4994,7 +4998,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5035,11 +5039,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5250,7 +5254,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5481,7 +5485,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5693,7 +5697,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6046,7 +6050,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6397,7 +6401,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7414,7 +7418,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7426,7 +7430,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7463,7 +7467,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -759,15 +759,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -1064,7 +1064,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1243,7 +1243,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1315,7 +1315,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1582,12 +1582,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1992,8 +1992,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2700,7 +2700,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2738,7 +2738,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2758,7 +2758,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3278,7 +3278,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3658,7 +3658,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4368,7 +4368,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4598,7 +4598,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4669,11 +4669,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4716,7 +4716,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5041,38 +5041,42 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
+msgstr ""
 
 #: lxc/remote.go:101
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5164,7 +5168,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5223,7 +5227,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5374,7 +5378,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5415,11 +5419,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5636,7 +5640,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5882,7 +5886,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -6098,7 +6102,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6412,7 +6416,7 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6456,7 +6460,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6823,7 +6827,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7627,7 +7631,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7987,7 +7991,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -8000,7 +8004,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8037,7 +8041,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -749,15 +749,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -792,7 +792,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -962,7 +962,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -1075,7 +1075,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1332,7 +1332,7 @@ msgid ""
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1346,7 +1346,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1617,12 +1617,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1661,7 +1661,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -2020,8 +2020,8 @@ msgstr "警告を削除します"
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2765,7 +2765,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2803,7 +2803,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2823,7 +2823,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -3268,7 +3268,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3357,7 +3357,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3850,7 +3850,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -4555,7 +4555,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr "NAME"
@@ -4582,7 +4582,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr "NO"
 
@@ -4814,7 +4814,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4885,11 +4885,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4930,7 +4930,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -5257,37 +5257,41 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
+msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
@@ -5377,7 +5381,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5436,7 +5440,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -5589,7 +5593,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5631,11 +5635,11 @@ msgstr "直接リクエスト (raw query) を LXD に送ります"
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -5904,7 +5908,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -6147,7 +6151,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -6359,7 +6363,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6696,7 +6700,7 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -6741,7 +6745,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr "URL"
 
@@ -7111,7 +7115,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr "YES"
 
@@ -7801,7 +7805,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr "現在値"
 
@@ -8318,7 +8322,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr "n"
 
@@ -8330,7 +8334,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -8369,7 +8373,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr "y"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1060,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1721,8 +1721,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2412,7 +2412,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3980,7 +3980,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4007,7 +4007,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4672,37 +4672,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4990,7 +4994,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5031,11 +5035,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5246,7 +5250,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5689,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5999,7 +6003,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6042,7 +6046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6393,7 +6397,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7050,7 +7054,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7410,7 +7414,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7422,7 +7426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7459,7 +7463,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-06-13 10:35+0200\n"
+        "POT-Creation-Date: 2024-07-02 10:12-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -482,15 +482,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -522,7 +522,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -664,7 +664,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -771,7 +771,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -947,7 +947,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -1017,7 +1017,7 @@ msgstr  ""
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -1031,7 +1031,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1240,12 +1240,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1284,7 +1284,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1543,7 +1543,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930 lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172 lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354 lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:171 lxc/network_forward.go:236 lxc/network_forward.go:379 lxc/network_forward.go:448 lxc/network_forward.go:546 lxc/network_forward.go:576 lxc/network_forward.go:718 lxc/network_forward.go:780 lxc/network_forward.go:795 lxc/network_forward.go:860 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383 lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549 lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722 lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90 lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838 lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:263 lxc/storage_volume.go:354 lxc/storage_volume.go:557 lxc/storage_volume.go:636 lxc/storage_volume.go:711 lxc/storage_volume.go:793 lxc/storage_volume.go:874 lxc/storage_volume.go:1083 lxc/storage_volume.go:1198 lxc/storage_volume.go:1345 lxc/storage_volume.go:1429 lxc/storage_volume.go:1674 lxc/storage_volume.go:1755 lxc/storage_volume.go:1870 lxc/storage_volume.go:2014 lxc/storage_volume.go:2123 lxc/storage_volume.go:2169 lxc/storage_volume.go:2266 lxc/storage_volume.go:2333 lxc/storage_volume.go:2487 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930 lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172 lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354 lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:171 lxc/network_forward.go:236 lxc/network_forward.go:379 lxc/network_forward.go:448 lxc/network_forward.go:546 lxc/network_forward.go:576 lxc/network_forward.go:718 lxc/network_forward.go:780 lxc/network_forward.go:795 lxc/network_forward.go:860 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383 lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549 lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722 lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90 lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844 lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:263 lxc/storage_volume.go:354 lxc/storage_volume.go:557 lxc/storage_volume.go:636 lxc/storage_volume.go:711 lxc/storage_volume.go:793 lxc/storage_volume.go:874 lxc/storage_volume.go:1083 lxc/storage_volume.go:1198 lxc/storage_volume.go:1345 lxc/storage_volume.go:1429 lxc/storage_volume.go:1674 lxc/storage_volume.go:1755 lxc/storage_volume.go:1870 lxc/storage_volume.go:2014 lxc/storage_volume.go:2123 lxc/storage_volume.go:2169 lxc/storage_volume.go:2266 lxc/storage_volume.go:2333 lxc/storage_volume.go:2487 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -2170,7 +2170,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1446 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2206,7 +2206,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2226,7 +2226,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2644,7 +2644,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2724,7 +2724,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -3074,7 +3074,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3638,7 +3638,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid   "NAME"
 msgstr  ""
 
@@ -3662,7 +3662,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid   "NO"
 msgstr  ""
 
@@ -3889,7 +3889,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3960,11 +3960,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4005,7 +4005,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -4300,36 +4300,40 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915 lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921 lxc/remote.go:961
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
+msgstr  ""
+
+#: lxc/remote.go:293
+msgid   "Remote address must not be empty"
 msgstr  ""
 
 #: lxc/remote.go:101
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
@@ -4415,7 +4419,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4471,7 +4475,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4613,7 +4617,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid   "STATIC"
 msgstr  ""
 
@@ -4654,11 +4658,11 @@ msgstr  ""
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -4841,7 +4845,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -5066,7 +5070,7 @@ msgid   "Show the current identity\n"
         "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -5278,7 +5282,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5575,7 +5579,7 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
@@ -5615,7 +5619,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid   "URL"
 msgstr  ""
 
@@ -5953,7 +5957,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid   "YES"
 msgstr  ""
 
@@ -6573,7 +6577,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid   "current"
 msgstr  ""
 
@@ -6870,7 +6874,7 @@ msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid   "n"
 msgstr  ""
 
@@ -6882,7 +6886,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6919,7 +6923,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -739,15 +739,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -780,7 +780,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1037,7 +1037,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1553,12 +1553,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1948,8 +1948,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2639,7 +2639,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2677,7 +2677,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2697,7 +2697,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3118,7 +3118,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3199,7 +3199,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3565,7 +3565,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4207,7 +4207,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4234,7 +4234,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4463,7 +4463,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4534,11 +4534,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4579,7 +4579,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4899,37 +4899,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5015,7 +5019,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5072,7 +5076,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5217,7 +5221,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5258,11 +5262,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5473,7 +5477,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5704,7 +5708,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5916,7 +5920,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6226,7 +6230,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6269,7 +6273,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6620,7 +6624,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7277,7 +7281,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7637,7 +7641,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7649,7 +7653,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7686,7 +7690,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -777,15 +777,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1075,7 +1075,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1325,7 +1325,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1339,7 +1339,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1591,12 +1591,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1635,7 +1635,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1986,8 +1986,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2677,7 +2677,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2735,7 +2735,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3156,7 +3156,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3237,7 +3237,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3603,7 +3603,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4245,7 +4245,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4272,7 +4272,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4501,7 +4501,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4572,11 +4572,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4617,7 +4617,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4937,37 +4937,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5053,7 +5057,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5110,7 +5114,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5255,7 +5259,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5296,11 +5300,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5511,7 +5515,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5742,7 +5746,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5954,7 +5958,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6264,7 +6268,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6307,7 +6311,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6658,7 +6662,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7315,7 +7319,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7675,7 +7679,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7687,7 +7691,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7724,7 +7728,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1060,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1721,8 +1721,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2412,7 +2412,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3980,7 +3980,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4007,7 +4007,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4672,37 +4672,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4990,7 +4994,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5031,11 +5035,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5246,7 +5250,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5689,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5999,7 +6003,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6042,7 +6046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6393,7 +6397,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7050,7 +7054,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7410,7 +7414,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7422,7 +7426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7459,7 +7463,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -1088,7 +1088,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1268,7 +1268,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1341,7 +1341,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1619,12 +1619,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1663,7 +1663,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -2044,8 +2044,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2762,7 +2762,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2800,7 +2800,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2820,7 +2820,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3263,7 +3263,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3345,7 +3345,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3720,7 +3720,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4407,7 +4407,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4434,7 +4434,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4734,11 +4734,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4780,7 +4780,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5108,30 +5108,34 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
@@ -5139,7 +5143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5237,7 +5241,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5298,7 +5302,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5453,7 +5457,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5494,11 +5498,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5722,7 +5726,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5979,7 +5983,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -6194,7 +6198,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6510,7 +6514,7 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6554,7 +6558,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6932,7 +6936,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7662,7 +7666,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -8022,7 +8026,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8034,7 +8038,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8071,7 +8075,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -819,7 +819,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -1085,7 +1085,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1338,7 +1338,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1607,12 +1607,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1651,7 +1651,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -2030,8 +2030,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2746,7 +2746,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2784,7 +2784,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3249,7 +3249,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3331,7 +3331,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3714,7 +3714,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4408,7 +4408,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4435,7 +4435,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4668,7 +4668,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4739,11 +4739,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5109,30 +5109,34 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
@@ -5140,7 +5144,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5232,7 +5236,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5293,7 +5297,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5447,7 +5451,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5488,11 +5492,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5711,7 +5715,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5965,7 +5969,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -6184,7 +6188,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6495,7 +6499,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6539,7 +6543,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6912,7 +6916,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -8149,7 +8153,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -8509,7 +8513,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8521,7 +8525,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8558,7 +8562,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1064,7 +1064,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1725,8 +1725,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2416,7 +2416,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4011,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4311,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4676,37 +4676,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4792,7 +4796,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4849,7 +4853,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4994,7 +4998,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5035,11 +5039,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5250,7 +5254,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5481,7 +5485,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5693,7 +5697,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6046,7 +6050,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6397,7 +6401,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7414,7 +7418,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7426,7 +7430,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7463,7 +7467,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1064,7 +1064,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1725,8 +1725,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2416,7 +2416,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4011,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4311,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4676,37 +4676,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4792,7 +4796,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4849,7 +4853,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4994,7 +4998,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5035,11 +5039,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5250,7 +5254,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5481,7 +5485,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5693,7 +5697,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6046,7 +6050,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6397,7 +6401,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7414,7 +7418,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7426,7 +7430,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7463,7 +7467,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1060,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1326,12 +1326,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1721,8 +1721,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2412,7 +2412,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3980,7 +3980,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4007,7 +4007,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4236,7 +4236,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4672,37 +4672,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4788,7 +4792,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4845,7 +4849,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4990,7 +4994,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5031,11 +5035,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5246,7 +5250,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5477,7 +5481,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5689,7 +5693,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5999,7 +6003,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6042,7 +6046,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6393,7 +6397,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7050,7 +7054,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7410,7 +7414,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7422,7 +7426,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7459,7 +7463,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1064,7 +1064,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1330,12 +1330,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1725,8 +1725,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2416,7 +2416,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4011,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4240,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4311,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4676,37 +4676,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4792,7 +4796,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4849,7 +4853,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4994,7 +4998,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5035,11 +5039,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5250,7 +5254,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5481,7 +5485,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5693,7 +5697,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6003,7 +6007,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6046,7 +6050,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6397,7 +6401,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7414,7 +7418,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7426,7 +7430,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7463,7 +7467,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -676,15 +676,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -974,7 +974,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1224,7 +1224,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1490,12 +1490,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1885,8 +1885,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2576,7 +2576,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2634,7 +2634,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3055,7 +3055,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3136,7 +3136,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3502,7 +3502,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -4144,7 +4144,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4171,7 +4171,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4400,7 +4400,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4471,11 +4471,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4516,7 +4516,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4836,37 +4836,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4952,7 +4956,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -5009,7 +5013,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -5154,7 +5158,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5195,11 +5199,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5410,7 +5414,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5641,7 +5645,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5853,7 +5857,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6163,7 +6167,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6206,7 +6210,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6557,7 +6561,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7214,7 +7218,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7574,7 +7578,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7586,7 +7590,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7623,7 +7627,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-06-13 10:35+0200\n"
+"POT-Creation-Date: 2024-07-02 10:12-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:835 lxc/remote.go:892
+#: lxc/remote.go:841 lxc/remote.go:898
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:938
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:762
+#: lxc/remote.go:768
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:744
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:574
+#: lxc/remote.go:580
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:871
+#: lxc/remote.go:877
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:454
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1329,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:469
+#: lxc/remote.go:224 lxc/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:480
+#: lxc/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1724,8 +1724,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:641 lxc/remote.go:679 lxc/remote.go:765 lxc/remote.go:838
-#: lxc/remote.go:894 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
+#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2415,7 +2415,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:683 lxc/storage.go:588
+#: lxc/project.go:804 lxc/remote.go:689 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:747
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:396
+#: lxc/remote.go:159 lxc/remote.go:400
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:348
+#: lxc/remote.go:352
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:337
+#: lxc/remote.go:341
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3341,7 +3341,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:678 lxc/remote.go:679
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "List the available remotes"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498
-#: lxc/remote.go:741 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4010,7 +4010,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:701 lxc/remote.go:706 lxc/remote.go:711
+#: lxc/project.go:481 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
 msgid "NO"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:743
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:745
+#: lxc/image.go:1073 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4355,7 +4355,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4675,37 +4675,41 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:795
+#: lxc/remote.go:801
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:786 lxc/remote.go:859 lxc/remote.go:915
-#: lxc/remote.go:955
+#: lxc/project.go:769 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
+#: lxc/remote.go:961
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:300
+#: lxc/remote.go:304
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:867
+#: lxc/remote.go:873
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:790 lxc/remote.go:863 lxc/remote.go:959
+#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
 #, c-format
 msgid "Remote %s is static and cannot be modified"
+msgstr ""
+
+#: lxc/remote.go:293
+msgid "Remote address must not be empty"
 msgstr ""
 
 #: lxc/remote.go:101
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:298
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4791,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:837 lxc/remote.go:838
+#: lxc/remote.go:843 lxc/remote.go:844
 msgid "Remove remotes"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:765
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Rename remotes"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:746
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5034,11 +5038,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:609
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5249,7 +5253,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:939 lxc/remote.go:940
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5480,7 +5484,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:640 lxc/remote.go:641
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Show the default remote"
 msgstr ""
 
@@ -5692,7 +5696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:893 lxc/remote.go:894
+#: lxc/remote.go:899 lxc/remote.go:900
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6002,7 +6006,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:570
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6045,7 +6049,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:742
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6396,7 +6400,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:483 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
 msgid "YES"
 msgstr ""
 
@@ -7053,7 +7057,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:732
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7413,7 +7417,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -7425,7 +7429,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:455
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7462,7 +7466,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:464
 msgid "y"
 msgstr ""
 


### PR DESCRIPTION
This PR adds a check to ensure that the provided remote address is not empty when adding a new remote server. In place of the previous panic, we now return an error message to the user.

Closes #13682