### PR TITLE
Fix unnecessary quota updates

### DIFF
--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -118,18 +118,12 @@ func (d *dir) setQuota(path string, volID int64, sizeBytes int64) error {
 		return err
 	}
 
-	// Remove current project if desired project ID is different.
-	if currentProjectID != d.quotaProjectID(volID) {
-		err = quota.DeleteProject(path, currentProjectID)
+	// Apply new project ID to path
+	if currentProjectID != projectID {
+		err = quota.SetProject(path, projectID)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed setting project: %w", err)
 		}
-	}
-
-	// Initialise the project.
-	err = quota.SetProject(path, projectID)
-	if err != nil {
-		return fmt.Errorf("Failed setting project: %w", err)
 	}
 
 	// Set the project quota size.


### PR DESCRIPTION
This is a bugfix for the issue reported [here](https://github.com/canonical/lxd/issues/13115). I also removed the call to `deleteProject`, because in case a project ID has actually changed, it does not make sense to update the file attributes twice.

If want to emphasize that this is not only a performance tweak. The iteration of all files of a container can take several minutes. If a file gets deleted after LXD has build its file list and before the file attributes update has been performed, a disk resize operation will fail due to "no such file or directory" error. I observed this error multiple times in a productive workload.

If there are any questions, please ask.