### PR TITLE
Removes CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @tomponline


### PR DESCRIPTION
No longer needed as we use GH's own push protections.