### PR TITLE
lxd/apparmor: allow userns for security.nesting=true case

### DIFF
--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -185,7 +185,7 @@ func parserSupports(sysOS *sys.OS, feature string) (bool, error) {
 		return ver.Compare(minVer) >= 0, nil
 	}
 
-	if feature == "mount_nosymfollow" {
+	if feature == "mount_nosymfollow" || feature == "userns_rule" {
 		sysOS.AppArmorFeatures.Lock()
 		defer sysOS.AppArmorFeatures.Unlock()
 		supported, ok := sysOS.AppArmorFeatures.Map[feature]

--- a/lxd/apparmor/feature_check.go
+++ b/lxd/apparmor/feature_check.go
@@ -20,6 +20,10 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount options=(nosymfollow) /,
 {{- end }}
 
+{{- if eq .feature "userns_rule" }}
+  userns,
+{{- end }}
+
 }
 `))
 

--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -161,12 +161,18 @@ func instanceProfile(sysOS *sys.OS, inst instance) (string, error) {
 			return "", err
 		}
 
+		usernsRuleSupported, err := parserSupports(sysOS, "userns_rule")
+		if err != nil {
+			return "", err
+		}
+
 		err = lxcProfileTpl.Execute(sb, map[string]any{
 			"feature_cgns":              sysOS.CGInfo.Namespacing,
 			"feature_cgroup2":           sysOS.CGInfo.Layout == cgroup.CgroupsUnified || sysOS.CGInfo.Layout == cgroup.CgroupsHybrid,
 			"feature_stacking":          sysOS.AppArmorStacking && !sysOS.AppArmorStacked,
 			"feature_unix":              unixSupported,
 			"feature_mount_nosymfollow": mountNosymfollowSupported,
+			"feature_userns_rule":       usernsRuleSupported,
 			"name":                      InstanceProfileName(inst),
 			"namespace":                 InstanceNamespaceName(inst),
 			"nesting":                   shared.IsTrue(inst.ExpandedConfig()["security.nesting"]),

--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -466,6 +466,11 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   ### Configuration: nesting
   pivot_root,
 
+  # Allow user namespaces to be created
+{{- if .feature_userns_rule }}
+  userns,
+{{- end }}
+
   # Allow sending signals and tracing children namespaces
   ptrace,
   signal,


### PR DESCRIPTION
Right now this patch does not change anything, because user namespaces are always allowed. But after we merge https://github.com/canonical/lxd-pkg-snap/pull/277 user namespaces become restricted by default and we need to explicitly allow it when needed.