### PR TITLE
Add `security.protection.start` to optionally prevent instance start up

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2441,3 +2441,8 @@ Adds a `start` field to the `POST /1.0/instances` API which when set
 to `true` will have the instance automatically start upon creation.
 
 In this scenario, the creation and startup is part of a single background operation.
+
+## `instance_protection_start`
+
+Enables setting the {config:option}`instance-security:security.protection.start` field which prevents instances
+from being started if set to `true`.

--- a/doc/howto/instances_manage.md
+++ b/doc/howto/instances_manage.md
@@ -131,6 +131,11 @@ Once it is running, you can select the {guilabel}`Terminal` tab to access the in
 ```
 ````
 
+### Prevent accidental start of instances
+
+To protect a specific instance from being started, set {config:option}`instance-security:security.protection.start` to `true` for the instance.
+See {ref}`instances-configure` for instructions.
+
 (instances-manage-stop)=
 ## Stop an instance
 

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -2166,7 +2166,7 @@ See {ref}`container-security` for more information.
 ```{config:option} security.protection.delete instance-security
 :defaultdesc: "`false`"
 :liveupdate: "yes"
-:shortdesc: "Prevents the instance from being deleted"
+:shortdesc: "Whether to prevent the instance from being deleted"
 :type: "bool"
 
 ```
@@ -2178,6 +2178,14 @@ See {ref}`container-security` for more information.
 :shortdesc: "Whether to protect the file system from being UID/GID shifted"
 :type: "bool"
 Set this option to `true` to prevent the instance's file system from being UID/GID shifted on startup.
+```
+
+```{config:option} security.protection.start instance-security
+:defaultdesc: "`false`"
+:liveupdate: "yes"
+:shortdesc: "Whether to prevent the instance from being started"
+:type: "bool"
+
 ```
 
 ```{config:option} security.secureboot instance-security

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2582,6 +2582,11 @@ func (d *lxc) validateStartup(statusCode api.StatusCode) error {
 		return fmt.Errorf("The image used by this instance requires nesting. Please set security.nesting=true on the instance")
 	}
 
+	// Check if instance is start protected.
+	if shared.IsTrue(d.expandedConfig["security.protection.start"]) {
+		return fmt.Errorf("Instance is protected from being started")
+	}
+
 	return nil
 }
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3731,7 +3731,7 @@ func (d *lxc) delete(force bool) error {
 	}
 
 	if !force && shared.IsTrue(d.expandedConfig["security.protection.delete"]) && !d.IsSnapshot() {
-		err := fmt.Errorf("Instance is protected")
+		err := fmt.Errorf("Instance is protected from being deleted")
 		d.logger.Warn("Failed to delete instance", logger.Ctx{"err": err})
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1095,6 +1095,11 @@ func (d *qemu) validateStartup(stateful bool, statusCode api.StatusCode) error {
 		return fmt.Errorf("Stateful start requires migration.stateful to be set to true")
 	}
 
+	// Check if instance is start protected.
+	if shared.IsTrue(d.expandedConfig["security.protection.start"]) {
+		return fmt.Errorf("Instance is protected from being started")
+	}
+
 	return nil
 }
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6119,7 +6119,7 @@ func (d *qemu) delete(force bool) error {
 
 	// Check if instance is delete protected.
 	if !force && shared.IsTrue(d.expandedConfig["security.protection.delete"]) && !d.IsSnapshot() {
-		return fmt.Errorf("Instance is protected")
+		return fmt.Errorf("Instance is protected from being deleted")
 	}
 
 	// Delete any persistent warnings for instance.

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -308,7 +308,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	//  type: bool
 	//  defaultdesc: `false`
 	//  liveupdate: yes
-	//  shortdesc: Prevents the instance from being deleted
+	//  shortdesc: Whether to prevent the instance from being deleted
 	"security.protection.delete": validate.Optional(validate.IsBool),
 
 	// lxdmeta:generate(entities=instance; group=security; key=security.protection.start)

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -311,6 +311,15 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	//  shortdesc: Prevents the instance from being deleted
 	"security.protection.delete": validate.Optional(validate.IsBool),
 
+	// lxdmeta:generate(entities=instance; group=security; key=security.protection.start)
+	//
+	// ---
+	//  type: bool
+	//  defaultdesc: `false`
+	//  liveupdate: yes
+	//  shortdesc: Whether to prevent the instance from being started
+	"security.protection.start": validate.Optional(validate.IsBool),
+
 	// lxdmeta:generate(entities=instance; group=snapshots; key=snapshots.schedule)
 	// Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots.
 	//

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -252,13 +252,16 @@ func (slice instanceAutostartList) Swap(i, j int) {
 var instancesStartMu sync.Mutex
 
 // instanceShouldAutoStart returns whether the instance should be auto-started.
-// Returns true if boot.autostart is enabled or boot.autostart is not set and instance was previously running.
+// Returns true if the conditions below are all met:
+// 1. security.protection.start is not enabled or not set.
+// 2. boot.autostart is enabled or boot.autostart is not set and instance was previously running.
 func instanceShouldAutoStart(inst instance.Instance) bool {
 	config := inst.ExpandedConfig()
 	autoStart := config["boot.autostart"]
 	lastState := config["volatile.last_state.power"]
+	protectStart := config["security.protection.start"]
 
-	return shared.IsTrue(autoStart) || (autoStart == "" && lastState == instance.PowerStateRunning)
+	return shared.IsFalseOrEmpty(protectStart) && (shared.IsTrue(autoStart) || (autoStart == "" && lastState == instance.PowerStateRunning))
 }
 
 func instancesStart(s *state.State, instances []instance.Instance) {

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2453,7 +2453,7 @@
 							"defaultdesc": "`false`",
 							"liveupdate": "yes",
 							"longdesc": "",
-							"shortdesc": "Prevents the instance from being deleted",
+							"shortdesc": "Whether to prevent the instance from being deleted",
 							"type": "bool"
 						}
 					},
@@ -2464,6 +2464,15 @@
 							"liveupdate": "yes",
 							"longdesc": "Set this option to `true` to prevent the instance's file system from being UID/GID shifted on startup.",
 							"shortdesc": "Whether to protect the file system from being UID/GID shifted",
+							"type": "bool"
+						}
+					},
+					{
+						"security.protection.start": {
+							"defaultdesc": "`false`",
+							"liveupdate": "yes",
+							"longdesc": "",
+							"shortdesc": "Whether to prevent the instance from being started",
 							"type": "bool"
 						}
 					},

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -148,7 +148,7 @@ _have lxc && {
       security.devlxd security.devlxd.images \
       security.idmap.base security.idmap.isolated security.idmap.size \
       security.nesting security.privileged \
-      security.protection.delete security.protection.shift \
+      security.protection.delete security.protection.shift security.protection.start\
       security.secureboot \
       security.sev security.sev.es security.sev.policy.es security.sev.session.dh security.sev.session.data \
       security.syscalls.allow \

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -411,6 +411,7 @@ var APIExtensions = []string{
 	"shared_custom_block_volumes",
 	"instance_import_conversion",
 	"instance_create_start",
+	"instance_protection_start",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -161,6 +161,18 @@ test_security_protection() {
 
   lxc profile unset default security.protection.delete
 
+  # Test start protection
+  lxc profile set default security.protection.start true
+
+  lxc init testimage c1
+  ! lxc start c1 || false
+
+  lxc config set c1 security.protection.start false
+  lxc start c1
+  lxc delete c1 --force
+
+  lxc profile unset default security.protection.start
+
   # Test shifting protection
 
   # Respawn LXD with kernel ID shifting support disabled to force manual shifting.


### PR DESCRIPTION
This PR adds a new instance configuration option `security.protection.start`, and throws an error if a given instance with this option set to `true` is started.

Closes #12110.