### PR TITLE
Update short description for the OIDC groups claim

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -4686,7 +4686,7 @@ This value is required by some providers.
 
 ```{config:option} oidc.groups.claim server-oidc
 :scope: "global"
-:shortdesc: "Expected audience value for the application"
+:shortdesc: "A claim used for mapping identity provider groups to LXD groups."
 :type: "string"
 Specify a custom claim to be requested when performing OIDC flows.
 Configure a corresponding custom claim in your identity provider and

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -687,7 +687,7 @@ var ConfigSchema = config.Schema{
 	// ---
 	//  type: string
 	//  scope: global
-	//  shortdesc: Expected audience value for the application
+	//  shortdesc: A claim used for mapping identity provider groups to LXD groups.
 	"oidc.groups.claim": {},
 	// OVN networking global keys.
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5317,7 +5317,7 @@
 						"oidc.groups.claim": {
 							"longdesc": "Specify a custom claim to be requested when performing OIDC flows.\nConfigure a corresponding custom claim in your identity provider and\nadd organization level groups to it. These can be mapped to LXD groups\nfor automatic access control.",
 							"scope": "global",
-							"shortdesc": "Expected audience value for the application",
+							"shortdesc": "A claim used for mapping identity provider groups to LXD groups.",
 							"type": "string"
 						}
 					},


### PR DESCRIPTION
The short description was missed when copying the metadata format from the audience key.