### PR TITLE
Lower qemu-img convert priority during conversion instead of limiting cpu time

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1826,8 +1826,8 @@ func (b *lxdBackend) imageConversionFiller(imgPath string, imgFormat string) fun
 
 		// Convert uploaded image from backups directory into RAW format on the instance volume.
 		cmd := []string{
-			// Use prlimit to limit QEMU to 1 GiB address space and 120 seconds of CPU time.
-			"prlimit", "--cpu=120", "--as=1073741824",
+			// Run with low priority to reduce CPU impact on other processes.
+			"nice", "-n19",
 			"qemu-img", "convert", "-f", imgFormat, "-O", "raw", imgPath, diskPath,
 		}
 


### PR DESCRIPTION
Lower `qemu-img convert` priority instead of limiting it to 2 minutes during the image conversion. This also make it consistent with ImageUnpack.