### PR TITLE
Update metrics.md to remove symlink trailing slash

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -124,7 +124,7 @@ cp /var/snap/lxd/common/lxd/server.crt /var/snap/prometheus/common/tls/
 
 # Create a symbolic link pointing to tls directory that you created
 # https://bugs.launchpad.net/prometheus-snap/+bug/2066910
-ln -s /var/snap/prometheus/common/tls/ /var/snap/prometheus/current/tls/
+ln -s /var/snap/prometheus/common/tls/ /var/snap/prometheus/current/tls
 ```
 
 If you are not using the snap, you must also make sure that Prometheus can read these files (usually, Prometheus is run as user `prometheus`):


### PR DESCRIPTION
Tiny fix. Trailing slash in the symbolic link probably should not be there.

When I run the command: "ln -s /var/snap/prometheus/common/tls/ /var/snap/prometheus/current/tls/"

The result is: "ln: failed to create symbolic link '/var/snap/prometheus/current/tls/': No such file or directory"

Removing the trailing slash from the symbolic link command corrects this and creates the sym link.