### PR TITLE
Add number of cpu cores to cluster member state response

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -597,6 +597,10 @@ definitions:
                     type: number
                 type: array
                 x-go-name: LoadAverages
+            num_cpu:
+                format: int64
+                type: integer
+                x-go-name: NumCPU
             processes:
                 format: uint16
                 type: integer

--- a/lxd/cluster/member_state.go
+++ b/lxd/cluster/member_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -106,6 +107,8 @@ func MemberState(ctx context.Context, s *state.State, memberName string) (*api.C
 			ResourcesStoragePool: *res,
 		}
 	}
+
+	memberState.SysInfo.NumCPU = runtime.NumCPU()
 
 	return &memberState, nil
 }

--- a/shared/api/cluster_state.go
+++ b/shared/api/cluster_state.go
@@ -15,6 +15,7 @@ type ClusterMemberSysInfo struct {
 	TotalSwap    uint64    `json:"total_swap" yaml:"total_swap"`
 	FreeSwap     uint64    `json:"free_swap" yaml:"free_swap"`
 	Processes    uint16    `json:"processes" yaml:"processes"`
+	NumCPU       int       `json:"num_cpu" yaml:"num_cpu"`
 }
 
 // ClusterMemberState represents the state of a cluster member.


### PR DESCRIPTION
This adds a field `num_cpu` with the number of CPU cores to the cluster member state response.