### PR TITLE
Reinstate 403 when TLS client lists resources in disallowed project

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -238,7 +238,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// If not authorized, return now. Untrusted users are not authorized.
-	err := s.Authorizer.CheckPermission(r.Context(), r, entity.ServerURL(), auth.EntitlementCanView)
+	err := s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanView)
 	if err != nil && auth.IsDeniedError(err) {
 		return response.SyncResponseETag(true, srv, nil)
 	} else if err != nil {
@@ -387,7 +387,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	fullSrv.AuthUserMethod = requestor.Protocol
 
 	// Only allow identities that can edit configuration to view it as sensitive information may be stored there.
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ServerURL(), auth.EntitlementCanEdit)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanEdit)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err == nil {

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -354,12 +354,12 @@ func getFilteredMetrics(s *state.State, r *http.Request, compress bool, metricSe
 		return response.SyncResponsePlain(true, compress, metricSet.String())
 	}
 
-	userHasProjectPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanViewMetrics, entity.TypeProject)
+	userHasProjectPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanViewMetrics, entity.TypeProject)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	userHasServerPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanViewMetrics, entity.TypeServer)
+	userHasServerPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanViewMetrics, entity.TypeServer)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -140,7 +140,7 @@ func projectsGet(d *Daemon, r *http.Request) response.Response {
 
 	recursion := util.IsRecursionRequest(r)
 
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeProject)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeProject)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/auth/drivers/common.go
+++ b/lxd/auth/drivers/common.go
@@ -4,13 +4,7 @@ package drivers
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
 
-	"github.com/canonical/lxd/lxd/auth"
-	"github.com/canonical/lxd/lxd/request"
-	"github.com/canonical/lxd/shared"
-	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -29,112 +23,6 @@ func (c *commonAuthorizer) init(driverName string, l logger.Logger) error {
 	c.driverName = driverName
 	c.logger = l
 	return nil
-}
-
-type requestDetails struct {
-	trusted              bool
-	userName             string
-	protocol             string
-	forwardedUsername    string
-	forwardedProtocol    string
-	isAllProjectsRequest bool
-	isPKI                bool
-	idpGroups            []string
-	forwardedIDPGroups   []string
-}
-
-func (r *requestDetails) isInternalOrUnix() bool {
-	if r.protocol == auth.AuthenticationMethodUnix {
-		return true
-	}
-
-	if r.protocol == auth.AuthenticationMethodCluster && (r.forwardedProtocol == auth.AuthenticationMethodUnix || r.forwardedProtocol == auth.AuthenticationMethodCluster || r.forwardedProtocol == "") {
-		return true
-	}
-
-	return false
-}
-
-func (r *requestDetails) username() string {
-	if r.protocol == auth.AuthenticationMethodCluster && r.forwardedUsername != "" {
-		return r.forwardedUsername
-	}
-
-	return r.userName
-}
-
-func (r *requestDetails) authenticationProtocol() string {
-	if r.protocol == auth.AuthenticationMethodCluster {
-		return r.forwardedProtocol
-	}
-
-	return r.protocol
-}
-
-func (r *requestDetails) identityProviderGroups() []string {
-	if r.protocol == auth.AuthenticationMethodCluster {
-		return r.forwardedIDPGroups
-	}
-
-	return r.idpGroups
-}
-
-func (c *commonAuthorizer) requestDetails(r *http.Request) (*requestDetails, error) {
-	if r == nil {
-		return nil, api.StatusErrorf(http.StatusInternalServerError, "Cannot inspect nil request")
-	} else if r.URL == nil {
-		return nil, api.StatusErrorf(http.StatusInternalServerError, "Request URL is not set")
-	}
-
-	var err error
-	d := &requestDetails{}
-
-	d.trusted, err = request.GetCtxValue[bool](r.Context(), request.CtxTrusted)
-	if err != nil {
-		return nil, api.StatusErrorf(http.StatusInternalServerError, "Failed getting authentication status: %w", err)
-	}
-
-	// If request is not trusted, no other values should be extracted.
-	if !d.trusted {
-		return d, nil
-	}
-
-	// Request protocol cannot be empty.
-	d.protocol, err = request.GetCtxValue[string](r.Context(), request.CtxProtocol)
-	if err != nil {
-		return nil, api.StatusErrorf(http.StatusInternalServerError, "Failed getting protocol: %w", err)
-	}
-
-	// Forwarded protocol can be empty.
-	d.forwardedProtocol, _ = request.GetCtxValue[string](r.Context(), request.CtxForwardedProtocol)
-
-	// If we're in a CA environment, it's possible for a certificate to be trusted despite not being present in the trust store.
-	// We rely on the validation of the certificate (and its potential revocation) having been done in CheckTrustState.
-	d.isPKI = d.authenticationProtocol() == api.AuthenticationMethodTLS && shared.PathExists(shared.VarPath("server.ca"))
-
-	// Username cannot be empty.
-	d.userName, err = request.GetCtxValue[string](r.Context(), request.CtxUsername)
-	if err != nil {
-		return nil, api.StatusErrorf(http.StatusInternalServerError, "Failed getting username: %w", err)
-	}
-
-	// Forwarded username can be empty.
-	d.forwardedUsername, _ = request.GetCtxValue[string](r.Context(), request.CtxForwardedUsername)
-
-	// Check for identity provider groups.
-	d.idpGroups, _ = request.GetCtxValue[[]string](r.Context(), request.CtxIdentityProviderGroups)
-	d.forwardedIDPGroups, _ = request.GetCtxValue[[]string](r.Context(), request.CtxForwardedIdentityProviderGroups)
-
-	// Check if the request is for all projects.
-	values, err := url.ParseQuery(r.URL.RawQuery)
-	if err != nil {
-		return nil, api.StatusErrorf(http.StatusBadRequest, "Failed to parse request query parameters: %w", err)
-	}
-
-	// Get project details.
-	d.isAllProjectsRequest = shared.IsTrue(values.Get("all-projects"))
-
-	return d, nil
 }
 
 // Driver returns the driver name.

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -118,35 +118,42 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, r *http.Request, 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	// Inspect request.
-	details, err := e.requestDetails(r)
-	if err != nil {
-		return fmt.Errorf("Failed to extract request details: %w", err)
-	}
-
 	// Untrusted requests are denied.
-	if !details.trusted {
+	if !auth.IsTrusted(ctx) {
 		return api.StatusErrorf(http.StatusForbidden, http.StatusText(http.StatusForbidden))
 	}
 
+	isRoot, err := auth.IsRootUserFromCtx(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to check caller privilege: %w", err)
+	}
+
 	// Cluster or unix socket requests have admin permission.
-	if details.isInternalOrUnix() {
+	if isRoot {
 		return nil
 	}
 
-	username := details.username()
-	protocol := details.authenticationProtocol()
+	username, err := auth.GetUsernameFromCtx(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get caller username: %w", err)
+	}
+
+	authenticationMethod, err := auth.GetAuthenticationMethodFromCtx(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get caller authentication method: %w", err)
+	}
+
 	logCtx["username"] = username
-	logCtx["protocol"] = protocol
+	logCtx["protocol"] = authenticationMethod
 	l := e.logger.AddContext(logCtx)
 
 	// If the authentication method was TLS, use the TLS driver instead.
-	if protocol == api.AuthenticationMethodTLS || protocol == auth.AuthenticationMethodPKI {
+	if authenticationMethod == api.AuthenticationMethodTLS || authenticationMethod == auth.AuthenticationMethodPKI {
 		return e.tlsAuthorizer.CheckPermission(ctx, r, entityURL, entitlement)
 	}
 
 	// Get the identity.
-	identityCacheEntry, err := e.identityCache.Get(protocol, username)
+	identityCacheEntry, err := e.identityCache.Get(authenticationMethod, username)
 	if err != nil {
 		return fmt.Errorf("Failed loading identity for %q: %w", username, err)
 	}
@@ -163,7 +170,11 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, r *http.Request, 
 
 	// Combine the users LXD groups with any mappings that have come from the IDP.
 	groups := identityCacheEntry.Groups
-	idpGroups := details.identityProviderGroups()
+	idpGroups, err := auth.GetIdentityProviderGroupsFromCtx(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get caller identity provider groups: %w", err)
+	}
+
 	for _, idpGroup := range idpGroups {
 		lxdGroups, err := e.identityCache.GetIdentityProviderGroupMapping(idpGroup)
 		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
@@ -185,7 +196,7 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, r *http.Request, 
 		return fmt.Errorf("Authorization driver failed to parse entity URL %q: %w", entityURL.String(), err)
 	}
 
-	userObject := fmt.Sprintf("%s:%s", entity.TypeIdentity, entity.IdentityURL(protocol, username).String())
+	userObject := fmt.Sprintf("%s:%s", entity.TypeIdentity, entity.IdentityURL(authenticationMethod, username).String())
 	entityObject := fmt.Sprintf("%s:%s", entityType, entityURL.String())
 
 	// Construct an OpenFGA check request.
@@ -308,35 +319,42 @@ func (e *embeddedOpenFGA) GetPermissionChecker(ctx context.Context, r *http.Requ
 		return nil, fmt.Errorf("Failed to get a permission checker: %w", err)
 	}
 
-	// Inspect request.
-	details, err := e.requestDetails(r)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to extract request details: %w", err)
-	}
-
 	// Untrusted requests are denied.
-	if !details.trusted {
+	if !auth.IsTrusted(ctx) {
 		return allowFunc(false), nil
 	}
 
+	isRoot, err := auth.IsRootUserFromCtx(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to check caller privilege: %w", err)
+	}
+
 	// Cluster or unix socket requests have admin permission.
-	if details.isInternalOrUnix() {
+	if isRoot {
 		return allowFunc(true), nil
 	}
 
-	username := details.username()
-	protocol := details.authenticationProtocol()
+	username, err := auth.GetUsernameFromCtx(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get caller username: %w", err)
+	}
+
+	authenticationMethod, err := auth.GetAuthenticationMethodFromCtx(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get caller authentication method: %w", err)
+	}
+
 	logCtx["username"] = username
-	logCtx["protocol"] = protocol
+	logCtx["protocol"] = authenticationMethod
 	l := e.logger.AddContext(logCtx)
 
 	// If the authentication method was TLS, use the TLS driver instead.
-	if protocol == api.AuthenticationMethodTLS || protocol == auth.AuthenticationMethodPKI {
+	if authenticationMethod == api.AuthenticationMethodTLS || authenticationMethod == auth.AuthenticationMethodPKI {
 		return e.tlsAuthorizer.GetPermissionChecker(ctx, r, entitlement, entityType)
 	}
 
 	// Get the identity.
-	identityCacheEntry, err := e.identityCache.Get(protocol, username)
+	identityCacheEntry, err := e.identityCache.Get(authenticationMethod, username)
 	if err != nil {
 		return nil, fmt.Errorf("Failed loading identity for %q: %w", username, err)
 	}
@@ -353,7 +371,11 @@ func (e *embeddedOpenFGA) GetPermissionChecker(ctx context.Context, r *http.Requ
 
 	// Combine the users LXD groups with any mappings that have come from the IDP.
 	groups := identityCacheEntry.Groups
-	idpGroups := details.identityProviderGroups()
+	idpGroups, err := auth.GetIdentityProviderGroupsFromCtx(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get caller identity provider groups: %w", err)
+	}
+
 	for _, idpGroup := range idpGroups {
 		lxdGroups, err := e.identityCache.GetIdentityProviderGroupMapping(idpGroup)
 		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
@@ -370,7 +392,7 @@ func (e *embeddedOpenFGA) GetPermissionChecker(ctx context.Context, r *http.Requ
 	}
 
 	// Construct an OpenFGA list objects request.
-	userObject := fmt.Sprintf("%s:%s", entity.TypeIdentity, entity.IdentityURL(protocol, username).String())
+	userObject := fmt.Sprintf("%s:%s", entity.TypeIdentity, entity.IdentityURL(authenticationMethod, username).String())
 	req := &openfgav1.ListObjectsRequest{
 		StoreId:  dummyDatastoreULID,
 		Type:     entityType.String(),

--- a/lxd/auth/types.go
+++ b/lxd/auth/types.go
@@ -36,8 +36,8 @@ type PermissionChecker func(entityURL *api.URL) bool
 type Authorizer interface {
 	Driver() string
 
-	CheckPermission(ctx context.Context, r *http.Request, entityURL *api.URL, entitlement Entitlement) error
-	GetPermissionChecker(ctx context.Context, r *http.Request, entitlement Entitlement, entityType entity.Type) (PermissionChecker, error)
+	CheckPermission(ctx context.Context, entityURL *api.URL, entitlement Entitlement) error
+	GetPermissionChecker(ctx context.Context, entitlement Entitlement, entityType entity.Type) (PermissionChecker, error)
 }
 
 // IsDeniedError returns true if the error is not found or forbidden. This is because the CheckPermission method on

--- a/lxd/auth/util.go
+++ b/lxd/auth/util.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -15,4 +17,92 @@ func ValidateAuthenticationMethod(authenticationMethod string) error {
 	}
 
 	return nil
+}
+
+// IsTrusted returns true if the value for `request.CtxTrusted` is set and is true.
+func IsTrusted(ctx context.Context) bool {
+	// The zero-value of a bool is false, so even if it isn't present in the context we'll return false.
+	// This will only return true when the value is present and is true.
+	trusted, _ := request.GetCtxValue[bool](ctx, request.CtxTrusted)
+	return trusted
+}
+
+// IsRootUserFromCtx inspects the context and returns true if the request was made from
+// the unix socket or initiated by another cluster member.
+func IsRootUserFromCtx(ctx context.Context) (bool, error) {
+	method, err := GetAuthenticationMethodFromCtx(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	// Unix and cluster requests have root access.
+	if method == AuthenticationMethodUnix || method == AuthenticationMethodCluster {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// GetUsernameFromCtx inspects the context and returns the username of the initial caller.
+// If the request was forwarded by another cluster member, we return the value for `request.CtxForwardedUsername`.
+// Otherwise, we return the value for `request.CtxUsername`.
+func GetUsernameFromCtx(ctx context.Context) (string, error) {
+	// Request protocol cannot be empty.
+	protocol, err := request.GetCtxValue[string](ctx, request.CtxProtocol)
+	if err != nil {
+		return "", api.StatusErrorf(http.StatusInternalServerError, "Failed getting protocol: %w", err)
+	}
+
+	// Username cannot be empty.
+	username, err := request.GetCtxValue[string](ctx, request.CtxUsername)
+	if err != nil {
+		return "", api.StatusErrorf(http.StatusInternalServerError, "Failed getting username: %w", err)
+	}
+
+	// Forwarded username can be empty.
+	forwardedUsername, _ := request.GetCtxValue[string](ctx, request.CtxForwardedUsername)
+
+	if protocol == AuthenticationMethodCluster && forwardedUsername != "" {
+		return forwardedUsername, nil
+	}
+
+	return username, nil
+}
+
+// GetAuthenticationMethodFromCtx gets the authentication method from the request context.
+// If the request was forwarded by another cluster member, the value for `request.CtxForwardedProtocol` is returned.
+// Otherwise, `request.CtxProtocol` is returned.
+func GetAuthenticationMethodFromCtx(ctx context.Context) (string, error) {
+	// Request protocol cannot be empty.
+	protocol, err := request.GetCtxValue[string](ctx, request.CtxProtocol)
+	if err != nil {
+		return "", api.StatusErrorf(http.StatusInternalServerError, "Failed getting protocol: %w", err)
+	}
+
+	// Forwarded protocol can be empty.
+	forwardedProtocol, _ := request.GetCtxValue[string](ctx, request.CtxForwardedProtocol)
+	if protocol == AuthenticationMethodCluster && forwardedProtocol != "" {
+		return forwardedProtocol, nil
+	}
+
+	return protocol, nil
+}
+
+// GetIdentityProviderGroupsFromCtx gets the identity provider groups from the request context if present.
+// If the request was forwarded by another cluster member, the value for `request.CtxForwardedIdentityProviderGroups` is
+// returned. Otherwise, the value for `request.CtxIdentityProviderGroups` is returned.
+func GetIdentityProviderGroupsFromCtx(ctx context.Context) ([]string, error) {
+	// Request protocol cannot be empty.
+	protocol, err := request.GetCtxValue[string](ctx, request.CtxProtocol)
+	if err != nil {
+		return nil, api.StatusErrorf(http.StatusInternalServerError, "Failed getting protocol: %w", err)
+	}
+
+	idpGroups, _ := request.GetCtxValue[[]string](ctx, request.CtxIdentityProviderGroups)
+	forwardedIDPGroups, _ := request.GetCtxValue[[]string](ctx, request.CtxForwardedIdentityProviderGroups)
+	if protocol == AuthenticationMethodCluster && forwardedIDPGroups != nil {
+		return forwardedIDPGroups, nil
+	}
+
+	return idpGroups, nil
 }

--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -164,17 +164,17 @@ func getAuthGroups(d *Daemon, r *http.Request) response.Response {
 	recursion := request.QueryParam(r, "recursion")
 	s := d.State()
 
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
 
-	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentity)
+	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentity)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
 
-	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
+	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
@@ -409,12 +409,12 @@ func getAuthGroup(d *Daemon, r *http.Request) response.Response {
 
 	var apiGroup *api.AuthGroup
 	s := d.State()
-	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentity)
+	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentity)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
 
-	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
+	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
@@ -486,12 +486,12 @@ func updateAuthGroup(d *Daemon, r *http.Request) response.Response {
 	defer cancel()
 
 	s := d.State()
-	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentity)
+	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentity)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
 
-	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
+	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
@@ -585,12 +585,12 @@ func patchAuthGroup(d *Daemon, r *http.Request) response.Response {
 	defer cancel()
 
 	s := d.State()
-	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentity)
+	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentity)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
 
-	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
+	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -134,7 +134,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 	s := d.State()
 
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeCertificate)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeCertificate)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -392,7 +392,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 
 	// Check if the caller has permission to create certificates.
 	var userCanCreateCertificates bool
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ServerURL(), auth.EntitlementCanCreateIdentities)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanCreateIdentities)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err == nil {
@@ -689,7 +689,7 @@ func certificateGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.CertificateURL(cert.Fingerprint), auth.EntitlementCanView)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.CertificateURL(cert.Fingerprint), auth.EntitlementCanView)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -848,7 +848,7 @@ func doCertificateUpdate(d *Daemon, dbInfo api.Certificate, req api.CertificateP
 	}
 
 	var userCanEditCertificate bool
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.CertificateURL(dbInfo.Fingerprint), auth.EntitlementCanEdit)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.CertificateURL(dbInfo.Fingerprint), auth.EntitlementCanEdit)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err == nil {
@@ -1003,7 +1003,7 @@ func certificateDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	var userCanEditCertificate bool
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.CertificateURL(certInfo.Fingerprint), auth.EntitlementCanDelete)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.CertificateURL(certInfo.Fingerprint), auth.EntitlementCanDelete)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err == nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -293,7 +293,7 @@ func allowPermission(entityType entity.Type, entitlement auth.Entitlement, muxVa
 		}
 
 		// Validate whether the user has the needed permission
-		err = s.Authorizer.CheckPermission(r.Context(), r, entityURL, entitlement)
+		err = s.Authorizer.CheckPermission(r.Context(), entityURL, entitlement)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -26,7 +26,7 @@ var privilegedEventTypes = []string{api.EventTypeLogging}
 var eventsCmd = APIEndpoint{
 	Path: "events",
 
-	Get: APIEndpointAction{Handler: eventsGet, AccessHandler: allowAuthenticated},
+	Get: APIEndpointAction{Handler: eventsGet, AccessHandler: allowProjectResourceList},
 }
 
 type eventsServe struct {

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -63,19 +63,19 @@ func eventsSocket(s *state.State, r *http.Request, w http.ResponseWriter) error 
 
 	var projectPermissionFunc auth.PermissionChecker
 	if projectName != "" {
-		err := s.Authorizer.CheckPermission(r.Context(), r, entity.ProjectURL(projectName), auth.EntitlementCanViewEvents)
+		err := s.Authorizer.CheckPermission(r.Context(), entity.ProjectURL(projectName), auth.EntitlementCanViewEvents)
 		if err != nil {
 			return err
 		}
 	} else if allProjects {
 		var err error
-		projectPermissionFunc, err = s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanViewEvents, entity.TypeProject)
+		projectPermissionFunc, err = s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanViewEvents, entity.TypeProject)
 		if err != nil {
 			return err
 		}
 	}
 
-	canViewPrivilegedEvents := s.Authorizer.CheckPermission(r.Context(), r, entity.ServerURL(), auth.EntitlementCanViewPrivilegedEvents) == nil
+	canViewPrivilegedEvents := s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanViewPrivilegedEvents) == nil
 
 	types := strings.Split(r.FormValue("type"), ",")
 	if len(types) == 1 && types[0] == "" {

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -99,7 +99,7 @@ func identityAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http
 			return response.SmartError(err)
 		}
 
-		err = s.Authorizer.CheckPermission(r.Context(), r, entity.IdentityURL(authenticationMethod, id.Identifier), entitlement)
+		err = s.Authorizer.CheckPermission(r.Context(), entity.IdentityURL(authenticationMethod, id.Identifier), entitlement)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -287,12 +287,12 @@ func getIdentities(d *Daemon, r *http.Request) response.Response {
 
 	recursion := r.URL.Query().Get("recursion")
 	s := d.State()
-	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentity)
+	canViewIdentity, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentity)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -424,7 +424,7 @@ func getIdentity(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -604,7 +604,7 @@ func updateIdentity(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -698,7 +698,7 @@ func patchIdentity(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/identity_provider_groups.go
+++ b/lxd/identity_provider_groups.go
@@ -145,12 +145,12 @@ func getIdentityProviderGroups(d *Daemon, r *http.Request) response.Response {
 	recursion := r.URL.Query().Get("recursion")
 	s := d.State()
 
-	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
+	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -240,7 +240,7 @@ func getIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -449,7 +449,7 @@ func updateIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -538,7 +538,7 @@ func patchIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
-	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeAuthGroup)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -974,7 +974,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
 
 	var userCanCreateImages bool
-	err := s.Authorizer.CheckPermission(r.Context(), r, entity.ProjectURL(projectName), auth.EntitlementCanCreateImages)
+	err := s.Authorizer.CheckPermission(r.Context(), entity.ProjectURL(projectName), auth.EntitlementCanCreateImages)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err == nil {
@@ -1639,7 +1639,7 @@ func imagesGet(d *Daemon, r *http.Request) response.Response {
 
 	// Get a permission checker. If the caller is not authenticated, the permission checker will deny all.
 	// However, the permission checker will not be called for public images.
-	canViewImage, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeImage)
+	canViewImage, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeImage)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3008,7 +3008,7 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	var userCanViewImage bool
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ImageURL(projectName, info.Fingerprint), auth.EntitlementCanView)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.ImageURL(projectName, info.Fingerprint), auth.EntitlementCanView)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err == nil {
@@ -3457,7 +3457,7 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeImageAlias)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeImageAlias)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("Failed to get a permission checker: %w", err))
 	}
@@ -3598,7 +3598,7 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	var userCanViewImageAlias bool
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ImageAliasURL(projectName, name), auth.EntitlementCanView)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.ImageAliasURL(projectName, name), auth.EntitlementCanView)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err == nil {
@@ -4024,7 +4024,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 
 	// Access control.
 	var userCanViewImage bool
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ImageURL(projectName, imgInfo.Fingerprint), auth.EntitlementCanView)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.ImageURL(projectName, imgInfo.Fingerprint), auth.EntitlementCanView)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err == nil {

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -324,7 +324,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		if req.Pool != "" || req.Project != "" {
 			// Check if user has access to target project.
 			if req.Project != "" {
-				err := s.Authorizer.CheckPermission(r.Context(), r, entity.ProjectURL(req.Project), auth.EntitlementCanCreateInstances)
+				err := s.Authorizer.CheckPermission(r.Context(), entity.ProjectURL(req.Project), auth.EntitlementCanCreateInstances)
 				if err != nil {
 					return response.SmartError(err)
 				}

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -34,9 +34,9 @@ var instancesCmd = APIEndpoint{
 		{Name: "vms", Path: "virtual-machines"},
 	},
 
-	Get:  APIEndpointAction{Handler: instancesGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: instancesGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: instancesPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateInstances)},
-	Put:  APIEndpointAction{Handler: instancesPut, AccessHandler: allowAuthenticated},
+	Put:  APIEndpointAction{Handler: instancesPut, AccessHandler: allowProjectResourceList},
 }
 
 var instanceCmd = APIEndpoint{

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -307,7 +307,7 @@ func doInstancesGet(s *state.State, r *http.Request) (any, error) {
 		return nil, err
 	}
 
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeInstance)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeInstance)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -97,7 +97,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 
 	action := instancetype.InstanceAction(req.State.Action)
 
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanUpdateState, entity.TypeInstance)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanUpdateState, entity.TypeInstance)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -168,7 +168,7 @@ func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	request.SetCtxValue(r, request.CtxEffectiveProjectName, projectName)
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeNetworkACL)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeNetworkACL)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -29,7 +29,7 @@ import (
 var networkACLsCmd = APIEndpoint{
 	Path: "network-acls",
 
-	Get:  APIEndpointAction{Handler: networkACLsGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: networkACLsGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: networkACLsPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateNetworkACLs)},
 }
 

--- a/lxd/network_allocations.go
+++ b/lxd/network_allocations.go
@@ -24,7 +24,7 @@ import (
 var networkAllocationsCmd = APIEndpoint{
 	Path: "network-allocations",
 
-	Get: APIEndpointAction{Handler: networkAllocationsGet, AccessHandler: allowAuthenticated},
+	Get: APIEndpointAction{Handler: networkAllocationsGet, AccessHandler: allowProjectResourceList},
 }
 
 // swagger:operation GET /1.0/network-allocations network-allocations network_allocations_get

--- a/lxd/network_allocations.go
+++ b/lxd/network_allocations.go
@@ -119,7 +119,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 
 	result := make([]api.NetworkAllocations, 0)
 
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeNetwork)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeNetwork)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -26,7 +26,7 @@ import (
 var networkZonesCmd = APIEndpoint{
 	Path: "network-zones",
 
-	Get:  APIEndpointAction{Handler: networkZonesGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: networkZonesGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: networkZonesPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateNetworkZones)},
 }
 

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -156,7 +156,7 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	request.SetCtxValue(r, request.CtxEffectiveProjectName, projectName)
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeNetworkZone)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeNetworkZone)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -211,7 +211,7 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeNetwork)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeNetwork)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -863,7 +863,7 @@ func doNetworkGet(s *state.State, r *http.Request, allNodes bool, projectName st
 		apiNet.Description = n.Description()
 		apiNet.Type = n.Type()
 
-		err = s.Authorizer.CheckPermission(r.Context(), r, entity.NetworkURL(projectName, networkName), auth.EntitlementCanEdit)
+		err = s.Authorizer.CheckPermission(r.Context(), entity.NetworkURL(projectName, networkName), auth.EntitlementCanEdit)
 		if err != nil && !auth.IsDeniedError(err) {
 			return api.Network{}, err
 		} else if err == nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -47,7 +47,7 @@ var networkCreateLock sync.Mutex
 var networksCmd = APIEndpoint{
 	Path: "networks",
 
-	Get:  APIEndpointAction{Handler: networksGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: networksGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: networksPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateNetworks)},
 }
 

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -277,7 +277,7 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 		for entityType, urls := range urlsByEntityType {
 			// If only one entry of this type, check directly.
 			if len(urls) == 1 {
-				err := s.Authorizer.CheckPermission(r.Context(), r, &urls[0], entitlement)
+				err := s.Authorizer.CheckPermission(r.Context(), &urls[0], entitlement)
 				if err != nil {
 					return response.SmartError(err)
 				}
@@ -286,7 +286,7 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Otherwise get a permission checker for the entity type.
-			hasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, entitlement, entityType)
+			hasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), entitlement, entityType)
 			if err != nil {
 				return response.SmartError(err)
 			}
@@ -518,7 +518,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		projectName = api.ProjectDefaultName
 	}
 
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanViewOperations, entity.TypeProject)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanViewOperations, entity.TypeProject)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("Failed to get operation permission checker: %w", err))
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -39,7 +39,7 @@ var operationCmd = APIEndpoint{
 var operationsCmd = APIEndpoint{
 	Path: "operations",
 
-	Get: APIEndpointAction{Handler: operationsGet, AccessHandler: allowAuthenticated},
+	Get: APIEndpointAction{Handler: operationsGet, AccessHandler: allowProjectResourceList},
 }
 
 var operationWait = APIEndpoint{

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -153,7 +153,7 @@ func profilesGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 
 	request.SetCtxValue(r, request.CtxEffectiveProjectName, p.Name)
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeProfile)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeProfile)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -36,7 +36,7 @@ import (
 var profilesCmd = APIEndpoint{
 	Path: "profiles",
 
-	Get:  APIEndpointAction{Handler: profilesGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: profilesGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: profilesPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateProfiles)},
 }
 

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1510,7 +1510,7 @@ func FilterUsedBy(authorizer auth.Authorizer, r *http.Request, entries []string)
 	for entityType, urls := range urlsByEntityType {
 		// If only one entry of this type, check directly.
 		if len(urls) == 1 {
-			err := authorizer.CheckPermission(r.Context(), r, urls[0], auth.EntitlementCanView)
+			err := authorizer.CheckPermission(r.Context(), urls[0], auth.EntitlementCanView)
 			if err != nil {
 				continue
 			}
@@ -1520,7 +1520,7 @@ func FilterUsedBy(authorizer auth.Authorizer, r *http.Request, entries []string)
 		}
 
 		// Otherwise get a permission checker for the entity type.
-		canViewEntity, err := authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entityType)
+		canViewEntity, err := authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entityType)
 		if err != nil {
 			logger.Error("Failed to get permission checker for project used-by filtering", logger.Ctx{"entity_type": entityType, "err": err})
 			continue
@@ -1559,7 +1559,7 @@ func projectHasRestriction(project *api.Project, restrictionKey string, blockVal
 func CheckClusterTargetRestriction(authorizer auth.Authorizer, r *http.Request, project *api.Project, targetFlag string) error {
 	if projectHasRestriction(project, "restricted.cluster.target", "block") && targetFlag != "" {
 		// Allow server administrators to move instances around even when restricted (node evacuation, ...)
-		err := authorizer.CheckPermission(r.Context(), r, entity.ServerURL(), auth.EntitlementCanOverrideClusterTargetRestriction)
+		err := authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanOverrideClusterTargetRestriction)
 		if err != nil && auth.IsDeniedError(err) {
 			return api.StatusErrorf(http.StatusForbidden, "This project doesn't allow cluster member targeting")
 		} else if err != nil {

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -27,7 +27,7 @@ import (
 var storagePoolBucketsCmd = APIEndpoint{
 	Path: "storage-pools/{poolName}/buckets",
 
-	Get:  APIEndpointAction{Handler: storagePoolBucketsGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: storagePoolBucketsGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: storagePoolBucketsPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateStorageBuckets)},
 }
 

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -196,7 +196,7 @@ func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	request.SetCtxValue(r, request.CtxEffectiveProjectName, bucketProjectName)
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeStorageBucket)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeStorageBucket)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -160,7 +160,7 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	hasEditPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanEdit, entity.TypeStoragePool)
+	hasEditPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanEdit, entity.TypeStoragePool)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -631,7 +631,7 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 	poolAPI := pool.ToAPI()
 	poolAPI.UsedBy = project.FilterUsedBy(s.Authorizer, r, poolUsedBy)
 
-	err = s.Authorizer.CheckPermission(r.Context(), r, entity.StoragePoolURL(poolName), auth.EntitlementCanEdit)
+	err = s.Authorizer.CheckPermission(r.Context(), entity.StoragePoolURL(poolName), auth.EntitlementCanEdit)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err != nil {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -47,26 +47,26 @@ import (
 var storageVolumesCmd = APIEndpoint{
 	Path: "storage-volumes",
 
-	Get: APIEndpointAction{Handler: storagePoolVolumesGet, AccessHandler: allowAuthenticated},
+	Get: APIEndpointAction{Handler: storagePoolVolumesGet, AccessHandler: allowProjectResourceList},
 }
 
 var storageVolumesTypeCmd = APIEndpoint{
 	Path: "storage-volumes/{type}",
 
-	Get: APIEndpointAction{Handler: storagePoolVolumesGet, AccessHandler: allowAuthenticated},
+	Get: APIEndpointAction{Handler: storagePoolVolumesGet, AccessHandler: allowProjectResourceList},
 }
 
 var storagePoolVolumesCmd = APIEndpoint{
 	Path: "storage-pools/{poolName}/volumes",
 
-	Get:  APIEndpointAction{Handler: storagePoolVolumesGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: storagePoolVolumesGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: storagePoolVolumesPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateStorageVolumes)},
 }
 
 var storagePoolVolumesTypeCmd = APIEndpoint{
 	Path: "storage-pools/{poolName}/volumes/{type}",
 
-	Get:  APIEndpointAction{Handler: storagePoolVolumesGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: storagePoolVolumesGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: storagePoolVolumesPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateStorageVolumes)},
 }
 

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -745,7 +745,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 		request.SetCtxValue(r, request.CtxEffectiveProjectName, customVolProjectName)
 	}
 
-	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeStorageVolume)
+	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeStorageVolume)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1380,7 +1380,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Check if user has access to effective storage target project
-		err := s.Authorizer.CheckPermission(r.Context(), r, entity.ProjectURL(targetProjectName), auth.EntitlementCanCreateStorageVolumes)
+		err := s.Authorizer.CheckPermission(r.Context(), entity.ProjectURL(targetProjectName), auth.EntitlementCanCreateStorageVolumes)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/test/suites/pki.sh
+++ b/test/suites/pki.sh
@@ -25,7 +25,8 @@ test_pki() {
         ./easyrsa init-pki
         echo "lxd" | ./easyrsa build-ca nopass
         ./easyrsa gen-crl
-        ./easyrsa build-client-full lxd-client nopass
+        ./easyrsa build-client-full restricted nopass
+        ./easyrsa build-client-full unrestricted nopass
         ./easyrsa build-client-full ca-trusted nopass
         ./easyrsa build-client-full prior-revoked nopass
         mkdir keys
@@ -63,11 +64,11 @@ test_pki() {
     # shellcheck disable=2030
     export LXD_CONF="${LXC5_DIR}"
 
-    ### CA signed certificate with `core.trust_ca_certificates` disabled.
+    ### Unrestricted CA signed client certificate with `core.trust_ca_certificates` disabled.
 
     # Set up the client config
-    cp "${TEST_DIR}/pki/keys/lxd-client.crt" "${LXD_CONF}/client.crt"
-    cp "${TEST_DIR}/pki/keys/lxd-client.key" "${LXD_CONF}/client.key"
+    cp "${TEST_DIR}/pki/keys/unrestricted.crt" "${LXD_CONF}/client.crt"
+    cp "${TEST_DIR}/pki/keys/unrestricted.key" "${LXD_CONF}/client.key"
     cp "${TEST_DIR}/pki/keys/ca.crt" "${LXD_CONF}/client.ca"
     cat "${LXD_CONF}/client.crt" "${LXD_CONF}/client.key" > "${LXD_CONF}/client.pem"
 
@@ -81,14 +82,14 @@ test_pki() {
     lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --token "${token}"
 
     # Should have trust store entry because `core.trust_ca_certificates` is disabled.
-    lxc_remote config trust ls pki-lxd: | grep lxd-client
+    lxc_remote config trust ls pki-lxd: | grep -wF unrestricted
 
-    # Should be able to view server config
+    # The certificate was not restricted, so should be able to view server config
     lxc_remote info pki-lxd: | grep -F 'core.https_address'
     curl -s --cert "${LXD_CONF}/client.pem" --cacert "${LXD5_DIR}/server.crt" "https://${LXD5_ADDR}/1.0" | jq -e '.metadata.config."core.https_address"'
 
     # Revoke the client certificate
-    cd "${TEST_DIR}/pki" && "${TEST_DIR}/pki/easyrsa" --batch revoke lxd-client keyCompromise && "${TEST_DIR}/pki/easyrsa" gen-crl && cd -
+    cd "${TEST_DIR}/pki" && "${TEST_DIR}/pki/easyrsa" --batch revoke unrestricted keyCompromise && "${TEST_DIR}/pki/easyrsa" gen-crl && cd -
 
     # Restart LXD with the revoked certificate in the CRL.
     shutdown_lxd "${LXD5_DIR}"
@@ -105,6 +106,66 @@ test_pki() {
     LXD_DIR="${LXD5_DIR}" lxc config trust remove "${fingerprint}"
     lxc_remote remote remove pki-lxd
 
+    # The certificate is now revoked, we shouldn't be able to re-add it.
+    token="$(LXD_DIR=${LXD5_DIR} lxc config trust add --name foo -q)"
+    ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --token "${token}" || false
+    ! lxc config trust ls | grep -wF unrestricted || false
+
+    ### Restricted CA signed client certificate with `core.trust_ca_certificates` disabled.
+
+    # Set up the client config
+    cp "${TEST_DIR}/pki/keys/restricted.crt" "${LXD_CONF}/client.crt"
+    cp "${TEST_DIR}/pki/keys/restricted.key" "${LXD_CONF}/client.key"
+    cat "${LXD_CONF}/client.crt" "${LXD_CONF}/client.key" > "${LXD_CONF}/client.pem"
+
+    # Try adding remote using an incorrect token. This should fail even though the client certificate
+    # has been signed by the CA because `core.trust_ca_certificates` is not enabled.
+    ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --token=bar || false
+
+    # Add remote using the correct token (restricted).
+    # This should work because the client certificate is signed by the CA.
+    token="$(LXD_DIR=${LXD5_DIR} lxc config trust add --name foo --quiet --restricted)"
+    lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --token "${token}"
+
+    # Should have a trust store entry because `core.trust_ca_certificates` is disabled.
+    lxc_remote config trust ls pki-lxd: | grep -wF restricted
+
+    # The certificate was restricted, so should not be able to view server config
+    ! lxc_remote info pki-lxd: | grep -F 'core.https_address' || false
+    ! curl -s --cert "${LXD_CONF}/client.pem" --cacert "${LXD5_DIR}/server.crt" "https://${LXD5_ADDR}/1.0" | jq -e '.metadata.config."core.https_address"' || false
+
+    # Enable `core.trust_ca_certificates`.
+    LXD_DIR=${LXD5_DIR} lxc config set core.trust_ca_certificates true
+
+    # The certificate was restricted, so should not be able to view server config even though `core.trust_ca_certificates` is now enabled.
+    ! lxc_remote info pki-lxd: | grep -F 'core.https_address' || false
+    ! curl -s --cert "${LXD_CONF}/client.pem" --cacert "${LXD5_DIR}/server.crt" "https://${LXD5_ADDR}/1.0" | jq -e '.metadata.config."core.https_address"' || false
+
+    # Revoke the client certificate
+    cd "${TEST_DIR}/pki" && "${TEST_DIR}/pki/easyrsa" --batch revoke restricted keyCompromise && "${TEST_DIR}/pki/easyrsa" gen-crl && cd -
+
+    # Restart LXD with the revoked certificate in the CRL.
+    shutdown_lxd "${LXD5_DIR}"
+    cp "${TEST_DIR}/pki/pki/crl.pem" "${LXD5_DIR}/ca.crl"
+    respawn_lxd "${LXD5_DIR}" true
+
+    # Revoked certificate no longer has access even though it is in the trust store.
+    lxc_remote info pki-lxd: | grep -F 'auth: untrusted'
+    ! lxc_remote ls pki-lxd: || false
+    [ "$(curl -s --cert "${LXD_CONF}/client.pem" --cacert "${LXD5_DIR}/server.crt" "https://${LXD5_ADDR}/1.0/instances" | jq -e -r '.error')" = "not authorized" ]
+
+    # Remove cert from truststore.
+    fingerprint="$(cert_fingerprint "${LXD_CONF}/client.crt")"
+    LXD_DIR="${LXD5_DIR}" lxc config trust remove "${fingerprint}"
+    lxc_remote remote remove pki-lxd
+
+    # Unset `core.trust_ca_certificates`.
+    LXD_DIR=${LXD5_DIR} lxc config unset core.trust_ca_certificates
+
+    # The certificate is now revoked, we shouldn't be able to re-add it.
+    token="$(LXD_DIR=${LXD5_DIR} lxc config trust add --name foo -q)"
+    ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --token "${token}" || false
+    ! lxc config trust ls | grep -wF restricted || false
 
     ### CA signed certificate with `core.trust_ca_certificates` enabled.
 
@@ -123,7 +184,7 @@ test_pki() {
     lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate
 
     # Client cert should not be present in trust store.
-    ! lxc_remote config trust ls pki-lxd: | grep ca-trusted || false
+    ! lxc_remote config trust ls pki-lxd: | grep -wF ca-trusted || false
 
     # Remove remote
     lxc_remote remote remove pki-lxd
@@ -133,7 +194,7 @@ test_pki() {
     lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --token=bar
 
     # Client cert should not be present in trust store.
-    ! lxc_remote config trust ls pki-lxd: | grep ca-trusted || false
+    ! lxc_remote config trust ls pki-lxd: | grep -wF ca-trusted || false
 
     # The certificate is trusted as root because `core.trust_ca_certificates` is enabled.
     lxc_remote info pki-lxd: | grep -F 'core.https_address'
@@ -177,7 +238,7 @@ test_pki() {
     # This should fail, and the revoked certificate should not be added to the trust store.
     token="$(LXD_DIR=${LXD5_DIR} lxc config trust add --name foo -q)"
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --token "${token}" || false
-    ! lxc config trust ls | grep prior-revoked || false
+    ! lxc config trust ls | grep -wF prior-revoked || false
 
     # Try adding a remote using a revoked client certificate, and an incorrect token.
     # This should fail, as if the certificate is revoked and token is wrong then no access should be allowed.
@@ -190,7 +251,7 @@ test_pki() {
     # This should fail, and the revoked certificate should not be added to the trust store.
     token="$(LXD_DIR=${LXD5_DIR} lxc config trust add --name foo -q)"
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --token "${token}" || false
-    ! lxc config trust ls | grep prior-revoked || false
+    ! lxc config trust ls | grep -wF prior-revoked || false
 
     # Try adding a remote using a revoked client certificate, and an incorrect token.
     # This should fail, as if the certificate is revoked and token is wrong then no access should be allowed.

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -106,9 +106,8 @@ test_remote_url_with_token() {
   # Check if we can see instances in the foo project
   [ "$(curl -k -s --key "${TEST_DIR}/token-client.key" --cert "${TEST_DIR}/token-client.crt" "https://${LXD_ADDR}/1.0/instances?project=foo" | jq '.status_code')" -eq 200 ]
 
-  # Check if we can see instances in the default project (this should succeed but the instance list should be empty)
-  [ "$(curl -k -s --key "${TEST_DIR}/token-client.key" --cert "${TEST_DIR}/token-client.crt" "https://${LXD_ADDR}/1.0/instances" | jq '.status_code')" -eq 200 ]
-  [ "$(curl -k -s --key "${TEST_DIR}/token-client.key" --cert "${TEST_DIR}/token-client.crt" "https://${LXD_ADDR}/1.0/instances" | jq '.metadata')" = '[]' ]
+  # Check if we can see instances in the default project (this should fail)
+  [ "$(curl -k -s --key "${TEST_DIR}/token-client.key" --cert "${TEST_DIR}/token-client.crt" "https://${LXD_ADDR}/1.0/instances" | jq '.error_code')" -eq 403 ]
 
   lxc config trust rm "$(lxc config trust list -f json | jq -r '.[].fingerprint')"
 

--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -51,6 +51,19 @@ test_tls_restrictions() {
   # Validate restricted caller cannot create projects.
   ! lxc_remote project create localhost:blah1 || false
 
+  # Validate restricted caller cannot list resources in projects they do not have access to
+  ! lxc_remote list localhost: --project default || false
+  ! lxc_remote profile list localhost: --project default || false
+  ! lxc_remote network list localhost: --project default || false
+  ! lxc_remote operation list localhost: --project default || false
+  ! lxc_remote network zone list localhost: --project default || false
+  ! lxc_remote storage volume list "localhost:${pool_name}" --project default || false
+  ! lxc_remote storage bucket list "localhost:${pool_name}" --project default || false
+
+  # Can still list images as some may be public. There are no public images in the default project now,
+  # so the list should be empty
+  [ "$(lxc_remote image list localhost --project default --format csv)" = "" ]
+
   # Set up the test image in the blah project (ensure_import_testimage imports the image into the current project).
   lxc project switch blah && ensure_import_testimage && lxc project switch default
 


### PR DESCRIPTION
The following changes have been made:
1. Remove the `requestDetails` struct and associated methods from the `lxd/auth/drivers` package. These have been moved to a set of utlils under `lxd/auth`.
2. Refactor the auth drivers to use the new utils.
3. Add an access handler to be used when listing resources within a project. This access handler checks if the caller is restricted, and disallows requests to projects that the caller does not have access to, as well as disallowing usage of the `all-projects` query parameter.
4. Set the new access handler on all project specific resource list endpoints (please double check this).
5. Refactors the `Authorizer` interface to remove the `*http.Request` parameter. This led to the authorizer over-extending it's intended functionality and causing bugs.