### PR TITLE
Instance: Fix containers not always starting up after host reboot

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -298,9 +298,9 @@ func internalContainerHookLoadFromReference(s *state.State, r *http.Request) (in
 			logger.Warn("Failed loading instance from database, trying backup file", logger.Ctx{"project": projectName, "instance": instanceRef, "err": err})
 
 			instancePath := filepath.Join(shared.VarPath("containers"), project.Instance(projectName, instanceRef))
-			inst, err = instance.LoadFromBackup(s, projectName, instancePath, false)
+			inst, err = instance.LoadFromBackup(s, projectName, instancePath)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("Failed loading instance from backup file: %w", err)
 			}
 		}
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -434,7 +434,7 @@ func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) 
 				l.Warn("Failed loading instance from database to handle monitor event, trying backup file", logger.Ctx{"err": err})
 
 				instancePath := filepath.Join(shared.VarPath("virtual-machines"), project.Instance(instProject.Name, instanceName))
-				inst, err = instance.LoadFromBackup(state, instProject.Name, instancePath, false)
+				inst, err = instance.LoadFromBackup(state, instProject.Name, instancePath)
 				if err != nil {
 					l.Error("Failed loading instance to handle monitor event", logger.Ctx{"err": err})
 					return

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -401,7 +401,7 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 			// Also generally it ensures that all devices are stopped cleanly too.
 			backupYamlPath := filepath.Join(instancePaths[instanceType], file.Name(), "backup.yaml")
 			if shared.PathExists(backupYamlPath) {
-				inst, err = instance.LoadFromBackup(s, projectName, filepath.Join(instancePaths[instanceType], file.Name()), false)
+				inst, err = instance.LoadFromBackup(s, projectName, filepath.Join(instancePaths[instanceType], file.Name()))
 				if err != nil {
 					logger.Warn("Failed loading instance", logger.Ctx{"project": projectName, "instance": instanceName, "backup_file": backupYamlPath, "err": err})
 				}


### PR DESCRIPTION
Ignore `liblxc.ErrNotRunning` error when stopping.

If the container refuses to stop, then check if the error is ErrNotRunning, and if so ignore it, because sometimes if an earlier shutdown request was sent, but timed out, the actual guest shutdown can still be proceeding and the container may have reached a stop state by now and is in the process of running the onStop hook to cleanup host side devices. If we returned here with ErrNotRunning then this would be incorrect as the onStop hook could still be running and we aren't fully cleaned up yet, which can cause issues with state reporting after Stop has returned.