### PR TITLE
test/main: don't check for xgettext command

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -40,7 +40,7 @@ import_subdir_files() {
 import_subdir_files includes
 
 echo "==> Checking for dependencies"
-check_dependencies lxd lxc curl dnsmasq jq git xgettext sqlite3 msgmerge msgfmt shuf setfacl socat dig
+check_dependencies lxd lxc curl dnsmasq jq git sqlite3 msgmerge msgfmt shuf setfacl socat dig
 
 if [ "${USER:-'root'}" != "root" ]; then
   echo "The testsuite must be run as root." >&2


### PR DESCRIPTION
The command xgettext is not used, only xgettext-go is but that's a different
thing.

The xgettext command comes from the gettext package which also provides
some other commands that are actually used like msgmerge and msgfmt. As such,
the list of dependencies to install remains unchanged.