### PR TITLE
lxd-migrate: Fix path provided to the raw disk check

### DIFF
--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -347,7 +347,7 @@ func (c *cmdMigrate) runInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 		}
 
 		if config.InstanceArgs.Type == api.InstanceTypeVM && config.InstanceArgs.Source.Type == "migration" {
-			isImageTypeRaw, err := isImageTypeRaw(config.SourcePath)
+			isImageTypeRaw, err := isImageTypeRaw(s)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Wrong path is passed to the `isImageTypeRaw` check.

Introduced in https://github.com/canonical/lxd/pull/13385