### PR TITLE
Auth: Use util for determining if the caller is a server administrator

### DIFF
--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -207,15 +207,6 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 		})
 	}
 
-	// For each project, append a contextual tuple to set make the identity an operator of that project (TLS authorization compatibility).
-	for _, projectName := range identityCacheEntry.Projects {
-		req.ContextualTuples.TupleKeys = append(req.ContextualTuples.TupleKeys, &openfgav1.TupleKey{
-			User:     userObject,
-			Relation: string(auth.EntitlementOperator),
-			Object:   fmt.Sprintf("%s:%s", entity.TypeProject, entity.ProjectURL(projectName).String()),
-		})
-	}
-
 	// Perform the check.
 	l.Debug("Checking OpenFGA relation")
 	resp, err := e.server.Check(ctx, req)
@@ -374,15 +365,6 @@ func (e *embeddedOpenFGA) GetPermissionChecker(ctx context.Context, entitlement 
 			User:     userObject,
 			Relation: "member",
 			Object:   fmt.Sprintf("%s:%s", entity.TypeAuthGroup, entity.AuthGroupURL(groupName).String()),
-		})
-	}
-
-	// For each project, append a contextual tuple to set make the identity an operator of that project (TLS authorization compatibility).
-	for _, projectName := range identityCacheEntry.Projects {
-		req.ContextualTuples.TupleKeys = append(req.ContextualTuples.TupleKeys, &openfgav1.TupleKey{
-			User:     userObject,
-			Relation: string(auth.EntitlementOperator),
-			Object:   fmt.Sprintf("%s:%s", entity.TypeProject, entity.ProjectURL(projectName).String()),
 		})
 	}
 

--- a/lxd/auth/util.go
+++ b/lxd/auth/util.go
@@ -7,19 +7,8 @@ import (
 
 	"github.com/canonical/lxd/lxd/identity"
 	"github.com/canonical/lxd/lxd/request"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 )
-
-// ValidateAuthenticationMethod returns an api.StatusError with http.StatusBadRequest if the given authentication
-// method is not recognised.
-func ValidateAuthenticationMethod(authenticationMethod string) error {
-	if !shared.ValueInSlice(authenticationMethod, []string{api.AuthenticationMethodTLS, api.AuthenticationMethodOIDC}) {
-		return api.StatusErrorf(http.StatusBadRequest, "Unrecognized authentication method %q", authenticationMethod)
-	}
-
-	return nil
-}
 
 // IsTrusted returns true if the value for `request.CtxTrusted` is set and is true.
 func IsTrusted(ctx context.Context) bool {

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -75,7 +75,7 @@ func identityAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http
 	return func(d *Daemon, r *http.Request) response.Response {
 		muxVars := mux.Vars(r)
 		authenticationMethod := muxVars["authenticationMethod"]
-		err := auth.ValidateAuthenticationMethod(authenticationMethod)
+		err := identity.ValidateAuthenticationMethod(authenticationMethod)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -279,7 +279,7 @@ func getIdentities(d *Daemon, r *http.Request) response.Response {
 	if authenticationMethod == "current" {
 		return getCurrentIdentityInfo(d, r)
 	} else if authenticationMethod != "" {
-		err = auth.ValidateAuthenticationMethod(authenticationMethod)
+		err = identity.ValidateAuthenticationMethod(authenticationMethod)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -492,7 +492,7 @@ func getCurrentIdentityInfo(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Must be a remote API request.
-	err = auth.ValidateAuthenticationMethod(protocol)
+	err = identity.ValidateAuthenticationMethod(protocol)
 	if err != nil {
 		return response.BadRequest(fmt.Errorf("Current identity information must be requested via the HTTPS API"))
 	}

--- a/lxd/identity/cache.go
+++ b/lxd/identity/cache.go
@@ -42,6 +42,11 @@ func (c *Cache) Get(authenticationMethod string, identifier string) (*CacheEntry
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	err := ValidateAuthenticationMethod(authenticationMethod)
+	if err != nil {
+		return nil, err
+	}
+
 	if c.entries == nil {
 		return nil, api.StatusErrorf(http.StatusNotFound, "Identity %q (%s) not found", identifier, authenticationMethod)
 	}
@@ -115,6 +120,11 @@ func (c *Cache) ReplaceAll(entries []CacheEntry, idpGroups map[string][]string) 
 
 	c.entries = make(map[string]map[string]*CacheEntry)
 	for _, entry := range entries {
+		err := ValidateAuthenticationMethod(entry.AuthenticationMethod)
+		if err != nil {
+			return err
+		}
+
 		if entry.AuthenticationMethod == api.AuthenticationMethodTLS && entry.Certificate == nil {
 			return fmt.Errorf("Identity cache entries of type %q must have a certificate", api.AuthenticationMethodTLS)
 		}

--- a/lxd/identity/util.go
+++ b/lxd/identity/util.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -29,4 +30,14 @@ func AuthenticationMethodFromIdentityType(identityType string) (string, error) {
 	}
 
 	return "", fmt.Errorf("Identity type %q not recognized", identityType)
+}
+
+// ValidateAuthenticationMethod returns an api.StatusError with http.StatusBadRequest if the given authentication
+// method is not recognised.
+func ValidateAuthenticationMethod(authenticationMethod string) error {
+	if !shared.ValueInSlice(authenticationMethod, []string{api.AuthenticationMethodTLS, api.AuthenticationMethodOIDC}) {
+		return api.StatusErrorf(http.StatusBadRequest, "Unrecognized authentication method %q", authenticationMethod)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This avoids repeating similar logic in multiple places by additionally checking the identity cache for unrestricted clients when checking for admin privileges. See https://github.com/canonical/lxd/pull/13702#discussion_r1665955250