### PR TITLE
test: replace many `grep -Fx` by shell comparison

### DIFF
--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -101,7 +101,7 @@ EOF
     lxc start c1
     lxc exec c1 --project test -- mount | grep /mnt
     echo "hello world" | lxc exec c1 --project test -- tee /mnt/test.txt
-    lxc exec c1 --project test -- grep -xF "hello world" /mnt/test.txt
+    [ "$(lxc exec c1 --project test -- cat /mnt/test.txt)" = "hello world" ]
     lxc stop -f c1
     lxc snapshot c1
     lxc info c1
@@ -187,7 +187,7 @@ EOF
 
     # Check custom volume accessible.
     lxc exec c1 --project test -- mount | grep /mnt
-    lxc exec c1 --project test -- grep -xF "hello world" /mnt/test.txt
+    [ "$(lxc exec c1 --project test -- cat /mnt/test.txt)" = "hello world" ]
 
     # Check snashot can be restored.
     lxc restore c1 snap0
@@ -475,9 +475,9 @@ _backup_import_with_project() {
 
   lxc import "${LXD_DIR}/c1-foo.tar.gz"
   lxc storage volume ls "${default_pool}"
-  lxc storage volume get "${default_pool}" container/c1-foo user.foo | grep -Fx "post-c1-foo-snap1"
-  lxc storage volume get "${default_pool}" container/c1-foo/c1-foo-snap0 user.foo | grep -Fx "c1-foo-snap0"
-  lxc storage volume get "${default_pool}" container/c1-foo/c1-foo-snap1 user.foo | grep -Fx "c1-foo-snap1"
+  [ "$(lxc storage volume get "${default_pool}" container/c1-foo user.foo)" = "post-c1-foo-snap1" ]
+  [ "$(lxc storage volume get "${default_pool}" container/c1-foo/c1-foo-snap0 user.foo)" = "c1-foo-snap0" ]
+  [ "$(lxc storage volume get "${default_pool}" container/c1-foo/c1-foo-snap1 user.foo)" = "c1-foo-snap1" ]
   lxc delete --force c1-foo
 
   # Create new storage pools
@@ -792,10 +792,10 @@ _backup_volume_export_with_project() {
   lxc storage volume delete "${custom_vol_pool}" testvol
   lxc storage volume import "${custom_vol_pool}" "${LXD_DIR}/testvol.tar.gz"
   lxc storage volume ls "${custom_vol_pool}"
-  lxc storage volume get "${custom_vol_pool}" testvol user.foo | grep -Fx "post-test-snap1"
+  [ "$(lxc storage volume get "${custom_vol_pool}" testvol user.foo)" = "post-test-snap1" ]
   lxc storage volume show "${custom_vol_pool}" testvol/test-snap0
-  lxc storage volume get "${custom_vol_pool}" testvol/test-snap0 user.foo | grep -Fx "test-snap0"
-  lxc storage volume get "${custom_vol_pool}" testvol/test-snap1 user.foo | grep -Fx "test-snap1"
+  [ "$(lxc storage volume get "${custom_vol_pool}" testvol/test-snap0 user.foo)" = "test-snap0" ]
+  [ "$(lxc storage volume get "${custom_vol_pool}" testvol/test-snap1 user.foo)" = "test-snap1" ]
 
   # Check if the imported volume and its snapshots have a new UUID.
   [ -n "$(lxc storage volume get "${custom_vol_pool}" testvol volatile.uuid)" ]
@@ -829,9 +829,9 @@ _backup_volume_export_with_project() {
     lxc storage volume delete "${custom_vol_pool}" testvol2
     lxc storage volume import "${custom_vol_pool}" "${LXD_DIR}/testvol-optimized.tar.gz"
     lxc storage volume ls "${custom_vol_pool}"
-    lxc storage volume get "${custom_vol_pool}" testvol user.foo | grep -Fx "post-test-snap1"
-    lxc storage volume get "${custom_vol_pool}" testvol/test-snap0 user.foo | grep -Fx "test-snap0"
-    lxc storage volume get "${custom_vol_pool}" testvol/test-snap1 user.foo | grep -Fx "test-snap1"
+    [ "$(lxc storage volume get "${custom_vol_pool}" testvol user.foo)" = "post-test-snap1" ]
+    [ "$(lxc storage volume get "${custom_vol_pool}" testvol/test-snap0 user.foo)" = "test-snap0" ]
+    [ "$(lxc storage volume get "${custom_vol_pool}" testvol/test-snap1 user.foo)" = "test-snap1" ]
 
     lxc storage volume import "${custom_vol_pool}" "${LXD_DIR}/testvol-optimized.tar.gz" testvol2
     lxc storage volume attach "${custom_vol_pool}" testvol c1 /mnt

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -432,11 +432,11 @@ test_basic_usage() {
   echo abc > "${LXD_DIR}/in"
 
   lxc file push "${LXD_DIR}/in" foo/root/
-  lxc exec foo -- /bin/cat /root/in | grep -xF abc
+  [ "$(lxc exec foo -- /bin/cat /root/in)" = "abc" ]
   lxc exec foo -- /bin/rm -f root/in
 
   lxc file push "${LXD_DIR}/in" foo/root/in1
-  lxc exec foo -- /bin/cat /root/in1 | grep -xF abc
+  [ "$(lxc exec foo -- /bin/cat /root/in1)" = "abc" ]
   lxc exec foo -- /bin/rm -f root/in1
 
   # test lxc file edit doesn't change target file's owner and permissions

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -244,8 +244,8 @@ test_clustering_membership() {
   # checking which are database nodes and which are database-standby nodes.
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster list
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node1 | grep -q "\- database-leader$"
-  LXD_DIR="${LXD_THREE_DIR}" lxc cluster list | grep -Fc "database-standby" | grep -Fx 2
-  LXD_DIR="${LXD_FIVE_DIR}" lxc cluster list | grep -Fc "database " | grep -Fx 3
+  [ "$(LXD_DIR="${LXD_THREE_DIR}" lxc cluster list | grep -Fc "database-standby")" = "2" ]
+  [ "$(LXD_DIR="${LXD_FIVE_DIR}" lxc cluster list | grep -Fc "database ")" = "3" ]
 
   # Show a single node
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node5 | grep -q "node5"
@@ -2328,7 +2328,7 @@ test_clustering_handover() {
   echo "Launched member 4"
 
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
-  LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep -Fc "database-standby" | grep -Fx 1
+  [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep -Fc "database-standby")" = "1" ]
 
   # Shutdown the first node.
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
@@ -2442,7 +2442,7 @@ test_clustering_rebalance() {
 
   # Check there is one database-standby member.
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
-  LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep -Fc "database-standby" | grep -Fx 1
+  [ "$(LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep -Fc "database-standby")" = "1" ]
 
   # Kill the second node.
   LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 11
@@ -2812,9 +2812,9 @@ test_clustering_image_refresh() {
     # Check image storage volume records exist.
     lxd sql global 'select name from storage_volumes'
     if [ "${poolDriver}" = "ceph" ]; then
-      lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}" | grep -Fx 1
+      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}")" = "1" ]
     else
-      lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}" | grep -Fx 3
+      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}")" = "3" ]
     fi
   fi
 
@@ -2834,11 +2834,11 @@ test_clustering_image_refresh() {
     lxd sql global 'select name from storage_volumes'
     # Check image storage volume records actually removed from relevant members and replaced with new fingerprint.
     if [ "${poolDriver}" = "ceph" ]; then
-      lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}" | grep -Fx 0
-      lxd sql global 'select name from storage_volumes' | grep -Fc "${new_fingerprint}" | grep -Fx 1
+      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}")" = "0" ]
+      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${new_fingerprint}")" = "1" ]
     else
-      lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}" | grep -Fx 1
-      lxd sql global 'select name from storage_volumes' | grep -Fc "${new_fingerprint}" | grep -Fx 2
+      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}")" = "1" ]
+      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${new_fingerprint}")" = "2" ]
     fi
   fi
 
@@ -3697,18 +3697,18 @@ test_clustering_events() {
   # Check events were distributed.
   for i in 1 2 3; do
     cat "${TEST_DIR}/node${i}.log"
-    grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log" | grep -Fx 2
+    [ "$(grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log")" = "2" ]
   done
 
   # Switch into event-hub mode.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster role add node1 event-hub
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster role add node2 event-hub
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -Fc event-hub | grep -Fx 2
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -Fc event-hub)" = "2" ]
 
   # Check events were distributed.
   for i in 1 2 3; do
-    grep -Fc "cluster-member-updated" "${TEST_DIR}/node${i}.log" | grep -Fx 2
+    [ "$(grep -Fc "cluster-member-updated" "${TEST_DIR}/node${i}.log")" = "2" ]
   done
 
   sleep 2 # Wait for notification heartbeat to distribute new roles.
@@ -3726,19 +3726,19 @@ test_clustering_events() {
   # Check events were distributed.
   for i in 1 2 3; do
     cat "${TEST_DIR}/node${i}.log"
-    grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log" | grep -Fx 4
+    [ "$(grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log")" = "4" ]
   done
 
   # Launch container on node3 to check image distribution events work during event-hub mode.
   LXD_DIR="${LXD_THREE_DIR}" lxc launch testimage c3 --target=node3
 
   for i in 1 2 3; do
-    grep -Fc "instance-created" "${TEST_DIR}/node${i}.log" | grep -Fx 1
+    [ "$(grep -Fc "instance-created" "${TEST_DIR}/node${i}.log")" = "1" ]
   done
 
   # Switch into full-mesh mode by removing one event-hub role so there is <2 in the cluster.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster role remove node1 event-hub
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -Fc event-hub | grep -Fx 1
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -Fc event-hub)" = "1" ]
 
   sleep 1 # Wait for notification heartbeat to distribute new roles.
   LXD_DIR="${LXD_ONE_DIR}" lxc info | grep -F "server_event_mode: full-mesh"
@@ -3749,7 +3749,7 @@ test_clustering_events() {
 
   # Check events were distributed.
   for i in 1 2 3; do
-    grep -Fc "cluster-member-updated" "${TEST_DIR}/node${i}.log" | grep -Fx 3
+    [ "$(grep -Fc "cluster-member-updated" "${TEST_DIR}/node${i}.log")" = "3" ]
   done
 
   # Restart instance generating restart lifecycle event.
@@ -3760,7 +3760,7 @@ test_clustering_events() {
   # Check events were distributed.
   for i in 1 2 3; do
     cat "${TEST_DIR}/node${i}.log"
-    grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log" | grep -Fx 6
+    [ "$(grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log")" = "6" ]
   done
 
   # Switch back into event-hub mode by giving the role to node4 and node5.
@@ -3790,10 +3790,10 @@ test_clustering_events() {
   LXD_DIR="${LXD_ONE_DIR}" lxc restart -f c1
   sleep 2
 
-  grep -Fc "instance-restarted" "${TEST_DIR}/node1.log" | grep -Fx 7
+  [ "$(grep -Fc "instance-restarted" "${TEST_DIR}/node1.log")" = "7" ]
   for i in 2 3; do
     cat "${TEST_DIR}/node${i}.log"
-    grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log" | grep -Fx 6
+    [ "$(grep -Fc "instance-restarted" "${TEST_DIR}/node${i}.log")" = "6" ]
   done
 
   # Kill monitors.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2846,12 +2846,12 @@ test_clustering_image_refresh() {
   # while project foo should still have the old image.
   # Also, it should only show 1 entry for the old image and 2 entries
   # for the new one.
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep "${old_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -c "${old_fingerprint}")" -eq 1 ] || false
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep -F "${old_fingerprint}"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${old_fingerprint}")" -eq 1 ]
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep "${new_fingerprint}"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep "${new_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -c "${new_fingerprint}")" -eq 2 ] || false
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep -F "${new_fingerprint}"
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep -F "${new_fingerprint}"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${new_fingerprint}")" -eq 2 ]
 
   pids=""
 
@@ -2868,12 +2868,12 @@ test_clustering_image_refresh() {
     wait "${pid}" || true
   done
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep "${old_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -c "${old_fingerprint}")" -eq 1 ] || false
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep -F "${old_fingerprint}"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${old_fingerprint}")" -eq 1 ]
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep "${new_fingerprint}"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep "${new_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -c "${new_fingerprint}")" -eq 2 ] || false
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep -F "${new_fingerprint}"
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep -F "${new_fingerprint}"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${new_fingerprint}")" -eq 2 ]
 
   # Modify public testimage
   dd if=/dev/urandom count=32 | LXD_DIR="${LXD_REMOTE_DIR}" lxc file push - c1/foo
@@ -2896,12 +2896,12 @@ test_clustering_image_refresh() {
 
   pids=""
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep "${old_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -c "${old_fingerprint}")" -eq 1 ] || false
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep -F "${old_fingerprint}"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${old_fingerprint}")" -eq 1 ]
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep "${new_fingerprint}"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep "${new_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -c "${new_fingerprint}")" -eq 2 ] || false
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep -F "${new_fingerprint}"
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep -F "${new_fingerprint}"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${new_fingerprint}")" -eq 2 ]
 
   # Clean up everything
   for project in default foo bar; do

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -258,7 +258,7 @@ test_config_profiles() {
   lxc start foo
 
   if [ -e /sys/module/apparmor ]; then
-    lxc exec foo -- grep -xF unconfined /proc/self/attr/current
+    [ "$(lxc exec foo -- cat /proc/self/attr/current)" = "unconfined" ]
   fi
   lxc exec foo -- ls /sys/class/net | grep eth0
 

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -724,7 +724,7 @@ test_container_devices_nic_bridged() {
   # Test container snapshot with conflicting addresses can be restored.
   lxc restore foo snap0 # Test restore, IPs conflict on config device update (due to only IPs changing).
   ! stat "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" || false # Check lease file removed (due to non-user requested update failing).
-  lxc config device get foo eth0 ipv4.address | grep -Fx '192.0.2.232'
+  [ "$(lxc config device get foo eth0 ipv4.address)" = '192.0.2.232' ]
   ! lxc start foo || false
   lxc config device set foo eth0 \
     hwaddr="0a:92:a7:0d:b7:c9" \
@@ -735,7 +735,7 @@ test_container_devices_nic_bridged() {
 
   lxc restore foo snap0 # Test restore, IPs conflict on config device remove/add (due to MAC change).
   ! stat "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" || false # Check lease file removed (due to MAC change).
-  lxc config device get foo eth0 ipv4.address | grep -Fx '192.0.2.232'
+  [ "$(lxc config device get foo eth0 ipv4.address)" = '192.0.2.232' ]
   ! lxc start foo || false
   lxc config device set foo eth0 \
     hwaddr="0a:92:a7:0d:b7:c9" \
@@ -749,14 +749,14 @@ test_container_devices_nic_bridged() {
   lxc import foo.tar.gz
   ! stat "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0" || false
   ! lxc start foo || false
-  lxc config device get foo eth0 ipv4.address | grep -Fx '192.0.2.232'
+  [ "$(lxc config device get foo eth0 ipv4.address)" = '192.0.2.232' ]
   lxc config show foo/snap0 | grep -F 'ipv4.address: 192.0.2.232'
   lxc config device set foo eth0 \
     hwaddr="0a:92:a7:0d:b7:c9" \
     ipv4.address=192.0.2.233 \
     ipv6.address=2001:db8::3
   grep -F "192.0.2.233" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/foo.eth0"
-  lxc config device get foo eth0 ipv4.address | grep -Fx '192.0.2.233'
+  [ "$(lxc config device get foo eth0 ipv4.address)" = '192.0.2.233' ]
   lxc start foo
 
   # Check MAC conflict detection:
@@ -765,26 +765,26 @@ test_container_devices_nic_bridged() {
 
   # Test container can be imported with device override to fix conflict.
   lxc import foo.tar.gz --device eth0,ipv4.address=192.0.2.233 --device eth0,ipv6.address=2001:db8::3
-  lxc config device get foo eth0 ipv4.address | grep -Fx '192.0.2.233'
-  lxc config device get foo eth0 ipv6.address | grep -Fx '2001:db8::3'
+  [ "$(lxc config device get foo eth0 ipv4.address)" = '192.0.2.233' ]
+  [ "$(lxc config device get foo eth0 ipv6.address)" = '2001:db8::3' ]
   lxc start foo
 
   # Test container can be copied with device override to fix conflict.
   lxc copy foo foo-copy --device eth0,ipv4.address=192.0.2.234 --device eth0,ipv6.address=2001:db8::4 --device eth0,host_name=veth0 --device eth0,ipv4.routes=192.0.2.20/32 --device eth0,ipv6.routes=2001:db8::20/128
-  lxc config device get foo-copy eth0 ipv4.address | grep -Fx '192.0.2.234'
-  lxc config device get foo-copy eth0 ipv6.address | grep -Fx '2001:db8::4'
-  lxc config device get foo-copy eth0 ipv4.routes | grep -Fx '192.0.2.20/32'
-  lxc config device get foo-copy eth0 ipv6.routes | grep -Fx '2001:db8::20/128'
+  [ "$(lxc config device get foo-copy eth0 ipv4.address)" = '192.0.2.234' ]
+  [ "$(lxc config device get foo-copy eth0 ipv6.address)" = '2001:db8::4' ]
+  [ "$(lxc config device get foo-copy eth0 ipv4.routes)" = '192.0.2.20/32' ]
+  [ "$(lxc config device get foo-copy eth0 ipv6.routes)" = '2001:db8::20/128' ]
   lxc start foo-copy
   lxc delete -f foo-copy
 
   # Test snapshot can be copied with device override to fix conflict.
   lxc snapshot foo tester
   lxc copy foo/tester snap-copy --device eth0,ipv4.address=192.0.2.235 --device eth0,ipv6.address=2001:db8::5 --device eth0,host_name=veth1 --device eth0,ipv4.routes=192.0.2.21/32 --device eth0,ipv6.routes=2001:db8::21/128
-  lxc config device get snap-copy eth0 ipv4.address | grep -Fx '192.0.2.235'
-  lxc config device get snap-copy eth0 ipv6.address | grep -Fx '2001:db8::5'
-  lxc config device get snap-copy eth0 ipv4.routes | grep -Fx '192.0.2.21/32'
-  lxc config device get snap-copy eth0 ipv6.routes | grep -Fx '2001:db8::21/128'
+  [ "$(lxc config device get snap-copy eth0 ipv4.address)" = '192.0.2.235' ]
+  [ "$(lxc config device get snap-copy eth0 ipv6.address)" = '2001:db8::5' ]
+  [ "$(lxc config device get snap-copy eth0 ipv4.routes)" = '192.0.2.21/32' ]
+  [ "$(lxc config device get snap-copy eth0 ipv6.routes)" = '2001:db8::21/128' ]
   lxc start snap-copy
   lxc delete -f snap-copy
   lxc delete -f foo
@@ -807,7 +807,7 @@ test_container_devices_nic_bridged() {
   lxc profile assign foo2 "${ctName}"
 
   # Test container start will fail due to volatile MAC conflict.
-  lxc config get foo volatile.eth0.hwaddr | grep -Fx "$(lxc config get foo2 volatile.eth0.hwaddr)"
+  [ "$(lxc config get foo volatile.eth0.hwaddr)" = "$(lxc config get foo2 volatile.eth0.hwaddr)" ]
   ! lxc start foo2 || false
   lxc delete -f foo foo2
 

--- a/test/suites/devlxd.sh
+++ b/test/suites/devlxd.sh
@@ -15,10 +15,10 @@ test_devlxd() {
   lxc file push --mode 0755 "devlxd-client/devlxd-client" devlxd/bin/
 
   lxc config set devlxd user.foo bar
-  lxc exec devlxd -- devlxd-client user.foo | grep bar
+  [ "$(lxc exec devlxd -- devlxd-client user.foo)" = "bar" ]
 
   lxc config set devlxd user.foo "bar %s bar"
-  lxc exec devlxd -- devlxd-client user.foo | grep "bar %s bar"
+  [ "$(lxc exec devlxd -- devlxd-client user.foo)" = "bar %s bar" ]
 
   lxc config set devlxd security.nesting true
   ! lxc exec devlxd -- devlxd-client security.nesting | grep true || false
@@ -96,13 +96,13 @@ EOF
   lxc exec devlxd -- devlxd-client ready-state true
   [ "$(lxc config get devlxd volatile.last_state.ready)" = "true" ]
 
-  grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log" | grep -Fx 1
+  [ "$(grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log")" = "1" ]
 
   lxc info devlxd | grep -q 'Status: READY'
   lxc exec devlxd -- devlxd-client ready-state false
   [ "$(lxc config get devlxd volatile.last_state.ready)" = "false" ]
 
-  grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log" | grep -Fx 1
+  [ "$(grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log")" = "1" ]
 
   lxc info devlxd | grep -q 'Status: RUNNING'
 
@@ -120,7 +120,7 @@ EOF
   lxc exec devlxd -- devlxd-client ready-state true
   [ "$(lxc config get devlxd volatile.last_state.ready)" = "true" ]
 
-  grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log" | grep -Fx 1
+  [ "$(grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log")" = "1" ]
 
   lxc stop -f devlxd
   [ "$(lxc config get devlxd volatile.last_state.ready)" = "false" ]
@@ -129,11 +129,11 @@ EOF
   lxc exec devlxd -- devlxd-client ready-state true
   [ "$(lxc config get devlxd volatile.last_state.ready)" = "true" ]
 
-  grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log" | grep -Fx 2
+  [ "$(grep -Fc "instance-ready" "${TEST_DIR}/devlxd.log")" = "2" ]
 
   # Check device configs are available and that NIC hwaddr is available even if volatile.
   hwaddr=$(lxc config get devlxd volatile.eth0.hwaddr)
-  lxc exec devlxd -- devlxd-client devices | jq -r .eth0.hwaddr | grep -Fx "${hwaddr}"
+  [ "$(lxc exec devlxd -- devlxd-client devices | jq -r .eth0.hwaddr)" = "${hwaddr}" ]
 
   lxc delete devlxd --force
   kill -9 ${monitorDevlxdPID} || true

--- a/test/suites/devlxd.sh
+++ b/test/suites/devlxd.sh
@@ -20,8 +20,10 @@ test_devlxd() {
   lxc config set devlxd user.foo "bar %s bar"
   [ "$(lxc exec devlxd -- devlxd-client user.foo)" = "bar %s bar" ]
 
+  # Make sure instance configuration keys are not accessible
+  [ "$(lxc exec devlxd -- devlxd-client security.nesting)" = "not authorized" ]
   lxc config set devlxd security.nesting true
-  ! lxc exec devlxd -- devlxd-client security.nesting | grep true || false
+  [ "$(lxc exec devlxd -- devlxd-client security.nesting)" = "not authorized" ]
 
   cmd=$(unset -f lxc; command -v lxc)
   ${cmd} exec devlxd -- devlxd-client monitor-websocket > "${TEST_DIR}/devlxd-websocket.log" &

--- a/test/suites/incremental_copy.sh
+++ b/test/suites/incremental_copy.sh
@@ -42,7 +42,7 @@ do_copy() {
   # Initial copy
   # shellcheck disable=2086
   lxc copy c1 c2 ${targetPoolFlag}
-  lxc storage volume get "${target_pool}" container/c2 user.foo | grep -Fx "main"
+  [ "$(lxc storage volume get "${target_pool}" container/c2 user.foo)" = "main" ]
 
   lxc start c1 c2
 
@@ -83,9 +83,9 @@ do_copy() {
   lxc copy c1 c2 --refresh ${targetPoolFlag}
   lxc config show c2/snap0
   lxc config show c2/snap1
-  lxc storage volume get "${target_pool}" container/c2 user.foo | grep -Fx "main"
-  lxc storage volume get "${target_pool}" container/c2/snap0 user.foo | grep -Fx "snap0"
-  lxc storage volume get "${target_pool}" container/c2/snap1 user.foo | grep -Fx "snap1"
+  [ "$(lxc storage volume get "${target_pool}" container/c2 user.foo)" = "main" ]
+  [ "$(lxc storage volume get "${target_pool}" container/c2/snap0 user.foo)" = "snap0" ]
+  [ "$(lxc storage volume get "${target_pool}" container/c2/snap1 user.foo)" = "snap1" ]
 
   # This will create snapshot c2/snap2
   lxc snapshot c2

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -202,9 +202,9 @@ migration() {
   [ "$(lxc info udssr | grep -c snap)" -eq 2 ]
   [ "$(lxc file pull udssr/blah -)" = "after" ]
   lxc storage volume show "${pool}" container/udssr
-  lxc storage volume get "${pool}" container/udssr user.foo | grep -Fx "postsnap1"
-  lxc storage volume get "${pool}" container/udssr/snap0 user.foo | grep -Fx "snap0"
-  lxc storage volume get "${pool}" container/udssr/snap1 user.foo | grep -Fx "snap1"
+  [ "$(lxc storage volume get "${pool}" container/udssr user.foo)" = "postsnap1" ]
+  [ "$(lxc storage volume get "${pool}" container/udssr/snap0 user.foo)" = "snap0" ]
+  [ "$(lxc storage volume get "${pool}" container/udssr/snap1 user.foo)" = "snap1" ]
   lxc delete udssr
 
   # Remote container only copy.
@@ -218,9 +218,9 @@ migration() {
   [ "$(lxc_remote info l2:udssr | grep -c snap)" -eq 2 ]
   [ "$(lxc_remote file pull l2:udssr/blah -)" = "after" ]
   lxc_remote storage volume show l2:"${remote_pool}" container/udssr
-  lxc_remote storage volume get l2:"${remote_pool}" container/udssr user.foo | grep -Fx "postsnap1"
-  lxc_remote storage volume get l2:"${remote_pool}" container/udssr/snap0 user.foo | grep -Fx "snap0"
-  lxc_remote storage volume get l2:"${remote_pool}" container/udssr/snap1 user.foo | grep -Fx "snap1"
+  [ "$(lxc_remote storage volume get l2:"${remote_pool}" container/udssr user.foo)" = "postsnap1" ]
+  [ "$(lxc_remote storage volume get l2:"${remote_pool}" container/udssr/snap0 user.foo)" = "snap0" ]
+  [ "$(lxc_remote storage volume get l2:"${remote_pool}" container/udssr/snap1 user.foo)" = "snap1" ]
   lxc_remote delete l2:udssr
 
   # Remote container only move.
@@ -384,9 +384,9 @@ migration() {
 
   # remote storage volume and snapshots migration in "pull" mode
   lxc_remote storage volume copy l1:"$remote_pool1/vol1" l2:"$remote_pool2/vol2"
-  lxc_remote storage volume get l2:"$remote_pool2" vol2 user.foo | grep -Fx "postsnap1vol1"
-  lxc_remote storage volume get l2:"$remote_pool2" vol2/snap0 user.foo | grep -Fx "snap0vol1"
-  lxc_remote storage volume get l2:"$remote_pool2" vol2/snap1 user.foo | grep -Fx "snap1vol1"
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2 user.foo)" = "postsnap1vol1" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2/snap0 user.foo)" = "snap0vol1" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2/snap1 user.foo)" = "snap1vol1" ]
 
   # check copied volume and snapshots have different UUIDs
   [ "$(lxc_remote storage volume get l1:"$remote_pool1" vol1 volatile.uuid)" != "$(lxc_remote storage volume get l2:"$remote_pool2" vol2 volatile.uuid)" ]
@@ -399,13 +399,13 @@ migration() {
   lxc_remote storage volume copy l1:"$remote_pool1/vol1" l1:"$remote_pool1/vol2"
   lxc_remote storage volume move l1:"$remote_pool1/vol2" l2:"$remote_pool2/vol3"
   ! lxc_remote storage volume show l1:"$remote_pool1" vol2 || false
-  lxc_remote storage volume get l2:"$remote_pool2" vol3 user.foo | grep -Fx "postsnap1vol1"
-  lxc_remote storage volume get l2:"$remote_pool2" vol3/snap0 user.foo | grep -Fx "snap0vol1"
-  lxc_remote storage volume get l2:"$remote_pool2" vol3/snap1 user.foo | grep -Fx "snap1vol1"
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol3 user.foo)" = "postsnap1vol1" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol3/snap0 user.foo)" = "snap0vol1" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol3/snap1 user.foo)" = "snap1vol1" ]
   lxc_remote storage volume delete l2:"$remote_pool2" vol3
 
   lxc_remote storage volume copy l1:"$remote_pool1/vol1" l2:"$remote_pool2/vol2" --volume-only
-  lxc_remote storage volume get l2:"$remote_pool2" vol2 user.foo | grep -Fx "postsnap1vol1"
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2 user.foo)" = "postsnap1vol1" ]
   ! lxc_remote storage volume show l2:"$remote_pool2" vol2/snap0 || false
   ! lxc_remote storage volume show l2:"$remote_pool2" vol2/snap1 || false
   lxc_remote storage volume delete l2:"$remote_pool2" vol2
@@ -417,10 +417,10 @@ migration() {
   lxc_remote storage volume copy l1:"$remote_pool1/vol1" l2:"$remote_pool2/vol2" --refresh
   lxc_remote storage volume delete l1:"$remote_pool1" vol1
 
-  lxc_remote storage volume get l2:"$remote_pool2" vol2 user.foo | grep -Fx "postsnap1vol1"
-  lxc_remote storage volume get l2:"$remote_pool2" vol2/snap0 user.foo | grep -Fx "snap0vol1"
-  lxc_remote storage volume get l2:"$remote_pool2" vol2/snap1 user.foo | grep -Fx "snap1vol1"
-  lxc_remote storage volume get l2:"$remote_pool2" vol2/snapremove user.foo | grep -Fx "snapremovevol1"
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2 user.foo)" = "postsnap1vol1" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2/snap0 user.foo)" = "snap0vol1" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2/snap1 user.foo)" = "snap1vol1" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2/snapremove user.foo)" = "snapremovevol1" ]
 
   # check remote storage volume refresh from a different volume
   lxc_remote storage volume create l1:"$remote_pool1" vol3
@@ -436,10 +436,10 @@ migration() {
   lxc_remote storage volume copy l1:"$remote_pool1/vol3" l2:"$remote_pool2/vol2" --refresh
   lxc_remote storage volume ls l2:"$remote_pool2"
   lxc_remote storage volume delete l1:"$remote_pool1" vol3
-  lxc_remote storage volume get l2:"$remote_pool2" vol2 user.foo | grep -Fx "postsnap1vol1" # FIXME Should be postsnap1vol3
-  lxc_remote storage volume get l2:"$remote_pool2" vol2/snap0 user.foo | grep -Fx "snap0vol3"
-  lxc_remote storage volume get l2:"$remote_pool2" vol2/snap1 user.foo | grep -Fx "snap1vol3"
-  lxc_remote storage volume get l2:"$remote_pool2" vol2/snap2 user.foo | grep -Fx "snap2vol3"
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2 user.foo)" = "postsnap1vol1" ] # FIXME Should be postsnap1vol3
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2/snap0 user.foo)" = "snap0vol3" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2/snap1 user.foo)" = "snap1vol3" ]
+  [ "$(lxc_remote storage volume get l2:"$remote_pool2" vol2/snap2 user.foo)" = "snap2vol3" ]
   ! lxc_remote storage volume show l2:"$remote_pool2" vol2/snapremove || false
   lxc_remote storage volume delete l2:"$remote_pool2" vol2
 

--- a/test/suites/network_zone.sh
+++ b/test/suites/network_zone.sh
@@ -102,13 +102,13 @@ test_network_zone() {
   ! dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxdfoo.example.net | grep "c1.lxd.example.net" || false
 
   # Check reverse zones include records from both projects associated to the relevant forward zone name.
-  dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 2.0.192.in-addr.arpa | grep -Fc "PTR" | grep -Fx 3
+  [ "$(dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 2.0.192.in-addr.arpa | grep -Fcw "PTR")" = "3" ]
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 2.0.192.in-addr.arpa | grep "300\s\+IN\s\+PTR\s\+${netName}.gw.lxd.example.net."
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 2.0.192.in-addr.arpa | grep "300\s\+IN\s\+PTR\s\+c1.lxd.example.net."
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 2.0.192.in-addr.arpa | grep "300\s\+IN\s\+PTR\s\+c2.lxdfoo.example.net."
 
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa
-  dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa | grep -Fc "PTR" | grep -Fx 3
+  [ "$(dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa | grep -Fcw "PTR")" = "3" ]
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa | grep "300\s\+IN\s\+PTR\s\+${netName}.gw.lxd.example.net."
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa | grep "300\s\+IN\s\+PTR\s\+c1.lxd.example.net."
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa | grep "300\s\+IN\s\+PTR\s\+c2.lxdfoo.example.net."
@@ -123,7 +123,7 @@ test_network_zone() {
   lxc network zone record entry add lxd.example.net demo MX "1 mx1.example.net." --ttl 900
   lxc network zone record entry add lxd.example.net demo MX "10 mx2.example.net." --ttl 900
   lxc network zone record list lxd.example.net
-  dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxd.example.net | grep -Fc demo.lxd.example.net | grep -Fx 6
+  [ "$(dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxd.example.net | grep -Fc demo.lxd.example.net)" = "6" ]
   lxc network zone record entry remove lxd.example.net demo A 1.1.1.1
 
   lxd sql global 'select * from networks_zones_records'
@@ -136,7 +136,7 @@ test_network_zone() {
   lxc network zone record entry add lxdfoo.example.net demo MX "1 mx1.example.net." --ttl 900 --project foo
   lxc network zone record entry add lxdfoo.example.net demo MX "10 mx2.example.net." --ttl 900 --project foo
   lxc network zone record list lxdfoo.example.net --project foo
-  dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxdfoo.example.net | grep -Fc demo.lxdfoo.example.net | grep -Fx 6
+  [ "$(dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr lxdfoo.example.net | grep -Fc demo.lxdfoo.example.net)" = "6" ]
   lxc network zone record entry remove lxdfoo.example.net demo A 1.1.1.1 --project foo
 
   # Check that the listener survives a restart of LXD

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -217,7 +217,7 @@ snap_restore() {
     fi
 
     # Check storage volume has been restored (user.foo=snap0)
-    lxc storage volume get "${pool}" container/bar user.foo | grep -Fx "snap0"
+    [ "$(lxc storage volume get "${pool}" container/bar user.foo)" = "snap0" ]
   fi
 
   ##########################################################
@@ -291,7 +291,7 @@ snap_restore() {
   fi
 
   # Check storage volume has been restored (user.foo=snap0)
-  lxc storage volume get "${pool}" container/bar user.foo | grep -Fx "snap1"
+  [ "$(lxc storage volume get "${pool}" container/bar user.foo)" = "snap1" ]
 
   ##########################################################
 

--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -135,13 +135,13 @@ test_storage_buckets() {
   # Test setting bucket policy to allow anonymous access (also tests bucket URL generation).
   bucketURL=$(lxc storage bucket show "${poolName}" "${bucketPrefix}.foo" | awk '{if ($1 == "s3_url:") {print $2}}')
 
-  curl -sI --insecure -o /dev/null -w "%{http_code}" "${bucketURL}/${lxdTestFile}" | grep -Fx "403"
+  [ "$(curl -sI --insecure -o /dev/null -w "%{http_code}" "${bucketURL}/${lxdTestFile}")" = "403" ]
   ! s3cmdrun "${lxd_backend}" "${roAccessKey}" "${roSecretKey}" setpolicy deps/s3_global_read_policy.json "s3://${bucketPrefix}.foo" || false
   s3cmdrun "${lxd_backend}" "${adAccessKey}" "${adSecretKey}" setpolicy deps/s3_global_read_policy.json "s3://${bucketPrefix}.foo"
-  curl -sI --insecure -o /dev/null -w "%{http_code}" "${bucketURL}/${lxdTestFile}" | grep -Fx "200"
+  [ "$(curl -sI --insecure -o /dev/null -w "%{http_code}" "${bucketURL}/${lxdTestFile}")" = "200" ]
   ! s3cmdrun "${lxd_backend}" "${roAccessKey}" "${roSecretKey}" delpolicy "s3://${bucketPrefix}.foo" || false
   s3cmdrun "${lxd_backend}" "${adAccessKey}" "${adSecretKey}" delpolicy "s3://${bucketPrefix}.foo"
-  curl -sI --insecure o /dev/null -w "%{http_code}" "${bucketURL}/${lxdTestFile}" | grep -Fx "403"
+  [ "$(curl -sI --insecure -o /dev/null -w "%{http_code}" "${bucketURL}/${lxdTestFile}")" = "403" ]
 
   # Test deleting a file from a bucket.
   ! s3cmdrun "${lxd_backend}" "${roAccessKey}" "${roSecretKey}" del "s3://${bucketPrefix}.foo/${lxdTestFile}" || false

--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -83,9 +83,9 @@ test_storage_local_volume_handling() {
     lxc storage volume show "${pool}" vol1copy/snap1
 
     # Check snapshot volume config was copied
-    lxc storage volume get "${pool}" vol1copy user.foo | grep -Fx "postsnap1"
-    lxc storage volume get "${pool}" vol1copy/snap0 user.foo | grep -Fx "snap0"
-    lxc storage volume get "${pool}" vol1copy/snap1 user.foo | grep -Fx "snap1"
+    [ "$(lxc storage volume get "${pool}" vol1copy user.foo)" = "postsnap1" ]
+    [ "$(lxc storage volume get "${pool}" vol1copy/snap0 user.foo)" = "snap0" ]
+    [ "$(lxc storage volume get "${pool}" vol1copy/snap1 user.foo)" = "snap1" ]
 
     # Check the volume and snapshot UUIDs are different
     [ "$(lxc storage volume get "${pool}" vol1 volatile.uuid)" != "$(lxc storage volume get "${pool}" vol1copy volatile.uuid)" ]
@@ -101,9 +101,9 @@ test_storage_local_volume_handling() {
     lxc storage volume show "${pool}1" vol1/snap1
 
     # Check snapshot volume config was copied
-    lxc storage volume get "${pool}1" vol1 user.foo | grep -Fx "postsnap1"
-    lxc storage volume get "${pool}1" vol1/snap0 user.foo | grep -Fx "snap0"
-    lxc storage volume get "${pool}1" vol1/snap1 user.foo | grep -Fx "snap1"
+    [ "$(lxc storage volume get "${pool}1" vol1 user.foo)" = "postsnap1" ]
+    [ "$(lxc storage volume get "${pool}1" vol1/snap0 user.foo)" = "snap0" ]
+    [ "$(lxc storage volume get "${pool}1" vol1/snap1 user.foo)" = "snap1" ]
 
     # Copy volume only
     lxc storage volume copy --volume-only "${pool}/vol1" "${pool}1/vol2"
@@ -113,14 +113,14 @@ test_storage_local_volume_handling() {
     ! lxc storage volume show "${pool}1" vol2/snap1 || false
 
     # Check snapshot volume config was copied
-    lxc storage volume get "${pool}1" vol2 user.foo | grep -Fx "postsnap1"
+    [ "$(lxc storage volume get "${pool}1" vol2 user.foo)" = "postsnap1" ]
 
     # Copy snapshot to volume
     lxc storage volume copy "${pool}/vol1/snap0" "${pool}1/vol3"
 
     # Check snapshot volume config was copied from snapshot
     lxc storage volume show "${pool}1" vol3
-    lxc storage volume get "${pool}1" vol3 user.foo | grep -Fx "snap0"
+    [ "$(lxc storage volume get "${pool}1" vol3 user.foo)" = "snap0" ]
 
     # Rename custom volume using `lxc storage volume move`
     lxc storage volume move "${pool}1/vol1" "${pool}1/vol4"
@@ -264,10 +264,10 @@ test_storage_local_volume_handling() {
           lxc storage volume copy --refresh "${source_pool}/vol5" "${target_pool}/vol5"
 
           # check snapshot volumes (including config) were copied
-          lxc storage volume get "${target_pool}" vol5 user.foo | grep -Fx "postsnap1vol5"
-          lxc storage volume get "${target_pool}" vol5/snap0 user.foo | grep -Fx "snap0vol5"
-          lxc storage volume get "${target_pool}" vol5/snap1 user.foo | grep -Fx "snap1vol5"
-          lxc storage volume get "${target_pool}" vol5/snapremove user.foo | grep -Fx "snapremovevol5"
+          [ "$(lxc storage volume get "${target_pool}" vol5 user.foo)" = "postsnap1vol5" ]
+          [ "$(lxc storage volume get "${target_pool}" vol5/snap0 user.foo)" = "snap0vol5" ]
+          [ "$(lxc storage volume get "${target_pool}" vol5/snap1 user.foo)" = "snap1vol5" ]
+          [ "$(lxc storage volume get "${target_pool}" vol5/snapremove user.foo)" = "snapremovevol5" ]
 
           # incremental copy to existing volume destination with refresh flag
           lxc storage volume copy --refresh "${source_pool}/vol6" "${target_pool}/vol5"
@@ -276,10 +276,10 @@ test_storage_local_volume_handling() {
           # present and that the missing snapshot has been removed.
           # Note: Due to a known issue we are currently only diffing the snapshots by name and creation date, so infact existing
           # snapshots of the same name and date won't be overwritten even if their config or contents is different.
-          lxc storage volume get "${target_pool}" vol5 user.foo | grep -Fx "postsnap1vol5"
-          lxc storage volume get "${target_pool}" vol5/snap0 user.foo | grep -Fx "snap0vol6"
-          lxc storage volume get "${target_pool}" vol5/snap1 user.foo | grep -Fx "snap1vol6"
-          lxc storage volume get "${target_pool}" vol5/snap2 user.foo | grep -Fx "snap2vol6"
+          [ "$(lxc storage volume get "${target_pool}" vol5 user.foo)" = "postsnap1vol5" ]
+          [ "$(lxc storage volume get "${target_pool}" vol5/snap0 user.foo)" = "snap0vol6" ]
+          [ "$(lxc storage volume get "${target_pool}" vol5/snap1 user.foo)" = "snap1vol6" ]
+          [ "$(lxc storage volume get "${target_pool}" vol5/snap2 user.foo)" = "snap2vol6" ]
           ! lxc storage volume get "${target_pool}" vol5/snapremove user.foo || false
 
           # check that another refresh doesn't change the volume's and snapshot's UUID


### PR DESCRIPTION
This PR is mainly to improve debuggability. Here's why:

```
# OK, no problem if we get what we expect
echo foo > test-file
cat test-file | grep -Fx "foo"

# Impossible to figure what we got if it's not what we expected
echo bar > test-file
cat test-file | grep -Fx "foo"
```
Versus:

```
# OK, no problem if we get what we expect
echo foo > test-file
[ "$(cat test-file)" = "foo" ]

# Easy to figure what we got if it's not what we expected
echo bar > test-file
[ "$(cat test-file)" = "foo" ]
```

In the last case, it will be easy to figure what was in the test file as we'll see `[ "bar" = "foo" ]` thanks to the test being run with `set -x`.

**Additional bonus**: this caught a bogus invocation of `curl` where the output was not properly redirected.