### PR TITLE
Device: Fix crash when device doesn't return run config when being live updated (stable-5.21)

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1523,7 +1523,7 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 				"config": entry.Config,
 			}
 
-			if len(runConf.Mounts) > 0 {
+			if runConf != nil && len(runConf.Mounts) > 0 {
 				for _, opt := range runConf.Mounts[0].Opts {
 					if strings.HasPrefix(opt, "mountTag=") {
 						parts := strings.SplitN(opt, "=", 2)


### PR DESCRIPTION
Fixes #13774