### PR TITLE
Test certificate add token remote operation

### DIFF
--- a/test/includes/uuid.sh
+++ b/test/includes/uuid.sh
@@ -1,0 +1,6 @@
+# shellcheck shell=sh
+is_uuid_v4() {
+  # Case insensitive match for a v4 UUID. The third group must start with 4, and the fourth group must start with 8, 9,
+  # a, or b. This accounts for the version and variant. See https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-4.
+  printf '%s' "${1}" | grep --ignore-case '^[0-9a-f]\{8\}-[0-9a-f]\{4\}-4[0-9a-f]\{3\}-[89ab][0-9a-f]\{3\}-[0-9a-f]\{12\}$'
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -257,6 +257,7 @@ if [ "${1:-"all"}" != "standalone" ]; then
     run_test test_clustering_groups "clustering groups"
     run_test test_clustering_events "clustering events"
     run_test test_clustering_uuid "clustering uuid"
+    run_test test_clustering_trust_add "clustering trust add"
 fi
 
 if [ "${1:-"all"}" != "cluster" ]; then


### PR DESCRIPTION
Tests the case where a certificate add operation is running on cluster member A, but the `POST /1.0/certificates` request containing the join token is sent to cluster member B.
