### PR TITLE
lxd: Update logic for project config patch

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -599,14 +599,14 @@ func projectPatch(d *Daemon, r *http.Request) response.Response {
 		req.Description = project.Description
 	}
 
-	config, err := reqRaw.GetMap("config")
-	if err != nil {
-		req.Config = project.Config
-	} else {
-		for k, v := range project.Config {
-			_, ok := config[k]
-			if !ok {
-				config[k] = v
+	// Perform config patch
+	req.Config = util.CopyConfig(project.Config)
+	patches, err := reqRaw.GetMap("config")
+	if err == nil {
+		for k, v := range patches {
+			strVal, ok := v.(string)
+			if ok {
+				req.Config[k] = strVal
 			}
 		}
 	}

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -20,6 +20,10 @@ test_projects_crud() {
   lxc project show foo | grep -q 'features.images: "true"'
   lxc project get foo "features.profiles" | grep -q 'true'
 
+  # Set a limit
+  lxc project set foo limits.containers 10
+  lxc project show foo | grep -q 'limits.containers: "10"'
+
   # Trying to create a project with the same name fails
   ! lxc project create foo || false
 
@@ -36,6 +40,13 @@ test_projects_crud() {
   # Edit the project
   lxc project show bar| sed 's/^description:.*/description: "Bar project"/' | lxc project edit bar
   lxc project show bar | grep -q "description: Bar project"
+
+  # Edit the project config via PATCH. Existing key/value pairs should remain or be updated.
+  lxc query -X PATCH -d '{\"config\" : {\"limits.memory\":\"5GiB\",\"features.images\":\"false\"}}' /1.0/projects/bar
+  lxc project show bar | grep -q 'limits.memory: 5GiB'
+  lxc project show bar | grep -q 'features.images: "false"'
+  lxc project show bar | grep -q 'features.profiles: "true"'
+  lxc project show bar | grep -q 'limits.containers: "10"'
 
   # Create a second project
   lxc project create foo


### PR DESCRIPTION
This PR provides an update to the logic for patching project configurations. Previously, there was an overwrite of the existing project config such that it was updated to consist solely of the data in the patch. With this update we maintain existing key/value pairs, and only overwrite those also present in the patch.

Closes #13632.