### PR TITLE
Specify subject name when generating keypair

### DIFF
--- a/lxc/config/cert.go
+++ b/lxc/config/cert.go
@@ -28,7 +28,7 @@ func (c *Config) GenerateClientCertificate() error {
 	certf := c.ConfigPath("client.crt")
 	keyf := c.ConfigPath("client.key")
 
-	return shared.FindOrGenCert(certf, keyf, true, false)
+	return shared.FindOrGenCert(certf, keyf, true, shared.CertOptions{})
 }
 
 // CopyGlobalCert will copy global (system-wide) certificate to the user config path.

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -1188,7 +1188,7 @@ func (c *cmdFileMount) sshSFTPServer(ctx context.Context, instName string, resou
 	}
 
 	// Generate random host key.
-	_, privKey, err := shared.GenerateMemCert(false, false)
+	_, privKey, err := shared.GenerateMemCert(false, shared.CertOptions{})
 	if err != nil {
 		return fmt.Errorf(i18n.G("Failed generating SSH host key: %w"), err)
 	}

--- a/lxd-agent/network.go
+++ b/lxd-agent/network.go
@@ -49,7 +49,7 @@ func (l *networkListener) Accept() (net.Conn, error) {
 }
 
 func serverTLSConfig() (*tls.Config, error) {
-	certInfo, err := shared.KeyPairAndCA(".", "agent", shared.CertServer, false)
+	certInfo, err := shared.KeyPairAndCA(".", "agent", shared.CertServer, shared.CertOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -170,7 +170,7 @@ func (c *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 		if certPath == "" || keyPath == "" {
 			var err error
 
-			clientCrt, clientKey, err = shared.GenerateMemCert(true, false)
+			clientCrt, clientKey, err = shared.GenerateMemCert(true, shared.CertOptions{})
 			if err != nil {
 				return nil, "", err
 			}

--- a/lxd-user/lxd.go
+++ b/lxd-user/lxd.go
@@ -166,7 +166,7 @@ func lxdSetupUser(uid uint32) error {
 	revert.Add(func() { _ = os.RemoveAll(userPath) })
 
 	// Generate certificate.
-	err = shared.FindOrGenCert(filepath.Join(userPath, "client.crt"), filepath.Join(userPath, "client.key"), true, false)
+	err = shared.FindOrGenCert(filepath.Join(userPath, "client.crt"), filepath.Join(userPath, "client.key"), true, shared.CertOptions{})
 	if err != nil {
 		return fmt.Errorf("Failed to generate user certificate: %w", err)
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -514,13 +514,13 @@ func (d *qemu) generateAgentCert() (agentCert string, agentKey string, clientCer
 	clientKeyFile := filepath.Join(d.Path(), "agent-client.key")
 
 	// Create server certificate.
-	err = shared.FindOrGenCert(agentCertFile, agentKeyFile, false, false)
+	err = shared.FindOrGenCert(agentCertFile, agentKeyFile, false, shared.CertOptions{})
 	if err != nil {
 		return "", "", "", "", err
 	}
 
 	// Create client certificate.
-	err = shared.FindOrGenCert(clientCertFile, clientKeyFile, true, false)
+	err = shared.FindOrGenCert(clientCertFile, clientKeyFile, true, shared.CertOptions{})
 	if err != nil {
 		return "", "", "", "", err
 	}

--- a/lxd/util/encryption.go
+++ b/lxd/util/encryption.go
@@ -18,7 +18,7 @@ func LoadCert(dir string) (*shared.CertInfo, error) {
 		prefix = "cluster"
 	}
 
-	cert, err := shared.KeyPairAndCA(dir, prefix, shared.CertServer, true)
+	cert, err := shared.KeyPairAndCA(dir, prefix, shared.CertServer, shared.CertOptions{AddHosts: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS certificate: %w", err)
 	}
@@ -32,7 +32,7 @@ func LoadCert(dir string) (*shared.CertInfo, error) {
 func LoadClusterCert(dir string) (*shared.CertInfo, error) {
 	prefix := "cluster"
 
-	cert, err := shared.KeyPairAndCA(dir, prefix, shared.CertServer, true)
+	cert, err := shared.KeyPairAndCA(dir, prefix, shared.CertServer, shared.CertOptions{AddHosts: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load cluster TLS certificate: %w", err)
 	}
@@ -43,7 +43,7 @@ func LoadClusterCert(dir string) (*shared.CertInfo, error) {
 // LoadServerCert reads the LXD server certificate from the given var dir.
 func LoadServerCert(dir string) (*shared.CertInfo, error) {
 	prefix := "server"
-	cert, err := shared.KeyPairAndCA(dir, prefix, shared.CertServer, true)
+	cert, err := shared.KeyPairAndCA(dir, prefix, shared.CertServer, shared.CertOptions{AddHosts: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS certificate: %w", err)
 	}

--- a/shared/cert_test.go
+++ b/shared/cert_test.go
@@ -20,7 +20,7 @@ func TestKeyPairAndCA(t *testing.T) {
 
 	defer func() { _ = os.RemoveAll(dir) }()
 
-	info, err := shared.KeyPairAndCA(dir, "test", shared.CertServer, true)
+	info, err := shared.KeyPairAndCA(dir, "test", shared.CertServer, shared.CertOptions{AddHosts: true})
 	if err != nil {
 		t.Errorf("initial call to KeyPairAndCA failed: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestGenerateMemCert(t *testing.T) {
 		t.Skip("skipping cert generation in short mode")
 	}
 
-	cert, key, err := shared.GenerateMemCert(false, true)
+	cert, key, err := shared.GenerateMemCert(false, shared.CertOptions{AddHosts: true})
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
This is primarily for microcluster. From the discussions in Madrid about join token verification (the MITM discussions), we decided we would verify that the SAN of the `server.crt` of a joiner microcluster node must match the node name specified when creating the join token.

By default, LXD sets this to be the hostname of the system that generated the certificate. In microcluster, the node name does not necessarily always have to line up exactly with the hostname of the system, rather the name is supplied at the time we bootstrap or join a cluster. So we need to be able to set the name in the certificate ourselves. 