### PR TITLE
doc/storage: change examples to sections instead of tabs

### DIFF
--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -25,9 +25,7 @@ See the {ref}`storage-drivers` documentation for a list of available configurati
 
 See the following examples for how to create a storage pool using different storage drivers.
 
-`````{tabs}
-
-````{group-tab} Directory
+#### Create a directory pool
 
 Create a directory pool named `pool1`:
 
@@ -36,8 +34,8 @@ Create a directory pool named `pool1`:
 Use the existing directory `/data/lxd` for `pool2`:
 
     lxc storage create pool2 dir source=/data/lxd
-````
-````{group-tab} Btrfs
+
+#### Create a Btrfs pool
 
 Create a loop-backed pool named `pool1`:
 
@@ -50,8 +48,8 @@ Use the existing Btrfs file system at `/some/path` for `pool2`:
 Create a pool named `pool3` on `/dev/sdX`:
 
     lxc storage create pool3 btrfs source=/dev/sdX
-````
-````{group-tab} LVM
+
+#### Create an LVM pool
 
 Create a loop-backed pool named `pool1` (the LVM volume group will also be called `pool1`):
 
@@ -72,8 +70,8 @@ Create a pool named `pool4` on `/dev/sdX` (the LVM volume group will also be cal
 Create a pool named `pool5` on `/dev/sdX` with the LVM volume group name `my-pool`:
 
     lxc storage create pool5 lvm source=/dev/sdX lvm.vg_name=my-pool
-````
-````{group-tab} ZFS
+
+#### Create a ZFS pool
 
 Create a loop-backed pool named `pool1` (the ZFS zpool will also be called `pool1`):
 
@@ -102,8 +100,8 @@ Create a pool named `pool6` on `/dev/sdX` (the ZFS zpool will also be called `po
 Create a pool named `pool7` on `/dev/sdX` with the ZFS zpool name `my-tank`:
 
     lxc storage create pool7 zfs source=/dev/sdX zfs.pool_name=my-tank
-````
-````{group-tab} Ceph RBD
+
+#### Create a Ceph RBD pool
 
 Create an OSD storage pool named `pool1` in the default Ceph cluster (named `ceph`):
 
@@ -124,8 +122,8 @@ Use the existing OSD storage pool `my-already-existing-osd` for `pool4`:
 Use the existing OSD erasure-coded pool `ecpool` and the OSD replicated pool `rpl-pool` for `pool5`:
 
     lxc storage create pool5 ceph source=rpl-pool ceph.osd.data_pool_name=ecpool
-````
-````{group-tab} CephFS
+
+#### Create a CephFS pool
 
 ```{note}
 Each CephFS file system consists of two OSD storage pools, one for the actual data and one for the file metadata.
@@ -143,8 +141,7 @@ Create a CephFS file system `my-filesystem` with a data pool called `my-data` an
 
     lxc storage create pool3 cephfs source=my-filesystem cephfs.create_missing=true cephfs.data_pool=my-data cephfs.meta_pool=my-metadata
 
-````
-````{group-tab} Ceph Object
+#### Create a Ceph Object pool
 
 ```{note}
 When using the Ceph Object driver, you must have a running Ceph Object Gateway [`radosgw`](https://docs.ceph.com/en/latest/radosgw/) URL available beforehand.
@@ -153,16 +150,16 @@ When using the Ceph Object driver, you must have a running Ceph Object Gateway [
 Use the existing Ceph Object Gateway `https://www.example.com/radosgw` to create `pool1`:
 
     lxc storage create pool1 cephobject cephobject.radosgw.endpoint=https://www.example.com/radosgw
-````
-````{group-tab} Dell PowerFlex
+
+#### Create a Dell PowerFlex pool
 
 Create a storage pool named `pool1` using the PowerFlex pool `sp1` in the protection domain `pd1`:
 
     lxc storage create pool1 powerflex powerflex.pool=sp1 powerflex.domain=pd1 powerflex.gateway=https://powerflex powerflex.user.name=lxd powerflex.user.password=foo
 
-Create a storage pool named `pool2` using the id of PowerFlex pool `sp1`:
+Create a storage pool named `pool2` using the ID of PowerFlex pool `sp1`:
 
-    lxc storage create pool2 powerflex powerflex.pool=<id of sp1> powerflex.gateway=https://powerflex powerflex.user.name=lxd powerflex.user.password=foo
+    lxc storage create pool2 powerflex powerflex.pool=<ID of sp1> powerflex.gateway=https://powerflex powerflex.user.name=lxd powerflex.user.password=foo
 
 Create a storage pool named `pool3` that uses PowerFlex volume snapshots (see {ref}`storage-powerflex-limitations`) when creating volume copies:
 
@@ -175,9 +172,6 @@ Create a storage pool named `pool4` that uses a PowerFlex gateway with a certifi
 Create a storage pool named `pool5` that explicitly uses the PowerFlex SDC:
 
     lxc storage create pool5 powerflex powerflex.mode=sdc powerflex.pool=<id of sp1> powerflex.gateway=https://powerflex powerflex.user.name=lxd powerflex.user.password=foo
-
-````
-`````
 
 (storage-pools-cluster)=
 ### Create a storage pool in a cluster


### PR DESCRIPTION
We have too many storage drivers now, so using tabs for them doesn't scale. ;-)
Also, it will cause problems when adding API/UI instructions anyway, so converting it into sections.

![image](https://github.com/user-attachments/assets/dad97fe3-5343-4dbb-bc9d-4bcd1c890082)
