### PR TITLE
github: Exclude lvm standalone tests as they fail on Github due to lack of space (stable-4.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,9 @@ jobs:
           - go: "1.16.x"
             suite: standalone
             backend: dir
+        exclude:
+          - suite: standalone
+            backend: lvm
 
     steps:
       - name: Performance tuning


### PR DESCRIPTION
Caused by requirement to use 3GiB pool size.