### PR TITLE
Instance: Fix deadlock during failed snapshot creation

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2959,16 +2959,25 @@ func (d *lxc) onStop(args map[string]string) error {
 		d.cleanupDevices(false, "")
 
 		// Remove directory ownership (to avoid issue if uidmap is re-used)
+		// Fails on zfs when the dataset is full due to CoW
 		err := os.Chown(d.Path(), 0, 0)
 		if err != nil {
-			op.Done(fmt.Errorf("Failed clearing ownership: %w", err))
-			return
+			if !strings.Contains(err.Error(), "disk quota exceeded") {
+				op.Done(fmt.Errorf("Failed clearing ownership: %w", err))
+				return
+			}
+
+			d.logger.Error("Failed clearing ownership; skipping", logger.Ctx{"err": err})
 		}
 
 		err = os.Chmod(d.Path(), 0100)
 		if err != nil {
-			op.Done(fmt.Errorf("Failed clearing permissions: %w", err))
-			return
+			if !strings.Contains(err.Error(), "disk quota exceeded") {
+				op.Done(fmt.Errorf("Failed clearing permissions: %w", err))
+				return
+			}
+
+			d.logger.Error("Failed clearing permissions; skipping", logger.Ctx{"err": err})
 		}
 
 		// Stop the storage for this container

--- a/test/main.sh
+++ b/test/main.sh
@@ -317,6 +317,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_snap_expiry "snapshot expiry"
     run_test test_snap_schedule "snapshot scheduling"
     run_test test_snap_volume_db_recovery "snapshot volume database record recovery"
+    run_test test_snap_fail "snapshot creation failure"
     run_test test_config_profiles "profiles and configuration"
     run_test test_config_edit "container configuration edit"
     run_test test_property "container property"

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -415,3 +415,23 @@ test_snap_volume_db_recovery() {
   lxc start c1
   lxc delete -f c1
 }
+
+test_snap_fail() {
+  local lxd_backend
+  lxd_backend=$(storage_backend "$LXD_DIR")
+
+  ensure_import_testimage
+
+  if [ "${lxd_backend}" = "zfs" ]; then
+    # Containers should fail to snapshot when root is full (can't write to backup.yaml)
+    lxc launch testimage c1 --device root,size=2MiB
+    lxc exec c1 -- dd if=/dev/urandom of=/root/big.bin count=100 bs=100K || true
+
+    ! lxc snapshot c1 || false
+
+    # Make sure that the snapshot creation failed (c1 has 0 snapshots)
+    [ "$(lxc ls --columns nS --format csv | awk --field-separator , '/c1/{print $2}')" -eq 0 ]
+
+    lxc delete --force c1
+  fi
+}


### PR DESCRIPTION
Fixes #13466

We need a non-locking delete on an `Instance`; otherwise a failure while mounting the instance/updating the backup file will deadlock.

I don't love the type assertion here. However, since `CreateInternal` returns `Instance`, we don't have a lot of options beyond enriching that interface or providing an additional one.

In order to avoid using type assertions we'd need to define an internal interface `instance` for `delete` and possibly a few other functions in the drivers/ package and implement it for `lxc`/`qemu`. Alternatively, moving the `Interface` interface into the same package as the drivers would allow us to define some private methods on `Interface` instead.

(Updating the backup file on the full volume was very likely the failure in #13466; this is after applying the fix):
```
$ lxc snapshot lucky-bulldog
Error: Failed to create file "/var/lib/lxd/containers/microcloud-test_lucky-bulldog/backup.yaml": open /var/lib/lxd/containers/microcloud-test_lucky-bulldog/backup.yaml: disk quota exceeded
```

I will throw a snapshot failure test on here this afternoon.

LXD-1117