### PR TITLE
Hint shellcheck that bash is used for all test scripts

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+#
+shell=bash

--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,7 @@ ifeq ($(shell command -v flake8),)
 	exit 1
 endif
 	flake8 test/deps/import-busybox
-	shellcheck --shell bash test/*.sh test/includes/*.sh test/suites/*.sh test/backends/*.sh test/lint/*.sh
-	shellcheck test/extras/*.sh
+	shellcheck test/*.sh test/includes/*.sh test/suites/*.sh test/backends/*.sh test/lint/*.sh test/extras/*.sh
 	NOT_EXEC="$(shell find test/lint -type f -not -executable)"; \
 	if [ -n "$$NOT_EXEC" ]; then \
         echo "lint scripts not executable: $$NOT_EXEC"; \

--- a/test/backends/btrfs.sh
+++ b/test/backends/btrfs.sh
@@ -1,5 +1,4 @@
 btrfs_setup() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -8,7 +7,6 @@ btrfs_setup() {
 }
 
 btrfs_configure() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -20,7 +18,6 @@ btrfs_configure() {
 }
 
 btrfs_teardown() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/backends/ceph.sh
+++ b/test/backends/ceph.sh
@@ -1,5 +1,4 @@
 ceph_setup() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -8,7 +7,6 @@ ceph_setup() {
 }
 
 ceph_configure() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -20,7 +18,6 @@ ceph_configure() {
 }
 
 ceph_teardown() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/backends/dir.sh
+++ b/test/backends/dir.sh
@@ -4,7 +4,6 @@
 
 # Any necessary backend-specific setup
 dir_setup() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -14,7 +13,6 @@ dir_setup() {
 
 # Do the API voodoo necessary to configure LXD to use this backend
 dir_configure() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -26,7 +24,6 @@ dir_configure() {
 }
 
 dir_teardown() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/backends/lvm.sh
+++ b/test/backends/lvm.sh
@@ -1,5 +1,4 @@
 lvm_setup() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -8,7 +7,6 @@ lvm_setup() {
 }
 
 lvm_configure() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -20,7 +18,6 @@ lvm_configure() {
 }
 
 lvm_teardown() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/backends/zfs.sh
+++ b/test/backends/zfs.sh
@@ -1,5 +1,4 @@
 zfs_setup() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -8,7 +7,6 @@ zfs_setup() {
 }
 
 zfs_configure() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1
@@ -20,7 +18,6 @@ zfs_configure() {
 }
 
 zfs_teardown() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_DIR=$1

--- a/test/includes/check.sh
+++ b/test/includes/check.sh
@@ -1,7 +1,6 @@
 # Miscellaneous test checks.
 
 check_dependencies() {
-    # shellcheck disable=SC2039,3043
     local dep missing
     missing=""
 

--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -109,7 +109,6 @@ teardown_clustering_netns() {
 }
 
 spawn_lxd_and_bootstrap_cluster() {
-  # shellcheck disable=SC2039,SC3043
   local LXD_NETNS
 
   set -e
@@ -198,7 +197,6 @@ EOF
 }
 
 spawn_lxd_and_join_cluster() {
-  # shellcheck disable=SC2039,SC3043
   local LXD_NETNS
 
   set -e
@@ -293,7 +291,7 @@ EOF
 }
 
 respawn_lxd_cluster_member() {
-  # shellcheck disable=SC2039,SC2034,SC3043
+  # shellcheck disable=SC2034
   local LXD_NETNS
 
   set -e

--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -7,7 +7,6 @@ lxc() {
 
 lxc_remote() {
     set +x
-    # shellcheck disable=SC2039,3043
     local injected cmd arg
 
     injected=0

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -5,7 +5,6 @@ spawn_lxd() {
     # LXD_DIR is local here because since $(lxc) is actually a function, it
     # overwrites the environment and we would lose LXD_DIR's value otherwise.
 
-    # shellcheck disable=2039,3043
     local LXD_DIR lxddir lxd_backend
 
     lxddir=${1}
@@ -80,7 +79,6 @@ respawn_lxd() {
     # LXD_DIR is local here because since $(lxc) is actually a function, it
     # overwrites the environment and we would lose LXD_DIR's value otherwise.
 
-    # shellcheck disable=2039,3043
     local LXD_DIR
 
     lxddir=${1}
@@ -115,7 +113,6 @@ kill_lxd() {
     # LXD_DIR is local here because since $(lxc) is actually a function, it
     # overwrites the environment and we would lose LXD_DIR's value otherwise.
 
-    # shellcheck disable=2039,3043
     local LXD_DIR daemon_dir daemon_pid check_leftovers lxd_backend
 
     daemon_dir=${1}
@@ -259,7 +256,6 @@ shutdown_lxd() {
     # LXD_DIR is local here because since $(lxc) is actually a function, it
     # overwrites the environment and we would lose LXD_DIR's value otherwise.
 
-    # shellcheck disable=2039,3043
     local LXD_DIR
 
     daemon_dir=${1}
@@ -277,7 +273,6 @@ shutdown_lxd() {
 }
 
 wait_for() {
-    # shellcheck disable=SC2039,3043
     local addr op
 
     addr=${1}
@@ -294,7 +289,6 @@ wipe() {
         fi
     fi
 
-    # shellcheck disable=SC2039,3043
     local pid
     # shellcheck disable=SC2009
     ps aux | grep lxc-monitord | grep "${1}" | awk '{print $2}' | while read -r pid; do
@@ -310,7 +304,6 @@ wipe() {
 
 # Kill and cleanup LXD instances and related resources
 cleanup_lxds() {
-    # shellcheck disable=SC2039,3043
     local test_dir daemon_dir
     test_dir="$1"
 

--- a/test/includes/net.sh
+++ b/test/includes/net.sh
@@ -13,7 +13,6 @@ EOF
         return
     fi
 
-    # shellcheck disable=SC2039,3043
     local port pid
 
     while true; do

--- a/test/includes/setup.sh
+++ b/test/includes/setup.sh
@@ -1,7 +1,6 @@
 # Test setup helper functions.
 
 ensure_has_localhost_remote() {
-    # shellcheck disable=SC2039,3043
     local addr="${1}"
     if ! lxc remote list | grep -q "localhost"; then
         token="$(lxc config trust add --name foo -q)"

--- a/test/includes/storage.sh
+++ b/test/includes/storage.sh
@@ -2,7 +2,6 @@
 
 # Whether a storage backend is available
 storage_backend_available() {
-    # shellcheck disable=2039,3043
     local backends
     backends="$(available_storage_backends)"
     if [ "${backends#*"$1"}" != "$backends" ]; then
@@ -36,7 +35,6 @@ storage_backend() {
 
 # Return a list of available storage backends
 available_storage_backends() {
-    # shellcheck disable=2039,3043
     local backend backends storage_backends
 
     backends="dir" # always available
@@ -56,7 +54,6 @@ available_storage_backends() {
 }
 
 import_storage_backends() {
-    # shellcheck disable=SC2039,3043
     local backend
     for backend in $(available_storage_backends); do
         # shellcheck disable=SC1090
@@ -65,7 +62,6 @@ import_storage_backends() {
 }
 
 configure_loop_device() {
-    # shellcheck disable=SC2039,3043
     local lv_loop_file pvloopdev
 
     # shellcheck disable=SC2153
@@ -82,17 +78,13 @@ configure_loop_device() {
     # The following code enables to return a value from a shell function by
     # calling the function as: fun VAR1
 
-    # shellcheck disable=2039,3043
     local __tmp1="${1}"
-    # shellcheck disable=2039,3043
     local res1="${lv_loop_file}"
     if [ "${__tmp1}" ]; then
         eval "${__tmp1}='${res1}'"
     fi
 
-    # shellcheck disable=2039,3043
     local __tmp2="${2}"
-    # shellcheck disable=2039,3043
     local res2="${pvloopdev}"
     if [ "${__tmp2}" ]; then
         eval "${__tmp2}='${res2}'"
@@ -100,7 +92,6 @@ configure_loop_device() {
 }
 
 deconfigure_loop_device() {
-    # shellcheck disable=SC2039,3043
     local lv_loop_file loopdev success
     lv_loop_file="${1}"
     loopdev="${2}"
@@ -129,7 +120,6 @@ deconfigure_loop_device() {
 }
 
 umount_loops() {
-    # shellcheck disable=SC2039,3043
     local line test_dir
     test_dir="$1"
 

--- a/test/lint/auth-up-to-date.sh
+++ b/test/lint/auth-up-to-date.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 f="lxd/auth/entitlements_generated.go"
 

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 # Default target branch.
 target_branch="main"

--- a/test/lint/i18n-up-to-date.sh
+++ b/test/lint/i18n-up-to-date.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 safe_pot_hash() {
   sed -e "/Project-Id-Version/,/Content-Transfer-Encoding/d" -e "/^#/d" "po/lxd.pot" | md5sum | cut -f1 -d" "

--- a/test/lint/licenses.sh
+++ b/test/lint/licenses.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 # Check LXD doesn't include non-permissive licenses (except for itself).
 mv COPYING COPYING.tmp

--- a/test/lint/metadata-up-to-date.sh
+++ b/test/lint/metadata-up-to-date.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 hash_before="lxd/metadata-before.txt"
 hash_after="lxd/metadata-after.txt"

--- a/test/lint/mixed-whitespace.sh
+++ b/test/lint/mixed-whitespace.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 echo "Checking for mixed tabs and spaces in shell scripts..."
 

--- a/test/lint/negated-is-bool.sh
+++ b/test/lint/negated-is-bool.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 echo "Checking usage of negated shared.Is(True|False)*() functions..."
 

--- a/test/lint/newline-after-block.sh
+++ b/test/lint/newline-after-block.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 echo "Checking that functional blocks are followed by newlines..."
 

--- a/test/lint/no-oneline-assign-and-test.sh
+++ b/test/lint/no-oneline-assign-and-test.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 echo "Checking for oneline assign & test..."
 

--- a/test/lint/no-short-form-imports.sh
+++ b/test/lint/no-short-form-imports.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 echo "Checking for short form imports..."
 

--- a/test/lint/rest-api-up-to-date.sh
+++ b/test/lint/rest-api-up-to-date.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 f="doc/rest-api.yaml"
 

--- a/test/lint/trailing-space.sh
+++ b/test/lint/trailing-space.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 
 echo "Checking that there are no trailing spaces in shell scripts..."
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
 # Don't translate lxc output for parsing in it in tests.

--- a/test/main.sh
+++ b/test/main.sh
@@ -30,7 +30,6 @@ LXD_NETNS=""
 
 import_subdir_files() {
     test "$1"
-    # shellcheck disable=SC2039,3043
     local file
     for file in "$1"/*.sh; do
         # shellcheck disable=SC1090
@@ -159,7 +158,6 @@ run_test() {
   echo "==> TEST BEGIN: ${TEST_CURRENT_DESCRIPTION}"
   START_TIME=$(date +%s)
 
-  # shellcheck disable=SC2039,3043
   local skip=false
 
   # Skip test if requested.

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/bash
+set -eu
 #
 # Performance tests runner
 #

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -13,7 +13,6 @@ LXD_NETNS=""
 
 import_subdir_files() {
     test  "$1"
-    # shellcheck disable=SC2039,3043
     local file
     for file in "$1"/*.sh; do
         # shellcheck disable=SC1090
@@ -28,7 +27,6 @@ log_message() {
 }
 
 run_benchmark() {
-    # shellcheck disable=SC2039,3043
     local label description
     label="$1"
     description="$2"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1,5 +1,4 @@
 test_basic_usage() {
-  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2099,11 +2099,12 @@ test_clustering_image_replication() {
 }
 
 test_clustering_dns() {
-  local LXD_DIR
+  local lxdDir
 
   # Because we do not want tests to only run on Ubuntu (due to cluster's fan network dependency)
   # instead we will just spawn forkdns directly and check DNS resolution.
 
+  # XXX: make a copy of the global LXD_DIR
   # shellcheck disable=SC2031
   lxdDir="${LXD_DIR}"
   prefix="lxd$$"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1,5 +1,4 @@
 test_clustering_enable() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_INIT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
@@ -179,7 +178,6 @@ test_clustering_enable() {
 }
 
 test_clustering_membership() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -378,7 +376,6 @@ test_clustering_membership() {
 }
 
 test_clustering_containers() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -564,7 +561,6 @@ test_clustering_containers() {
 }
 
 test_clustering_storage() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -972,7 +968,6 @@ test_clustering_storage() {
 # two-stage process required multi-node clusters, or directly with the normal
 # procedure for non-clustered daemons.
 test_clustering_storage_single_node() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1044,7 +1039,6 @@ test_clustering_storage_single_node() {
 }
 
 test_clustering_network() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1244,7 +1238,6 @@ test_clustering_network() {
 # Perform an upgrade of a 2-member cluster, then a join a third member and
 # perform one more upgrade
 test_clustering_upgrade() {
-  # shellcheck disable=2039,3043
   local LXD_DIR LXD_NETNS
 
   setup_clustering_bridge
@@ -1340,7 +1333,6 @@ test_clustering_upgrade() {
 
 # Perform an upgrade of an 8-member cluster.
 test_clustering_upgrade_large() {
-  # shellcheck disable=2039,3043
   local LXD_DIR LXD_NETNS N
 
   setup_clustering_bridge
@@ -1396,7 +1388,6 @@ test_clustering_upgrade_large() {
 }
 
 test_clustering_publish() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1448,7 +1439,6 @@ test_clustering_publish() {
 }
 
 test_clustering_profiles() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1522,7 +1512,6 @@ EOF
 }
 
 test_clustering_update_cert() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1601,7 +1590,6 @@ test_clustering_update_cert() {
 }
 
 test_clustering_update_cert_reversion() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1695,7 +1683,7 @@ test_clustering_update_cert_reversion() {
 }
 
 test_clustering_join_api() {
-  # shellcheck disable=2039,2034,3043
+  # shellcheck disable=SC2034
   local LXD_DIR LXD_NETNS
 
   setup_clustering_bridge
@@ -1736,7 +1724,6 @@ test_clustering_join_api() {
 }
 
 test_clustering_shutdown_nodes() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1808,7 +1795,6 @@ test_clustering_shutdown_nodes() {
 }
 
 test_clustering_projects() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1873,7 +1859,6 @@ test_clustering_projects() {
 }
 
 test_clustering_address() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -1952,7 +1937,6 @@ test_clustering_address() {
 }
 
 test_clustering_image_replication() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2115,7 +2099,6 @@ test_clustering_image_replication() {
 }
 
 test_clustering_dns() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   # Because we do not want tests to only run on Ubuntu (due to cluster's fan network dependency)
@@ -2200,7 +2183,7 @@ test_clustering_dns() {
 }
 
 test_clustering_recover() {
-  # shellcheck disable=2039,2034,3043
+  # shellcheck disable=SC2034
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2282,7 +2265,7 @@ test_clustering_recover() {
 # When a voter cluster member is shutdown, its role gets transferred to a spare
 # node.
 test_clustering_handover() {
-  # shellcheck disable=2039,2034,3043
+  # shellcheck disable=SC2034
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2400,7 +2383,7 @@ test_clustering_handover() {
 # If a voter node crashes and is detected as offline, its role is migrated to a
 # stand-by.
 test_clustering_rebalance() {
-  # shellcheck disable=2039,2034,3043
+  # shellcheck disable=SC2034
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2489,7 +2472,6 @@ test_clustering_rebalance() {
 # Recover a cluster where a raft node was removed from the nodes table but not
 # from the raft configuration.
 test_clustering_remove_raft_node() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2610,7 +2592,6 @@ test_clustering_remove_raft_node() {
 }
 
 test_clustering_failure_domains() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2714,7 +2695,6 @@ test_clustering_failure_domains() {
 }
 
 test_clustering_image_refresh() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -2946,7 +2926,6 @@ test_clustering_image_refresh() {
 }
 
 test_clustering_evacuation() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3095,7 +3074,6 @@ test_clustering_evacuation() {
 }
 
 test_clustering_edit_configuration() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3244,7 +3222,6 @@ test_clustering_edit_configuration() {
 }
 
 test_clustering_remove_members() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3382,7 +3359,6 @@ test_clustering_remove_members() {
 }
 
 test_clustering_autotarget() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3434,7 +3410,6 @@ test_clustering_autotarget() {
 }
 
 test_clustering_groups() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3624,7 +3599,6 @@ test_clustering_groups() {
 }
 
 test_clustering_events() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3826,7 +3800,6 @@ test_clustering_events() {
 }
 
 test_clustering_uuid() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge
@@ -3883,7 +3856,6 @@ test_clustering_uuid() {
 }
 
 test_clustering_trust_add() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   setup_clustering_bridge

--- a/test/suites/clustering_instance_placement_scriptlet.sh
+++ b/test/suites/clustering_instance_placement_scriptlet.sh
@@ -1,5 +1,5 @@
 test_clustering_instance_placement_scriptlet() {
-  # shellcheck disable=2039,3043,SC2034
+  # shellcheck disable=SC2034
   local LXD_DIR
 
   setup_clustering_bridge

--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -1,5 +1,5 @@
 test_clustering_move() {
-  # shellcheck disable=2039,3043,SC2034
+  # shellcheck disable=SC2034
   local LXD_DIR
 
   setup_clustering_bridge

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -325,7 +325,6 @@ test_property() {
 
 
   # Create a storage volume, create a volume snapshot and set its expiration timestamp
-  # shellcheck disable=2039,3043
   local storage_pool
   storage_pool="lxdtest-$(basename "${LXD_DIR}")"
   storage_volume="${storage_pool}-vol"
@@ -347,8 +346,8 @@ test_property() {
 }
 
 test_config_edit_container_snapshot_pool_config() {
-    # shellcheck disable=2034,2039,2155,3043
-    local storage_pool="lxdtest-$(basename "${LXD_DIR}")"
+    local storage_pool
+    storage_pool="lxdtest-$(basename "${LXD_DIR}")"
 
     ensure_import_testimage
 

--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -15,7 +15,6 @@ test_container_devices_disk() {
 }
 
 _container_devices_disk_shift() {
-  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
@@ -122,7 +121,6 @@ _container_devices_raw_mount_options() {
 }
 
 _container_devices_disk_ceph() {
-  # shellcheck disable=SC2039,3043
   local LXD_BACKEND
 
   LXD_BACKEND=$(storage_backend "$LXD_DIR")
@@ -147,7 +145,6 @@ _container_devices_disk_ceph() {
 }
 
 _container_devices_disk_cephfs() {
-  # shellcheck disable=SC2039,3043
   local LXD_BACKEND
 
   LXD_BACKEND=$(storage_backend "$LXD_DIR")

--- a/test/suites/container_local_cross_pool_handling.sh
+++ b/test/suites/container_local_cross_pool_handling.sh
@@ -1,7 +1,6 @@
 test_container_local_cross_pool_handling() {
   ensure_import_testimage
 
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
   LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)

--- a/test/suites/database.sh
+++ b/test/suites/database.sh
@@ -43,7 +43,6 @@ EOF
 }
 
 test_database_no_disk_space() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_NOSPACE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)

--- a/test/suites/filtering.sh
+++ b/test/suites/filtering.sh
@@ -1,6 +1,5 @@
 # Test API filtering.
 test_filtering() {
-  # shellcheck disable=2039,3043
   local LXD_DIR
 
   LXD_FILTERING_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -1,5 +1,4 @@
 test_image_expiry() {
-  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"
@@ -81,8 +80,8 @@ test_image_expiry() {
 
 test_image_list_all_aliases() {
     ensure_import_testimage
-    # shellcheck disable=2039,2034,2155,3043
-    local sum="$(lxc image info testimage | awk '/^Fingerprint/ {print $2}')"
+    local sum
+    sum="$(lxc image info testimage | awk '/^Fingerprint/ {print $2}')"
     lxc image alias create zzz "$sum"
     lxc image list | grep -vq zzz
     # both aliases are listed if the "aliases" column is included in output
@@ -94,17 +93,17 @@ test_image_list_all_aliases() {
 test_image_import_dir() {
     ensure_import_testimage
     lxc image export testimage
-    # shellcheck disable=2039,2034,2155,3043
-    local image="$(ls -1 -- *.tar.xz)"
+    local image
+    image="$(ls -1 -- *.tar.xz)"
     mkdir -p unpacked
     tar -C unpacked -xf "$image"
-    # shellcheck disable=2039,2034,2155,3043
-    local fingerprint="$(lxc image import unpacked | awk '{print $NF;}')"
+    local fingerprint
+    fingerprint="$(lxc image import unpacked | awk '{print $NF;}')"
     rm -rf "$image" unpacked
 
     lxc image export "$fingerprint"
-    # shellcheck disable=2039,2034,2155,3043
-    local exported="${fingerprint}.tar.xz"
+    local exported
+    exported="${fingerprint}.tar.xz"
 
     tar tvf "$exported" | grep -Fq metadata.yaml
     rm "$exported"
@@ -125,7 +124,6 @@ test_image_import_existing_alias() {
 }
 
 test_image_refresh() {
-  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"

--- a/test/suites/image_auto_update.sh
+++ b/test/suites/image_auto_update.sh
@@ -3,7 +3,6 @@ test_image_auto_update() {
       lxc image delete testimage
   fi
 
-  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"

--- a/test/suites/image_prefer_cached.sh
+++ b/test/suites/image_prefer_cached.sh
@@ -6,7 +6,6 @@ test_image_prefer_cached() {
       lxc image delete testimage
   fi
 
-  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"

--- a/test/suites/incremental_copy.sh
+++ b/test/suites/incremental_copy.sh
@@ -5,7 +5,6 @@ test_incremental_copy() {
   do_copy "" ""
 
   # cross-pool copy
-  # shellcheck disable=2039,3043
   local source_pool
   source_pool="lxdtest-$(basename "${LXD_DIR}")-dir-pool"
   lxc storage create "${source_pool}" dir
@@ -14,9 +13,7 @@ test_incremental_copy() {
 }
 
 do_copy() {
-  # shellcheck disable=2039,3043
   local source_pool="${1}"
-  # shellcheck disable=2039,3043
   local target_pool="${2}"
 
   # Make sure the containers don't exist

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -1,6 +1,5 @@
 test_migration() {
   # setup a second LXD
-  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR lxd_backend
   # shellcheck disable=2153
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -29,7 +28,6 @@ test_migration() {
   if [ "${LXD_BACKEND}" = "lvm" ]; then
     # Test that non-thinpool lvm backends work fine with migration.
 
-    # shellcheck disable=2039,3043
     local storage_pool1 storage_pool2
     # shellcheck disable=2153
     storage_pool1="lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-migration"
@@ -57,7 +55,6 @@ test_migration() {
         continue
       fi
 
-      # shellcheck disable=2039,3043
       local storage_pool1 storage_pool2
       # shellcheck disable=2153
       storage_pool1="lxdtest-$(basename "${LXD_DIR}")-block-mode"
@@ -84,7 +81,6 @@ test_migration() {
 }
 
 migration() {
-  # shellcheck disable=2039,3043
   local lxd2_dir lxd_backend lxd2_backend
   lxd2_dir="$1"
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -741,7 +741,6 @@ test_projects_limits() {
   # too small for resize2fs.
   if [ "${LXD_BACKEND}" = "dir" ] || [ "${LXD_BACKEND}" = "zfs" ]; then
     # Add a remote LXD to be used as image server.
-    # shellcheck disable=2039,3043
     local LXD_REMOTE_DIR
     LXD_REMOTE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
     chmod +x "${LXD_REMOTE_DIR}"

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -185,7 +185,6 @@ test_remote_admin() {
 }
 
 test_remote_usage() {
-  # shellcheck disable=2039,3043
   local LXD2_DIR LXD2_ADDR
   LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD2_DIR}"

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -24,14 +24,14 @@ test_security() {
   lxc launch testimage test-priv -c security.privileged=true
 
   PERM=$(stat -L -c %a "${LXD_DIR}/containers/test-priv")
-  UID=$(stat -L -c %u "${LXD_DIR}/containers/test-priv")
+  FUID=$(stat -L -c %u "${LXD_DIR}/containers/test-priv")
   if [ "${PERM}" != "100" ]; then
     echo "Bad container permissions: ${PERM}"
     false
   fi
 
-  if [ "${UID}" != "0" ]; then
-    echo "Bad container owner: ${UID}"
+  if [ "${FUID}" != "0" ]; then
+    echo "Bad container owner: ${FUID}"
     false
   fi
 
@@ -41,14 +41,14 @@ test_security() {
   lxc restart test-priv --force
 
   PERM=$(stat -L -c %a "${LXD_DIR}/containers/test-priv")
-  UID=$(stat -L -c %u "${LXD_DIR}/containers/test-priv")
+  FUID=$(stat -L -c %u "${LXD_DIR}/containers/test-priv")
   if [ "${PERM}" != "100" ]; then
     echo "Bad container permissions: ${PERM}"
     false
   fi
 
-  if [ "${UID}" != "0" ]; then
-    echo "Bad container owner: ${UID}"
+  if [ "${FUID}" != "0" ]; then
+    echo "Bad container owner: ${FUID}"
     false
   fi
 
@@ -59,14 +59,14 @@ test_security() {
   lxc restart test-unpriv --force
 
   PERM=$(stat -L -c %a "${LXD_DIR}/containers/test-unpriv")
-  UID=$(stat -L -c %u "${LXD_DIR}/containers/test-unpriv")
+  FUID=$(stat -L -c %u "${LXD_DIR}/containers/test-unpriv")
   if [ "${PERM}" != "100" ]; then
     echo "Bad container permissions: ${PERM}"
     false
   fi
 
-  if [ "${UID}" != "0" ]; then
-    echo "Bad container owner: ${UID}"
+  if [ "${FUID}" != "0" ]; then
+    echo "Bad container owner: ${FUID}"
     false
   fi
 
@@ -74,14 +74,14 @@ test_security() {
   lxc restart test-unpriv --force
 
   PERM=$(stat -L -c %a "${LXD_DIR}/containers/test-unpriv")
-  UID=$(stat -L -c %u "${LXD_DIR}/containers/test-unpriv")
+  FUID=$(stat -L -c %u "${LXD_DIR}/containers/test-unpriv")
   if [ "${PERM}" != "100" ]; then
     echo "Bad container permissions: ${PERM}"
     false
   fi
 
-  if [ "${UID}" = "0" ]; then
-    echo "Bad container owner: ${UID}"
+  if [ "${FUID}" = "0" ]; then
+    echo "Bad container owner: ${FUID}"
     false
   fi
 

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -87,7 +87,6 @@ test_security() {
 
   lxc delete test-unpriv --force
 
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR
 
   LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -21,7 +21,6 @@ _server_config_access() {
 }
 
 _server_config_storage() {
-  # shellcheck disable=2039,3043
   local lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -17,7 +17,6 @@ test_snapshots() {
 }
 
 snapshots() {
-  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
   pool="$1"
@@ -126,7 +125,6 @@ test_snap_restore() {
 }
 
 snap_restore() {
-  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
   pool="$1"
@@ -343,7 +341,6 @@ restore_and_compare_fs() {
 }
 
 test_snap_expiry() {
-  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
@@ -369,7 +366,6 @@ test_snap_expiry() {
 }
 
 test_snap_schedule() {
-  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 
@@ -396,7 +392,6 @@ test_snap_schedule() {
 }
 
 test_snap_volume_db_recovery() {
-  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -1,7 +1,6 @@
 test_storage() {
   ensure_import_testimage
 
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -10,7 +9,6 @@ test_storage() {
   spawn_lxd "${LXD_STORAGE_DIR}" false
 
   # edit storage and pool description
-  # shellcheck disable=2039,3043
   local storage_pool storage_volume
   storage_pool="lxdtest-$(basename "${LXD_DIR}")-pool"
   storage_volume="${storage_pool}-vol"
@@ -49,7 +47,6 @@ test_storage() {
 
   # Test btrfs resize
   if [ "$lxd_backend" = "lvm" ] || [ "$lxd_backend" = "ceph" ]; then
-      # shellcheck disable=2039,3043
       local btrfs_storage_pool btrfs_storage_volume
       btrfs_storage_pool="lxdtest-$(basename "${LXD_DIR}")-pool-btrfs"
       btrfs_storage_volume="${storage_pool}-vol"

--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -1,5 +1,4 @@
 s3cmdrun () {
-  # shellcheck disable=2039,3043
   local backend accessKey secreyKey
   backend="${1}"
   accessKey="${2}"
@@ -27,7 +26,6 @@ s3cmdrun () {
 }
 
 test_storage_buckets() {
-  # shellcheck disable=2039,3043
   local lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/storage_driver_btrfs.sh
+++ b/test/suites/storage_driver_btrfs.sh
@@ -1,5 +1,4 @@
 test_storage_driver_btrfs() {
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/storage_driver_ceph.sh
+++ b/test/suites/storage_driver_ceph.sh
@@ -1,5 +1,4 @@
 test_storage_driver_ceph() {
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/storage_driver_cephfs.sh
+++ b/test/suites/storage_driver_cephfs.sh
@@ -1,5 +1,4 @@
 test_storage_driver_cephfs() {
-  # shellcheck disable=2039,3043
   local lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/storage_driver_dir.sh
+++ b/test/suites/storage_driver_dir.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 test_storage_driver_dir() {
   do_dir_on_empty_fs

--- a/test/suites/storage_driver_dir.sh
+++ b/test/suites/storage_driver_dir.sh
@@ -5,7 +5,6 @@ test_storage_driver_dir() {
 }
 
 do_dir_on_empty_fs() {
-  # shellcheck disable=2039,3043
   local lxd_backend
 
   lxd_backend=$(storage_backend "${LXD_DIR}")

--- a/test/suites/storage_driver_zfs.sh
+++ b/test/suites/storage_driver_zfs.sh
@@ -8,7 +8,6 @@ test_storage_driver_zfs() {
 }
 
 do_zfs_delegate() {
-  # shellcheck disable=2039,3043
   local lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -46,7 +45,6 @@ do_zfs_delegate() {
 }
 
 do_zfs_cross_pool_copy() {
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -118,7 +116,6 @@ do_storage_driver_zfs() {
     return
   fi
 
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")

--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -1,7 +1,6 @@
 test_storage_local_volume_handling() {
   ensure_import_testimage
 
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
   LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -2,7 +2,6 @@ test_storage_volume_snapshots() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  # shellcheck disable=2039,3043
   local LXD_STORAGE_DIR lxd_backend
 
   lxd_backend=$(storage_backend "$LXD_DIR")
@@ -10,7 +9,6 @@ test_storage_volume_snapshots() {
   chmod +x "${LXD_STORAGE_DIR}"
   spawn_lxd "${LXD_STORAGE_DIR}" false
 
-  # shellcheck disable=2039,3043
   local storage_pool storage_volume
   storage_pool="lxdtest-$(basename "${LXD_STORAGE_DIR}")-pool"
   storage_pool2="${storage_pool}2"

--- a/test/suites/template.sh
+++ b/test/suites/template.sh
@@ -1,5 +1,4 @@
 test_template() {
-  # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
 


### PR DESCRIPTION
Also, since we are using `bash`, stop silencing the `local` is not supported by `sh` as it works now.