### PR TITLE
Live migration with attached storage volumes (from Incus)

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -115,18 +115,7 @@ func (d *disk) sourceIsCeph() bool {
 
 // CanHotPlug returns whether the device can be managed whilst the instance is running.
 func (d *disk) CanHotPlug() bool {
-	// Containers support hot-plugging all disk types.
-	if d.inst.Type() == instancetype.Container {
-		return true
-	}
-
-	// Only VirtioFS works with path hotplug.
-	// As migration.stateful turns off VirtioFS, this also turns off hotplugging of paths.
-	if shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
-		return false
-	}
-
-	// Block disks can be hot-plugged into VMs.
+	// All disks can be hot-plugged.
 	return true
 }
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -500,8 +500,8 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 					return fmt.Errorf("Failed checking if custom volume is exclusively attached to another instance: %w", err)
 				}
 
-				if remoteInstance != nil {
-					return fmt.Errorf("Custom volume is already attached to an instance on a different node")
+				if remoteInstance != nil && remoteInstance.ID != instConf.ID() {
+					return fmt.Errorf("Custom volume is already attached to an instance on a different cluster member")
 				}
 
 				// Check that block volumes are *only* attached to VM instances.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6857,6 +6857,51 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 		return err
 	}
 
+	// Derive the effective storage project name from the instance config's project.
+	storageProjectName, err := project.StorageVolumeProject(d.state.DB.Cluster, d.project.Name, dbCluster.StoragePoolVolumeTypeCustom)
+	if err != nil {
+		return err
+	}
+
+	// Notify the shared disks that they're going to be accessed from another system.
+	diskPools := make(map[string]storagePools.Pool, len(d.expandedDevices))
+	for _, dev := range d.expandedDevices.Sorted() {
+		if dev.Config["type"] != "disk" || dev.Config["path"] == "/" {
+			continue
+		}
+
+		poolName := dev.Config["pool"]
+		if poolName == "" {
+			continue
+		}
+
+		diskPool, ok := diskPools[poolName]
+		if !ok {
+			// Load the pool for the disk.
+			diskPool, err = storagePools.LoadByName(d.state, poolName)
+			if err != nil {
+				return fmt.Errorf("Failed loading storage pool: %w", err)
+			}
+
+			// Save it to the pools map to avoid loading it from the DB multiple times.
+			diskPools[poolName] = diskPool
+		}
+
+		// Setup the volume entry.
+		extraSourceArgs := &migration.VolumeSourceArgs{
+			ClusterMove: true,
+		}
+
+		vol := diskPool.GetVolume(storageDrivers.VolumeTypeCustom, storageDrivers.ContentTypeBlock, project.StorageVolume(storageProjectName, dev.Config["source"]), nil)
+		volCopy := storageDrivers.NewVolumeCopy(vol)
+
+		// Call MigrateVolume on the source.
+		err = diskPool.Driver().MigrateVolume(volCopy, nil, extraSourceArgs, nil)
+		if err != nil {
+			return fmt.Errorf("Failed to prepare device %q for migration: %w", dev.Name, err)
+		}
+	}
+
 	// Non-shared storage snapshot transfer.
 	if !sharedStorage {
 		listener, err := net.Listen("unix", "")
@@ -7336,6 +7381,51 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		err = pool.CreateInstanceFromMigration(d, filesystemConn, volTargetArgs, d.op)
 		if err != nil {
 			return fmt.Errorf("Failed creating instance on target: %w", err)
+		}
+
+		// Derive the effective storage project name from the instance config's project.
+		storageProjectName, err := project.StorageVolumeProject(d.state.DB.Cluster, d.project.Name, dbCluster.StoragePoolVolumeTypeCustom)
+		if err != nil {
+			return err
+		}
+
+		// Notify the shared disks that they're going to be accessed from another system.
+		diskPools := make(map[string]storagePools.Pool, len(d.expandedDevices))
+		for _, dev := range d.expandedDevices.Sorted() {
+			if dev.Config["type"] != "disk" || dev.Config["path"] == "/" {
+				continue
+			}
+
+			poolName := dev.Config["pool"]
+			if poolName == "" {
+				continue
+			}
+
+			diskPool, ok := diskPools[poolName]
+			if !ok {
+				// Load the pool for the disk.
+				diskPool, err = storagePools.LoadByName(d.state, poolName)
+				if err != nil {
+					return fmt.Errorf("Failed loading storage pool: %w", err)
+				}
+
+				// Save it to the pools map to avoid loading it from the DB multiple times.
+				diskPools[poolName] = diskPool
+			}
+
+			// Setup the volume entry.
+			extraTargetArgs := migration.VolumeTargetArgs{
+				ClusterMoveSourceName: args.ClusterMoveSourceName,
+			}
+
+			vol := diskPool.GetVolume(storageDrivers.VolumeTypeCustom, storageDrivers.ContentTypeBlock, project.StorageVolume(storageProjectName, dev.Config["source"]), nil)
+			volCopy := storageDrivers.NewVolumeCopy(vol)
+
+			// Create a volume from the migration.
+			err = diskPool.Driver().CreateVolumeFromMigration(volCopy, nil, extraTargetArgs, nil, nil)
+			if err != nil {
+				return fmt.Errorf("Failed to prepare device %q for migration: %w", dev.Name, err)
+			}
 		}
 
 		// Only delete all instance volumes on error if the pool volume creation has succeeded to

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -62,6 +62,8 @@ type ConfigReader interface {
 	Project() api.Project
 	Type() instancetype.Type
 	Architecture() int
+	ID() int
+
 	ExpandedConfig() map[string]string
 	ExpandedDevices() deviceConfig.Devices
 	LocalConfig() map[string]string
@@ -128,7 +130,6 @@ type Instance interface {
 	OnHook(hookName string, args map[string]string) error
 
 	// Properties.
-	ID() int
 	Location() string
 	Name() string
 	CloudInitID() string

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -968,15 +968,6 @@ func migrateInstance(s *state.State, r *http.Request, inst instance.Instance, ta
 		return err
 	}
 
-	// In case of live migration, only root disk can be migrated.
-	if req.Live && inst.IsRunning() {
-		for _, rawConfig := range inst.ExpandedDevices() {
-			if rawConfig["type"] == "disk" && !instancetype.IsRootDiskDevice(rawConfig) {
-				return fmt.Errorf("Cannot live migrate instance with attached custom volume")
-			}
-		}
-	}
-
 	// Retrieve storage pool of the source instance.
 	srcPool, err := storagePools.LoadByInstance(s, inst)
 	if err != nil {


### PR DESCRIPTION
Enables live-migration of an instance with volumes attached as long as those disks are also on a remote storage pool.

Created as draft while I finish writing tests.

Closes #12694 