### PR TITLE
lxd: Add support for starting instances on creation (from Incus)

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2434,3 +2434,10 @@ This feature was added to prevent data loss which can happen when custom block v
 ## `instance_import_conversion`
 
 Adds the ability to convert images from different formats (e.g. VMDK or QCow2) into RAW image format and import them as LXD instances.
+
+## `instance_create_start`
+
+Adds a `start` field to the `POST /1.0/instances` API which when set
+to `true` will have the instance automatically start upon creation.
+
+In this scenario, the creation and startup is part of a single background operation.

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -74,6 +74,19 @@ To start an instance, send a PUT request to change the instance state:
 
 See {ref}`instances-manage-start` for more information.
 
+If you would like to start the instance upon creation, set the `start` property to true. The following example will create the container, then start it:
+
+    lxc query --request POST /1.0/instances --data '{
+      "name": "<instance_name>",
+      "source": {
+        "alias": "<image_alias>",
+        "protocol": "simplestreams",
+        "server": "<server_URL>",
+        "type": "image"
+      },
+      "start": true
+    }'
+
 ````
 
 ````{group-tab} UI

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2752,6 +2752,11 @@ definitions:
                 x-go-name: Restore
             source:
                 $ref: '#/definitions/InstanceSource'
+            start:
+                description: Whether to start the instance after creation
+                example: true
+                type: boolean
+                x-go-name: Start
             stateful:
                 description: Whether the instance currently has saved state on disk
                 example: false

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -81,11 +81,11 @@ func (c *cmdInit) run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	_, _, err = c.create(c.global.conf, args)
+	_, _, err = c.create(c.global.conf, args, false)
 	return err
 }
 
-func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer, string, error) {
+func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.InstanceServer, string, error) {
 	var name string
 	var image string
 	var remote string
@@ -164,10 +164,18 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 	}
 
 	if !c.global.flagQuiet {
-		if name == "" {
-			fmt.Printf(i18n.G("Creating the instance") + "\n")
+		if d.HasExtension("instance_create_start") && launch {
+			if name == "" {
+				fmt.Printf(i18n.G("Launching the instance") + "\n")
+			} else {
+				fmt.Printf(i18n.G("Launching %s")+"\n", name)
+			}
 		} else {
-			fmt.Printf(i18n.G("Creating %s")+"\n", name)
+			if name == "" {
+				fmt.Printf(i18n.G("Creating the instance") + "\n")
+			} else {
+				fmt.Printf(i18n.G("Creating %s")+"\n", name)
+			}
 		}
 	}
 
@@ -252,6 +260,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 		Name:         name,
 		InstanceType: c.flagType,
 		Type:         instanceDBType,
+		Start:        launch,
 	}
 
 	req.Config = configMap

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -58,9 +58,14 @@ func (c *cmdLaunch) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Call the matching code from init
-	d, name, err := c.init.create(conf, args)
+	d, name, err := c.init.create(conf, args, true)
 	if err != nil {
 		return err
+	}
+
+	// Check if the instance was started by the server.
+	if d.HasExtension("instance_create_start") {
+		return nil
 	}
 
 	// Get the remote

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3049,6 +3049,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5565,7 +5574,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5770,7 +5779,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5931,11 +5940,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6008,7 +6017,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1824,12 +1824,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2171,7 +2171,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
@@ -3286,7 +3286,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3480,6 +3480,16 @@ msgstr ""
 #: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
+
+#: lxc/init.go:171
+#, fuzzy, c-format
+msgid "Launching %s"
+msgstr "Erstelle %s"
+
+#: lxc/init.go:169
+#, fuzzy
+msgid "Launching the instance"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/info.go:220
 #, fuzzy, c-format
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6196,7 +6206,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6413,7 +6423,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6580,11 +6590,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6657,7 +6667,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -772,7 +772,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1502,12 +1502,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1835,7 +1835,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2902,7 +2902,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3087,6 +3087,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -5003,7 +5012,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5663,7 +5672,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5868,7 +5877,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6030,11 +6039,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6107,7 +6116,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1761,12 +1761,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
@@ -2097,7 +2097,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3175,7 +3175,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3364,6 +3364,16 @@ msgstr ""
 #: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
+
+#: lxc/init.go:171
+#, fuzzy, c-format
+msgid "Launching %s"
+msgstr "Creando %s"
+
+#: lxc/init.go:169
+#, fuzzy
+msgid "Launching the instance"
+msgstr "Creando el contenedor"
 
 #: lxc/info.go:220
 #, fuzzy, c-format
@@ -5311,7 +5321,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5975,7 +5985,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6183,7 +6193,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6346,11 +6356,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6423,7 +6433,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1843,12 +1843,12 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
@@ -2190,7 +2190,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -3330,7 +3330,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3521,6 +3521,16 @@ msgstr "Dernière utilisation : %s"
 #: lxc/image.go:982
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
+
+#: lxc/init.go:171
+#, fuzzy, c-format
+msgid "Launching %s"
+msgstr "Création de %s"
+
+#: lxc/init.go:169
+#, fuzzy
+msgid "Launching the instance"
+msgstr "Création du conteneur"
 
 #: lxc/info.go:220
 #, fuzzy, c-format
@@ -5630,7 +5640,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -6328,7 +6338,7 @@ msgstr "Source :"
 msgid "Start instances"
 msgstr "Création du conteneur"
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr "Démarrage de %s"
@@ -6550,7 +6560,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -6717,12 +6727,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -6797,7 +6807,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1496,12 +1496,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3053,6 +3053,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4934,7 +4943,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5569,7 +5578,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5774,7 +5783,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5935,11 +5944,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6012,7 +6021,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1757,12 +1757,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3167,7 +3167,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3357,6 +3357,16 @@ msgstr ""
 #: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
+
+#: lxc/init.go:171
+#, fuzzy, c-format
+msgid "Launching %s"
+msgstr "Creazione di %s in corso"
+
+#: lxc/init.go:169
+#, fuzzy
+msgid "Launching the instance"
+msgstr "Creazione del container in corso"
 
 #: lxc/info.go:220
 #, fuzzy, c-format
@@ -5311,7 +5321,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5972,7 +5982,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6180,7 +6190,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6344,11 +6354,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6421,7 +6431,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1789,12 +1789,12 @@ msgstr "プロファイルを適用しないインスタンスを作成します
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
@@ -2122,7 +2122,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
@@ -3240,7 +3240,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3437,6 +3437,16 @@ msgstr "最終使用: %s"
 #: lxc/image.go:982
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
+
+#: lxc/init.go:171
+#, fuzzy, c-format
+msgid "Launching %s"
+msgstr "%s を作成中"
+
+#: lxc/init.go:169
+#, fuzzy
+msgid "Launching the instance"
+msgstr "インスタンスを作成中"
 
 #: lxc/info.go:220
 #, c-format
@@ -5528,7 +5538,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -6235,7 +6245,7 @@ msgstr "取得元:"
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr "%s を起動中"
@@ -6443,7 +6453,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -6619,13 +6629,13 @@ msgstr "インスタンスがクリーンにシャットダウンするまで待
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -6705,7 +6715,7 @@ msgstr "通信ポリシー"
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3049,6 +3049,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5565,7 +5574,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5770,7 +5779,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5931,11 +5940,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6008,7 +6017,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-07-02 10:12-0700\n"
+        "POT-Creation-Date: 2024-07-24 14:26-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -728,7 +728,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -830,7 +830,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -1405,12 +1405,12 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid   "Creating the instance"
 msgstr  ""
 
@@ -1613,7 +1613,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
@@ -2617,7 +2617,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -2796,6 +2796,15 @@ msgstr  ""
 
 #: lxc/image.go:982
 msgid   "Last used: never"
+msgstr  ""
+
+#: lxc/init.go:171
+#, c-format
+msgid   "Launching %s"
+msgstr  ""
+
+#: lxc/init.go:169
+msgid   "Launching the instance"
 msgstr  ""
 
 #: lxc/info.go:220
@@ -4554,7 +4563,7 @@ msgstr  ""
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -5154,7 +5163,7 @@ msgstr  ""
 msgid   "Start instances"
 msgstr  ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid   "Starting %s"
 msgstr  ""
@@ -5354,7 +5363,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -5509,11 +5518,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -5584,7 +5593,7 @@ msgstr  ""
 msgid   "Trust token for %s: "
 msgstr  ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -993,7 +993,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1719,12 +1719,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -2046,7 +2046,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3091,7 +3091,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3276,6 +3276,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -5157,7 +5166,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5792,7 +5801,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5997,7 +6006,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6158,11 +6167,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6235,7 +6244,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1136,7 +1136,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1757,12 +1757,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -2084,7 +2084,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3129,7 +3129,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3314,6 +3314,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -5195,7 +5204,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5830,7 +5839,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6035,7 +6044,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6196,11 +6205,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6273,7 +6282,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3049,6 +3049,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5565,7 +5574,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5770,7 +5779,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5931,11 +5940,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6008,7 +6017,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1801,12 +1801,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
@@ -2146,7 +2146,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3236,7 +3236,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3424,6 +3424,16 @@ msgstr ""
 #: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
+
+#: lxc/init.go:171
+#, fuzzy, c-format
+msgid "Launching %s"
+msgstr "Criando %s"
+
+#: lxc/init.go:169
+#, fuzzy
+msgid "Launching the instance"
+msgstr "Criando %s"
 
 #: lxc/info.go:220
 #, fuzzy, c-format
@@ -5390,7 +5400,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6069,7 +6079,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6279,7 +6289,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6442,11 +6452,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6519,7 +6529,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1790,12 +1790,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3221,7 +3221,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3410,6 +3410,16 @@ msgstr ""
 #: lxc/image.go:982
 msgid "Last used: never"
 msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+#, fuzzy
+msgid "Launching the instance"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/info.go:220
 #, fuzzy, c-format
@@ -5384,7 +5394,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6056,7 +6066,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6265,7 +6275,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6427,11 +6437,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6504,7 +6514,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1496,12 +1496,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3053,6 +3053,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4934,7 +4943,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5569,7 +5578,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5774,7 +5783,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5935,11 +5944,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6012,7 +6021,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1496,12 +1496,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3053,6 +3053,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4934,7 +4943,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5569,7 +5578,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5774,7 +5783,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5935,11 +5944,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6012,7 +6021,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3049,6 +3049,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5565,7 +5574,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5770,7 +5779,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5931,11 +5940,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6008,7 +6017,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1496,12 +1496,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3053,6 +3053,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4934,7 +4943,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5569,7 +5578,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5774,7 +5783,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5935,11 +5944,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6012,7 +6021,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -930,7 +930,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1656,12 +1656,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1983,7 +1983,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3028,7 +3028,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3213,6 +3213,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -5094,7 +5103,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5729,7 +5738,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5934,7 +5943,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6095,11 +6104,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6172,7 +6181,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-07-02 10:12-0700\n"
+"POT-Creation-Date: 2024-07-24 14:26-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:324 lxc/rebuild.go:130
+#: lxc/init.go:333 lxc/rebuild.go:130
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:139 lxc/init.go:224 lxc/move.go:380 lxc/project.go:129
+#: lxc/copy.go:139 lxc/init.go:232 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:170
+#: lxc/init.go:177
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:168
+#: lxc/init.go:175
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:384
+#: lxc/init.go:393
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:395
+#: lxc/init.go:404
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3052,6 +3052,15 @@ msgstr ""
 
 #: lxc/image.go:982
 msgid "Last used: never"
+msgstr ""
+
+#: lxc/init.go:171
+#, c-format
+msgid "Launching %s"
+msgstr ""
+
+#: lxc/init.go:169
+msgid "Launching the instance"
 msgstr ""
 
 #: lxc/info.go:220
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: lxc/init.go:338
+#: lxc/init.go:347
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5568,7 +5577,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:82
+#: lxc/launch.go:87
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5773,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:416
+#: lxc/init.go:425
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5934,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:418
+#: lxc/init.go:427
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:426
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6011,7 +6020,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:114
+#: lxc/action.go:287 lxc/launch.go:119
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -49,6 +49,12 @@ type InstancesPost struct {
 	// Type (container or virtual-machine)
 	// Example: container
 	Type InstanceType `json:"type" yaml:"type"`
+
+	// Whether to start the instance after creation
+	// Example: true
+	//
+	// API extension: instance_create_start
+	Start bool `json:"start" yaml:"start"`
 }
 
 // InstancesPut represents the fields available for a mass update.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -410,6 +410,7 @@ var APIExtensions = []string{
 	"explicit_trust_token",
 	"shared_custom_block_volumes",
 	"instance_import_conversion",
+	"instance_create_start",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds support for starting instances on creation.

Includes cherry-picks from https://github.com/lxc/incus/pull/410.

Closes #13322