### PR TITLE
lxd/instance/exec: Only use keepalives on TCP sockets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/securecookie v1.1.2
-	github.com/gorilla/websocket v1.5.3
+	github.com/gorilla/websocket v1.5.1
 	github.com/gosexy/gettext v0.0.0-20160830220431-74466a0a0c4a
 	github.com/j-keck/arping v1.0.3
 	github.com/jaypipes/pcidb v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,8 @@ github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosexy/gettext v0.0.0-20160830220431-74466a0a0c4a h1:N2b2mb4Gki1SlF3WuhR9P1YHOpl7oy/b+xxX4A3iM2E=

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -100,23 +100,23 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 					if err != nil {
 						logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 					}
-				}
 
-				// Start channel keep alive to run until channel is closed.
-				go func() {
-					pingInterval := time.Second * 10
-					t := time.NewTicker(pingInterval)
-					defer t.Stop()
+					// Start channel keep alive to run until channel is closed.
+					go func() {
+						pingInterval := time.Second * 10
+						t := time.NewTicker(pingInterval)
+						defer t.Stop()
 
-					for {
-						err := conn.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
-						if err != nil {
-							return
+						for {
+							err := conn.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
+							if err != nil {
+								return
+							}
+
+							<-t.C
 						}
-
-						<-t.C
-					}
-				}()
+					}()
+				}
 
 				if fd == execWSControl {
 					s.waitControlConnected.Cancel() // Control connection connected.

--- a/test/godeps/client.list
+++ b/test/godeps/client.list
@@ -58,6 +58,8 @@ golang.org/x/crypto/internal/poly1305
 golang.org/x/crypto/pbkdf2
 golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
+golang.org/x/net/internal/socks
+golang.org/x/net/proxy
 golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials
 golang.org/x/oauth2/internal

--- a/test/godeps/lxc-config.list
+++ b/test/godeps/lxc-config.list
@@ -59,6 +59,8 @@ golang.org/x/crypto/internal/poly1305
 golang.org/x/crypto/pbkdf2
 golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
+golang.org/x/net/internal/socks
+golang.org/x/net/proxy
 golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials
 golang.org/x/oauth2/internal

--- a/test/godeps/lxd-agent.list
+++ b/test/godeps/lxd-agent.list
@@ -206,9 +206,11 @@ golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/iana
 golang.org/x/net/internal/socket
+golang.org/x/net/internal/socks
 golang.org/x/net/internal/timeseries
 golang.org/x/net/ipv4
 golang.org/x/net/ipv6
+golang.org/x/net/proxy
 golang.org/x/net/trace
 golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials


### PR DESCRIPTION
Also restore websocket package to latest non-pre release version.

This is to try workaround recently started "Error: websocket: close 1006 (abnormal closure): unexpected EOF" errors on riscv64 builders with LXD 6.1.