### PR TITLE
Container: Allow apparmor nosymfollow mount flag in more cases

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -543,6 +543,16 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount options=(ro,remount,bind,noatime,nosuid,noexec,nodev),
   mount options=(ro,remount,bind,nosuid,noexec,strictatime),
   mount options=(ro,remount,nosuid,noexec,strictatime),
+{{- if .feature_mount_nosymfollow }}
+  mount options=(ro,remount,bind,nosymfollow),
+  mount options=(ro,remount,bind,nosymfollow,nodev),
+  mount options=(ro,remount,bind,nosymfollow,noexec),
+  mount options=(ro,remount,bind,nosymfollow,nosuid),
+  mount options=(ro,remount,bind,nosymfollow,noexec,nodev),
+  mount options=(ro,remount,bind,nosymfollow,nosuid,nodev),
+  mount options=(ro,remount,bind,nosymfollow,nosuid,noexec),
+  mount options=(ro,remount,bind,nosymfollow,nosuid,noexec,nodev),
+{{- end }}
 
   # Allow remounting things read-only
   mount options=(ro,remount) /,


### PR DESCRIPTION
It turns out, that a ruleset:
```
{{- if .feature_mount_nosymfollow }}
  # see https://github.com/canonical/lxd/pull/12698
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /[^spd]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /d[^e]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /de[^v]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/.[^l]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/.l[^x]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/.lx[^c]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/.lxc?*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/[^.]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev?*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /p[^r]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /pr[^o]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /pro[^c]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /proc?*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /s[^y]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /sy[^s]*{,/**},
  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /sys?*{,/**},
{{- end }}
```

is not enough to allow nosymfollow. We still getting AppArmor denials like this:
```
[110841.647871] audit: type=1400 audit(1721910063.197:1611): apparmor="DENIED" operation="mount" class="mount" info="failed flags match" error=-13 profile="lxd-secure-oriole_</var/snap/lxd/common/lxd>" name="/dev/shm/" pid=712867 comm="(sd-mkdcreds)" flags="ro, nosuid, nodev, noexec, remount, bind"
```

First of all, there is no "nosymfollow" in the kernel log. Which is a bug and should be fixed by: https://lore.kernel.org/all/20240628153712.288166-1-aleksandr.mikhalitsyn@canonical.com/

Secondly, it looks like these rules in the form of mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /some/path,

just does not work at all. At least in AppArmor 4.0+ (have not yet tested with older ones).

During my local experiments, I found that working variant of it might be: mount 
```
options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) -> /some/path,
```

or wider:
```
mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow),
```

Let's just add a wider variant of the rule in addition to what we already have for unprivileged containers. But keep in mind that something is wrong with these rules in their more restrictive form (with path specifier). This is a matter of a futher investigation, because it's important for privileged containers case.

See also:
canonical#12698

Closes #12698
May close #13810