### PR TITLE
API: Add request metrics for disaster recovery

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,9 +68,6 @@ linters-settings:
       # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#deep-exit
       - name: deep-exit
 
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#defer
-      - name: defer
-
       # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bool-literal-in-expr
       - name: bool-literal-in-expr
 

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2457,3 +2457,10 @@ This can be used by a virtual machine running LXD to access raw images from the 
 
 Adds a new `virtio-blk` value for `io.bus` on `disk` devices which allows
 for the attached disk to be connected to the `virtio-blk` bus.
+
+## `metrics_api_requests`
+
+Adds the following internal metrics:
+
+* Total completed requests
+* Number of ongoing requests

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -29,26 +29,66 @@ To view the raw data that LXD collects, use the [`lxc query`](lxc_query.md) comm
 ```{terminal}
 :input: lxc query /1.0/metrics
 
-# HELP lxd_cpu_seconds_total The total number of CPU time used in seconds.
-# TYPE lxd_cpu_seconds_total counter
-lxd_cpu_seconds_total{cpu="0",mode="system",name="u1",project="default",type="container"} 60.304517
-lxd_cpu_seconds_total{cpu="0",mode="user",name="u1",project="default",type="container"} 145.647502
-lxd_cpu_seconds_total{cpu="0",mode="iowait",name="vm",project="default",type="virtual-machine"} 4614.78
-lxd_cpu_seconds_total{cpu="0",mode="irq",name="vm",project="default",type="virtual-machine"} 0
-lxd_cpu_seconds_total{cpu="0",mode="idle",name="vm",project="default",type="virtual-machine"} 412762
-lxd_cpu_seconds_total{cpu="0",mode="nice",name="vm",project="default",type="virtual-machine"} 35.06
-lxd_cpu_seconds_total{cpu="0",mode="softirq",name="vm",project="default",type="virtual-machine"} 2.41
-lxd_cpu_seconds_total{cpu="0",mode="steal",name="vm",project="default",type="virtual-machine"} 9.84
-lxd_cpu_seconds_total{cpu="0",mode="system",name="vm",project="default",type="virtual-machine"} 340.84
-lxd_cpu_seconds_total{cpu="0",mode="user",name="vm",project="default",type="virtual-machine"} 261.25
+# HELP lxd_api_requests_completed_total The total number of completed API requests.
+# TYPE lxd_api_requests_completed_total counter
+lxd_api_requests_completed_total{entity_type="server",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="server",result="succeeded"} 9
+lxd_api_requests_completed_total{entity_type="server",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="network",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="network",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="network",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="cluster_member",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="cluster_member",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="cluster_member",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="project",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="project",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="project",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="image",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="image",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="image",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="operation",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="operation",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="operation",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="storage_pool",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="storage_pool",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="storage_pool",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="warning",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="warning",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="warning",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="identity",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="identity",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="identity",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="profile",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="profile",result="error_client"} 0
+lxd_api_requests_completed_total{entity_type="profile",result="succeeded"} 0
+lxd_api_requests_completed_total{entity_type="instance",result="succeeded"} 2
+lxd_api_requests_completed_total{entity_type="instance",result="error_server"} 0
+lxd_api_requests_completed_total{entity_type="instance",result="error_client"} 0
+# HELP lxd_api_requests_ongoing The number of API requests currently being handled.
+# TYPE lxd_api_requests_ongoing gauge
+lxd_api_requests_ongoing{entity_type="server"} 1
+lxd_api_requests_ongoing{entity_type="network"} 0
+lxd_api_requests_ongoing{entity_type="cluster_member"} 0
+lxd_api_requests_ongoing{entity_type="project"} 0
+lxd_api_requests_ongoing{entity_type="image"} 0
+lxd_api_requests_ongoing{entity_type="operation"} 0
+lxd_api_requests_ongoing{entity_type="storage_pool"} 0
+lxd_api_requests_ongoing{entity_type="warning"} 0
+lxd_api_requests_ongoing{entity_type="identity"} 0
+lxd_api_requests_ongoing{entity_type="profile"} 0
+lxd_api_requests_ongoing{entity_type="instance"} 0
 # HELP lxd_cpu_effective_total The total number of effective CPUs.
 # TYPE lxd_cpu_effective_total gauge
-lxd_cpu_effective_total{name="u1",project="default",type="container"} 4
-lxd_cpu_effective_total{name="vm",project="default",type="virtual-machine"} 0
+lxd_cpu_effective_total{name="c",project="default",type="container"} 8
+# HELP lxd_cpu_seconds_total The total number of CPU time used in seconds.
+# TYPE lxd_cpu_seconds_total counter
+lxd_cpu_seconds_total{cpu="0",mode="system",name="c",project="default",type="container"} 1.53794
+lxd_cpu_seconds_total{cpu="0",mode="user",name="c",project="default",type="container"} 2.613658
 # HELP lxd_disk_read_bytes_total The total number of bytes read.
 # TYPE lxd_disk_read_bytes_total counter
-lxd_disk_read_bytes_total{device="loop5",name="u1",project="default",type="container"} 2048
-lxd_disk_read_bytes_total{device="loop3",name="vm",project="default",type="virtual-machine"} 353280
+lxd_disk_read_bytes_total{device="nvme0n1",name="c",project="default",type="container"} 3.6151296e+07
+# HELP lxd_disk_reads_completed_total The total number of completed reads.
+# TYPE lxd_disk_reads_completed_total counter
 ...
 ```
 

--- a/doc/reference/provided_metrics.md
+++ b/doc/reference/provided_metrics.md
@@ -100,6 +100,10 @@ The following internal metrics are provided:
 
 * - Metric
   - Description
+* - `lxd_api_requests_completed_total`
+  - Total number of completed requests. See [API rates metrics](api-rates-metrics).
+* - `lxd_api_requests_ongoing`
+  - Number of requests currently being handled. See [API rates metrics](api-rates-metrics).
 * - `lxd_go_alloc_bytes_total`
   - Total number of bytes allocated (even if freed)
 * - `lxd_go_alloc_bytes`
@@ -153,6 +157,19 @@ The following internal metrics are provided:
 * - `lxd_warnings_total`
   - Number of active warnings
 ```
+
+(api-rates-metrics)=
+## API rates metrics
+
+The API rates metrics include `lxd_api_requests_completed_total` and `lxd_api_requests_ongoing`. These metrics can be consumed by an observability tool deployed externally (for example, the [Canonical Observability Stack](https://charmhub.io/topics/canonical-observability-stack) or another third-party tool) to help identify failures or overload on a LXD server. You can set thresholds on the observability tools for these metrics' values to trigger alarms and take programmatic actions.
+
+These metrics consider all endpoints in the [LXD REST API](../api), with the exception of the `/` endpoint. Requests using an invalid URL are also counted. Requests against the metrics server are also counted. Both introduced metrics include a label `entity_type` based on the main entity type that the endpoint is operating on.
+
+`lxd_api_requests_ongoing` contains the number of requests that are not yet completed by the time the metrics are queried. A request is considered completed when the response is returned to the client and any asynchronous operations spawned by that request are done. `lxd_api_requests_completed_total` contains the number of completed requests. This metric includes an additional label named `result` based on the outcome of the request. The label can have one of the following values:
+
+- `error_server`, for errors on the server side, this includes responses with HTTP status codes from 500 to 599. Any failed asynchronous operations also fall into this category.
+- `error_client`, for responses with HTTP status codes from 400 to 499, indicating an error on the client side.
+- `succeeded`, for endpoints that executed successfully.
 
 ## Related topics
 

--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -175,7 +175,7 @@ var devLxdEventsGet = devLxdHandler{
 }
 
 func devlxdEventsGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
-	err := eventsGet(d, r).Render(w)
+	err := eventsGet(d, r).Render(w, r)
 	if err != nil {
 		return smartResponse(err)
 	}

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -30,8 +30,8 @@ type eventsServe struct {
 }
 
 // Render starts event socket.
-func (r *eventsServe) Render(w http.ResponseWriter) error {
-	return eventsSocket(r.d, r.req, w)
+func (r *eventsServe) Render(w http.ResponseWriter, request *http.Request) error {
+	return eventsSocket(r.d, request, w)
 }
 
 func (r *eventsServe) String() string {

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -25,8 +25,7 @@ var eventsCmd = APIEndpoint{
 }
 
 type eventsServe struct {
-	req *http.Request
-	d   *Daemon
+	d *Daemon
 }
 
 // Render starts event socket.
@@ -89,7 +88,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 }
 
 func eventsGet(d *Daemon, r *http.Request) response.Response {
-	return &eventsServe{req: r, d: d}
+	return &eventsServe{d: d}
 }
 
 func eventsPost(d *Daemon, r *http.Request) response.Response {

--- a/lxd-agent/operations.go
+++ b/lxd-agent/operations.go
@@ -163,7 +163,7 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	return operations.OperationWebSocket(r, op)
+	return operations.OperationWebSocket(op)
 }
 
 func operationWaitGet(d *Daemon, r *http.Request) response.Response {

--- a/lxd-agent/server.go
+++ b/lxd-agent/server.go
@@ -23,7 +23,7 @@ func restServer(tlsConfig *tls.Config, cert *x509.Certificate, d *Daemon) *http.
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)
+		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 	})
 
 	for _, c := range api10 {
@@ -46,7 +46,7 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 
 		if !authenticate(r, cert) {
 			logger.Error("Not authorized")
-			_ = response.InternalError(fmt.Errorf("Not authorized")).Render(w)
+			_ = response.InternalError(fmt.Errorf("Not authorized")).Render(w, r)
 			return
 		}
 
@@ -57,7 +57,7 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 			multiW := io.MultiWriter(newBody, captured)
 			_, err := io.Copy(multiW, r.Body)
 			if err != nil {
-				_ = response.InternalError(err).Render(w)
+				_ = response.InternalError(err).Render(w, r)
 				return
 			}
 
@@ -92,9 +92,9 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 		}
 
 		// Handle errors
-		err := resp.Render(w)
+		err := resp.Render(w, r)
 		if err != nil {
-			writeErr := response.InternalError(err).Render(w)
+			writeErr := response.InternalError(err).Render(w, r)
 			if writeErr != nil {
 				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err, "writeErr": writeErr})
 			}

--- a/lxd-agent/sftp.go
+++ b/lxd-agent/sftp.go
@@ -17,12 +17,11 @@ var sftpCmd = APIEndpoint{
 }
 
 func sftpHandler(d *Daemon, r *http.Request) response.Response {
-	return &sftpServe{d, r}
+	return &sftpServe{d}
 }
 
 type sftpServe struct {
 	d *Daemon
-	r *http.Request
 }
 
 func (r *sftpServe) String() string {

--- a/lxd-agent/sftp.go
+++ b/lxd-agent/sftp.go
@@ -28,6 +28,7 @@ func (r *sftpServe) String() string {
 	return "sftp handler"
 }
 
+// Render hijacks the connection and starts a sftp server.
 func (r *sftpServe) Render(w http.ResponseWriter, request *http.Request) error {
 	// Upgrade to sftp.
 	if request.Header.Get("Upgrade") != "sftp" {

--- a/lxd-agent/sftp.go
+++ b/lxd-agent/sftp.go
@@ -29,9 +29,9 @@ func (r *sftpServe) String() string {
 	return "sftp handler"
 }
 
-func (r *sftpServe) Render(w http.ResponseWriter) error {
+func (r *sftpServe) Render(w http.ResponseWriter, request *http.Request) error {
 	// Upgrade to sftp.
-	if r.r.Header.Get("Upgrade") != "sftp" {
+	if request.Header.Get("Upgrade") != "sftp" {
 		http.Error(w, "Missing or invalid upgrade header", http.StatusBadRequest)
 		return nil
 	}

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/lxd/lxd/cluster/request"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/metrics"
 	lxdRequest "github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	storagePools "github.com/canonical/lxd/lxd/storage"
@@ -207,6 +208,9 @@ func restServer(d *Daemon) *http.Server {
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.NotFound(nil).Render(w)
 	})
+
+	// Initialize API metrics with zero values.
+	metrics.InitAPIMetrics()
 
 	return &http.Server{
 		Handler:     &lxdHTTPServer{r: mux, d: d},

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -172,10 +172,9 @@ func restServer(d *Daemon) *http.Server {
 		if strings.Contains(ua, "Gecko") {
 			http.Redirect(w, r, "/ui/", http.StatusMovedPermanently)
 			return
-		} else {
-			// Normal client handling.
-			_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 		}
+		// Normal client handling.
+		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 	})
 
 	for endpoint, f := range d.gateway.HandlerFuncs(d.heartbeatHandler, d.identityCache) {

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -204,6 +204,7 @@ func restServer(d *Daemon) *http.Server {
 	}
 
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lxdRequest.CountStartedRequest(r)
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.NotFound(nil).Render(w)
@@ -259,6 +260,7 @@ func metricsServer(d *Daemon) *http.Server {
 	d.createCmd(mux, "1.0", metricsCmd)
 
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lxdRequest.CountStartedRequest(r)
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.NotFound(nil).Render(w)

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -173,7 +173,7 @@ func restServer(d *Daemon) *http.Server {
 			return
 		} else {
 			// Normal client handling.
-			_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)
+			_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 		}
 	})
 
@@ -207,7 +207,7 @@ func restServer(d *Daemon) *http.Server {
 		lxdRequest.CountStartedRequest(r)
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
-		_ = response.NotFound(nil).Render(w)
+		_ = response.NotFound(nil).Render(w, r)
 	})
 
 	// Initialize API metrics with zero values.
@@ -233,7 +233,7 @@ func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Re
 		}
 
 		resp := f(d, inst, w, r)
-		_ = resp.Render(w)
+		_ = resp.Render(w, r)
 	}
 }
 
@@ -249,7 +249,7 @@ func metricsServer(d *Daemon) *http.Server {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)
+		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 	})
 
 	for endpoint, f := range d.gateway.HandlerFuncs(d.heartbeatHandler, d.identityCache) {
@@ -263,7 +263,7 @@ func metricsServer(d *Daemon) *http.Server {
 		lxdRequest.CountStartedRequest(r)
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
-		_ = response.NotFound(nil).Render(w)
+		_ = response.NotFound(nil).Render(w, r)
 	})
 
 	return &http.Server{Handler: &lxdHTTPServer{r: mux, d: d}}

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -106,7 +106,8 @@ func restServer(d *Daemon) *http.Server {
 		uiHandlerErrorUINotEnabled := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprint(w, errorMessage)
+			_, err := fmt.Fprint(w, errorMessage)
+			logger.Warn("Failed sending error message to client", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr, "err": err})
 		})
 		mux.PathPrefix("/ui").Handler(uiHandlerErrorUINotEnabled)
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -945,7 +945,7 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 	}()
 
 	return response.ManualResponse(func(w http.ResponseWriter) error {
-		err := response.EmptySyncResponse.Render(w)
+		err := response.EmptySyncResponse.Render(w, r)
 		if err != nil {
 			return err
 		}
@@ -2035,7 +2035,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		return response.ManualResponse(func(w http.ResponseWriter) error {
-			err := response.EmptySyncResponse.Render(w)
+			err := response.EmptySyncResponse.Render(w, r)
 			if err != nil {
 				return err
 			}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -247,7 +247,7 @@ func internalShutdown(d *Daemon, r *http.Request) response.Response {
 
 		// Run shutdown sequence synchronously.
 		stopErr := d.Stop(forceCtx, unix.SIGPWR)
-		err := response.SmartError(stopErr).Render(w)
+		err := response.SmartError(stopErr).Render(w, r)
 		if err != nil {
 			return err
 		}

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -167,6 +167,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	// If all valid, return immediately.
 	if len(projectsToFetch) == 0 {
+		metricSet.Merge(intMetrics)
 		return getFilteredMetrics(s, r, compress, metricSet)
 	}
 
@@ -192,6 +193,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	// If all valid, return immediately.
 	if len(projectsToFetch) == 0 {
+		metricSet.Merge(intMetrics)
 		return getFilteredMetrics(s, r, compress, metricSet)
 	}
 
@@ -315,10 +317,6 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	updatedProjects := []string{}
 	for project, entries := range newMetrics {
-		if project == api.ProjectDefaultName {
-			entries.Merge(intMetrics) // internal metrics are always considered new. Add them to the default project.
-		}
-
 		counterMetric, ok := counterMetrics[project]
 		if ok {
 			entries.Merge(counterMetric)
@@ -344,6 +342,8 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	metricsCacheLock.Unlock()
+
+	metricSet.Merge(intMetrics) // Include the internal metrics after caching so they are not cached.
 
 	return getFilteredMetrics(s, r, compress, metricSet)
 }

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -396,6 +396,27 @@ func internalMetrics(ctx context.Context, daemonStartTime time.Time, tx *db.Clus
 		out.AddSamples(metrics.OperationsTotal, metrics.Sample{Value: float64(len(operations))})
 	}
 
+	// API request metrics
+	for _, entityType := range entity.APIMetricsEntityTypes() {
+		out.AddSamples(
+			metrics.APIOngoingRequests,
+			metrics.Sample{
+				Labels: map[string]string{"entity_type": entityType.String()},
+				Value:  float64(metrics.GetOngoingRequests(entityType)),
+			},
+		)
+
+		for result, resultName := range metrics.GetRequestResultsNames() {
+			out.AddSamples(
+				metrics.APICompletedRequests,
+				metrics.Sample{
+					Labels: map[string]string{"entity_type": entityType.String(), "result": resultName},
+					Value:  float64(metrics.GetCompletedRequests(entityType, result)),
+				},
+			)
+		}
+	}
+
 	// Daemon uptime
 	out.AddSamples(metrics.UptimeSeconds, metrics.Sample{Value: time.Since(daemonStartTime).Seconds()})
 

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -275,7 +275,7 @@ func (o *Verifier) getGroupsFromClaims(customClaims map[string]any) []string {
 func (o *Verifier) Login(w http.ResponseWriter, r *http.Request) {
 	err := o.ensureConfig(r.Context(), r.Host)
 	if err != nil {
-		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Login failed: %w", err).Error()).Render(w)
+		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Login failed: %w", err).Error()).Render(w, r)
 		return
 	}
 
@@ -287,7 +287,7 @@ func (o *Verifier) Login(w http.ResponseWriter, r *http.Request) {
 func (o *Verifier) Logout(w http.ResponseWriter, r *http.Request) {
 	err := o.setCookies(w, nil, uuid.UUID{}, "", "", true)
 	if err != nil {
-		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to delete login information: %w", err).Error()).Render(w)
+		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to delete login information: %w", err).Error()).Render(w, r)
 		return
 	}
 
@@ -298,7 +298,7 @@ func (o *Verifier) Logout(w http.ResponseWriter, r *http.Request) {
 func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
 	err := o.ensureConfig(r.Context(), r.Host)
 	if err != nil {
-		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("OIDC callback failed: %w", err).Error()).Render(w)
+		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("OIDC callback failed: %w", err).Error()).Render(w, r)
 		return
 	}
 
@@ -306,13 +306,13 @@ func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
 		sessionID := uuid.New()
 		secureCookie, err := o.secureCookieFromSession(sessionID)
 		if err != nil {
-			_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to start a new session: %w", err).Error()).Render(w)
+			_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to start a new session: %w", err).Error()).Render(w, r)
 			return
 		}
 
 		err = o.setCookies(w, secureCookie, sessionID, tokens.IDToken, tokens.RefreshToken, false)
 		if err != nil {
-			_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to set login information: %w", err).Error()).Render(w)
+			_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to set login information: %w", err).Error()).Render(w, r)
 			return
 		}
 

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -274,7 +274,7 @@ func (h *notifyFixtures) Unavailable(i int, err error) {
 	mux.HandleFunc("/1.0/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		err := response.Unavailable(err)
-		_ = err.Render(w)
+		_ = err.Render(w, r)
 	})
 
 	h.servers[i].Config.Handler = mux

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -616,6 +616,11 @@ func (d *Daemon) UnixSocket() string {
 	return filepath.Join(d.os.VarDir, "unix.socket")
 }
 
+// createCmd creates API handlers for the provided endpoint including some useful behavior,
+// such as appropriate authentication, authorization and checking server availability.
+//
+// The created handler also keeps track of handled requests for the API metrics
+// for the main API endpoints.
 func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 	var uri string
 	if c.Path == "" {
@@ -627,6 +632,12 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 	}
 
 	route := restAPI.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
+		// Only endpoints from the main API (version 1.0) should be counted for the metrics.
+		// This prevents internal endpoints from being included as well.
+		if version == "1.0" {
+			request.CountStartedRequest(r)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 
 		if !(r.RemoteAddr == "@" && version == "internal") {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -828,7 +828,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		if err != nil {
 			writeErr := response.SmartError(err).Render(w, r)
 			if writeErr != nil {
-				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err, "writeErr": writeErr})
+				logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err, "writeErr": writeErr})
 			}
 		}
 	})

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -125,7 +125,7 @@ func devlxdImageExportHandler(d *Daemon, c instance.Instance, w http.ResponseWri
 
 	resp := imageExport(d, r)
 
-	err := resp.Render(w)
+	err := resp.Render(w, r)
 	if err != nil {
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 	}
@@ -345,7 +345,7 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 		}
 
 		resp := f(d, c, w, r)
-		_ = resp.Render(w)
+		_ = resp.Render(w, r)
 	}
 }
 

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -30,13 +30,12 @@ var eventsCmd = APIEndpoint{
 }
 
 type eventsServe struct {
-	req *http.Request
-	s   *state.State
+	s *state.State
 }
 
 // Render starts event socket.
 func (r *eventsServe) Render(w http.ResponseWriter, req *http.Request) error {
-	return eventsSocket(r.s, r.req, w)
+	return eventsSocket(r.s, req, w)
 }
 
 func (r *eventsServe) String() string {
@@ -209,5 +208,5 @@ func eventsSocket(s *state.State, r *http.Request, w http.ResponseWriter) error 
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func eventsGet(d *Daemon, r *http.Request) response.Response {
-	return &eventsServe{req: r, s: d.State()}
+	return &eventsServe{s: d.State()}
 }

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/events"
+	"github.com/canonical/lxd/lxd/metrics"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
@@ -35,7 +36,14 @@ type eventsServe struct {
 
 // Render starts event socket.
 func (r *eventsServe) Render(w http.ResponseWriter, req *http.Request) error {
-	return eventsSocket(r.s, req, w)
+	err := eventsSocket(r.s, req, w)
+
+	if err == nil {
+		// If there was an error on Render, the callback function will be called during the error handling.
+		request.MetricsCallback(req, metrics.Success)
+	}
+
+	return err
 }
 
 func (r *eventsServe) String() string {

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -35,7 +35,7 @@ type eventsServe struct {
 }
 
 // Render starts event socket.
-func (r *eventsServe) Render(w http.ResponseWriter) error {
+func (r *eventsServe) Render(w http.ResponseWriter, req *http.Request) error {
 	return eventsSocket(r.s, r.req, w)
 }
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -4252,7 +4252,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		requestor := request.CreateRequestor(r)
 		s.Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(imgInfo.Fingerprint, projectName, requestor, nil))
 
-		return response.FileResponse(r, files, nil)
+		return response.FileResponse(files, nil)
 	}
 
 	files := make([]response.FileResponseEntry, 1)
@@ -4263,7 +4263,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	requestor := request.CreateRequestor(r)
 	s.Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(imgInfo.Fingerprint, projectName, requestor, nil))
 
-	return response.FileResponse(r, files, nil)
+	return response.FileResponse(files, nil)
 }
 
 // swagger:operation POST /1.0/images/{fingerprint}/export images images_export_post

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -701,5 +701,5 @@ func instanceBackupExportGet(d *Daemon, r *http.Request) response.Response {
 
 	s.Events.SendLifecycle(projectName, lifecycle.InstanceBackupRetrieved.Event(fullName, backup.Instance(), nil))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
+	return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 }

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -611,7 +611,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 		consoleBufferLogPath := c.ConsoleBufferLogPath()
 		ent.Path = consoleBufferLogPath
 		ent.Filename = consoleBufferLogPath
-		return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
+		return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 	}
 
 	// Query the container's console ringbuffer.
@@ -631,7 +631,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if errno == unix.ENODATA {
-			return response.FileResponse(r, []response.FileResponseEntry{}, nil)
+			return response.FileResponse([]response.FileResponseEntry{}, nil)
 		}
 
 		return response.SmartError(err)
@@ -641,7 +641,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 	ent.FileModified = time.Now()
 	ent.FileSize = int64(len(logContents))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
+	return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 }
 
 // swagger:operation DELETE /1.0/instances/{name}/console instances instance_console_delete

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -212,7 +212,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 		}
 
 		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
-		return response.FileResponse(r, files, headers)
+		return response.FileResponse(files, headers)
 	} else if fileType == "symlink" {
 		// Find symlink target.
 		target, err := client.ReadLink(path)
@@ -243,7 +243,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 		files[0].FileSize = int64(len(target))
 
 		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFileRetrieved.Event(inst, logger.Ctx{"path": path}))
-		return response.FileResponse(r, files, headers)
+		return response.FileResponse(files, headers)
 	} else if fileType == "directory" {
 		dirEnts := []string{}
 

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -264,7 +264,7 @@ func instanceLogGet(d *Daemon, r *http.Request) response.Response {
 
 	s.Events.SendLifecycle(projectName, lifecycle.InstanceLogRetrieved.Event(file, inst, request.CreateRequestor(r), nil))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
+	return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 }
 
 // swagger:operation DELETE /1.0/instances/{name}/logs/{filename} instances instance_log_delete
@@ -581,7 +581,7 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 
 	s.Events.SendLifecycle(projectName, lifecycle.InstanceLogRetrieved.Event(file, inst, request.CreateRequestor(r), nil))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
+	return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 }
 
 // swagger:operation DELETE /1.0/instances/{name}/logs/exec-output/{filename} instances instance_exec-output_delete

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -534,7 +534,7 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 
 	s.Events.SendLifecycle(projectName, lifecycle.InstanceMetadataTemplateRetrieved.Event(c, request.CreateRequestor(r), logger.Ctx{"path": templateName}))
 
-	return response.FileResponse(r, files, nil)
+	return response.FileResponse(files, nil)
 }
 
 // swagger:operation POST /1.0/instances/{name}/metadata/templates instances instance_metadata_templates_post

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -109,7 +109,7 @@ func (r *sftpServeResponse) String() string {
 }
 
 // Render renders the server response.
-func (r *sftpServeResponse) Render(w http.ResponseWriter) error {
+func (r *sftpServeResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	defer func() { _ = r.instConn.Close() }()
 
 	hijacker, ok := w.(http.Hijacker)

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -66,7 +66,6 @@ func instanceSFTPHandler(d *Daemon, r *http.Request) response.Response {
 	}
 
 	resp := &sftpServeResponse{
-		req:         r,
 		projectName: projectName,
 		instName:    instName,
 	}
@@ -98,7 +97,6 @@ func instanceSFTPHandler(d *Daemon, r *http.Request) response.Response {
 }
 
 type sftpServeResponse struct {
-	req         *http.Request
 	projectName string
 	instName    string
 	instConn    net.Conn
@@ -138,7 +136,7 @@ func (r *sftpServeResponse) Render(w http.ResponseWriter, req *http.Request) err
 		return api.StatusErrorf(http.StatusInternalServerError, "Failed to upgrade SFTP connection: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(r.req.Context())
+	ctx, cancel := context.WithCancel(req.Context())
 	l := logger.AddContext(logger.Ctx{
 		"project":  r.projectName,
 		"instance": r.instName,

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/metrics"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
@@ -173,6 +174,8 @@ func (r *sftpServeResponse) Render(w http.ResponseWriter, req *http.Request) err
 	}
 
 	wg.Wait() // Wait for copy go routine to finish.
+
+	request.MetricsCallback(req, metrics.Success)
 
 	return nil
 }

--- a/lxd/metrics/api_rates.go
+++ b/lxd/metrics/api_rates.go
@@ -1,0 +1,74 @@
+package metrics
+
+import (
+	"net/url"
+	"sync/atomic"
+
+	"github.com/canonical/lxd/shared/entity"
+)
+
+// RequestResult represents a completed request status category.
+type RequestResult int8
+
+// This defines every possible request result to be used as a metric label.
+const (
+	ErrorServer RequestResult = iota
+	ErrorClient
+	Success
+)
+
+var requestResultNames = map[RequestResult]string{
+	ErrorServer: "error_server",
+	ErrorClient: "error_client",
+	Success:     "succeeded",
+}
+
+// GetRequestResultsNames returns a map containing all possible request result types and their names.
+// This is also used to iterate through the possible results.
+func GetRequestResultsNames() map[RequestResult]string {
+	return requestResultNames
+}
+
+type completedMetricsLabeling struct {
+	entityType entity.Type
+	result     RequestResult
+}
+
+var ongoingRequests map[entity.Type]*atomic.Int64
+var completedRequests map[completedMetricsLabeling]*atomic.Int64
+
+// InitAPIMetrics initializes maps with initial values for the API rates metrics.
+func InitAPIMetrics() {
+	relevantEntityTypes := entity.APIMetricsEntityTypes()
+	ongoingRequests = make(map[entity.Type]*atomic.Int64, len(relevantEntityTypes))
+	completedRequests = make(map[completedMetricsLabeling]*atomic.Int64, len(relevantEntityTypes)*len(requestResultNames))
+
+	for _, entityType := range relevantEntityTypes {
+		ongoingRequests[entityType] = new(atomic.Int64)
+		for result := range requestResultNames {
+			completedRequests[completedMetricsLabeling{entityType: entityType, result: result}] = new(atomic.Int64)
+		}
+	}
+}
+
+// TrackStartedRequest should be called before each request handler to keep track of ongoing requests.
+func TrackStartedRequest(url url.URL) {
+	ongoingRequests[entity.EndpointEntityType(url)].Add(1)
+}
+
+// TrackCompletedRequest should be called after each request is completed to keep track of completed requests.
+func TrackCompletedRequest(url url.URL, result RequestResult) {
+	entityType := entity.EndpointEntityType(url)
+	ongoingRequests[entityType].Add(-1)
+	completedRequests[completedMetricsLabeling{entityType: entityType, result: result}].Add(1)
+}
+
+// GetOngoingRequests gets the value for ongoing metrics filtered by entity type.
+func GetOngoingRequests(entityType entity.Type) int64 {
+	return ongoingRequests[entityType].Load()
+}
+
+// GetCompletedRequests gets the value of completed requests filtered by entity type and result.
+func GetCompletedRequests(entityType entity.Type, result RequestResult) int64 {
+	return completedRequests[completedMetricsLabeling{entityType: entityType, result: result}].Load()
+}

--- a/lxd/metrics/metrics.go
+++ b/lxd/metrics/metrics.go
@@ -95,6 +95,7 @@ func (m *MetricSet) String() string {
 		GoGoroutines,
 		GoHeapObjects,
 		Instances,
+		APIOngoingRequests,
 	}
 
 	for _, metricType := range metricTypes {

--- a/lxd/metrics/types.go
+++ b/lxd/metrics/types.go
@@ -16,10 +16,10 @@ type MetricSet struct {
 type MetricType int
 
 const (
-	// CPUSecondsTotal represents the total CPU seconds used.
-	CPUSecondsTotal MetricType = iota
 	// CPUs represents the total number of effective CPUs.
-	CPUs
+	CPUs MetricType = iota
+	// CPUSecondsTotal represents the total CPU seconds used.
+	CPUSecondsTotal
 	// DiskReadBytesTotal represents the read bytes for a disk.
 	DiskReadBytesTotal
 	// DiskReadsCompletedTotal represents the completed for a disk.
@@ -34,12 +34,60 @@ const (
 	FilesystemFreeBytes
 	// FilesystemSizeBytes represents the size in bytes of a filesystem.
 	FilesystemSizeBytes
+	// GoAllocBytes represents the number of bytes allocated and still in use.
+	GoAllocBytes
+	// GoAllocBytesTotal represents the total number of bytes allocated, even if freed.
+	GoAllocBytesTotal
+	// GoBuckHashSysBytes represents the number of bytes used by the profiling bucket hash table.
+	GoBuckHashSysBytes
+	// GoFreesTotal represents the total number of frees.
+	GoFreesTotal
+	// GoGCSysBytes represents the number of bytes used for garbage collection system metadata.
+	GoGCSysBytes
+	// GoGoroutines represents the number of goroutines that currently exist..
+	GoGoroutines
+	// GoHeapAllocBytes represents the number of heap bytes allocated and still in use.
+	GoHeapAllocBytes
+	// GoHeapIdleBytes represents the number of heap bytes waiting to be used.
+	GoHeapIdleBytes
+	// GoHeapInuseBytes represents the number of heap bytes that are in use.
+	GoHeapInuseBytes
+	// GoHeapObjects represents the number of allocated objects.
+	GoHeapObjects
+	// GoHeapReleasedBytes represents the number of heap bytes released to OS.
+	GoHeapReleasedBytes
+	// GoHeapSysBytes represents the number of heap bytes obtained from system.
+	GoHeapSysBytes
+	// GoLookupsTotal represents the total number of pointer lookups.
+	GoLookupsTotal
+	// GoMallocsTotal represents the total number of mallocs.
+	GoMallocsTotal
+	// GoMCacheInuseBytes represents the number of bytes in use by mcache structures.
+	GoMCacheInuseBytes
+	// GoMCacheSysBytes represents the number of bytes used for mcache structures obtained from system.
+	GoMCacheSysBytes
+	// GoMSpanInuseBytes represents the number of bytes in use by mspan structures.
+	GoMSpanInuseBytes
+	// GoMSpanSysBytes represents the number of bytes used for mspan structures obtained from system.
+	GoMSpanSysBytes
+	// GoNextGCBytes represents the number of heap bytes when next garbage collection will take place.
+	GoNextGCBytes
+	// GoOtherSysBytes represents the number of bytes used for other system allocations.
+	GoOtherSysBytes
+	// GoStackInuseBytes represents the number of bytes in use by the stack allocator.
+	GoStackInuseBytes
+	// GoStackSysBytes represents the number of bytes obtained from system for stack allocator.
+	GoStackSysBytes
+	// GoSysBytes represents the number of bytes obtained from system.
+	GoSysBytes
+	// Instances represents the instance count.
+	Instances
 	// MemoryActiveAnonBytes represents the amount of anonymous memory on active LRU list.
 	MemoryActiveAnonBytes
-	// MemoryActiveFileBytes represents the amount of file-backed memory on active LRU list.
-	MemoryActiveFileBytes
 	// MemoryActiveBytes represents the amount of memory on active LRU list.
 	MemoryActiveBytes
+	// MemoryActiveFileBytes represents the amount of file-backed memory on active LRU list.
+	MemoryActiveFileBytes
 	// MemoryCachedBytes represents the amount of cached memory.
 	MemoryCachedBytes
 	// MemoryDirtyBytes represents the amount of memory waiting to get written back to the disk.
@@ -50,10 +98,10 @@ const (
 	MemoryHugePagesTotalBytes
 	// MemoryInactiveAnonBytes represents the amount of anonymous memory on inactive LRU list.
 	MemoryInactiveAnonBytes
-	// MemoryInactiveFileBytes represents the amount of file-backed memory on inactive LRU list.
-	MemoryInactiveFileBytes
 	// MemoryInactiveBytes represents the amount of memory on inactive LRU list.
 	MemoryInactiveBytes
+	// MemoryInactiveFileBytes represents the amount of file-backed memory on inactive LRU list.
+	MemoryInactiveFileBytes
 	// MemoryMappedBytes represents the amount of mapped memory.
 	MemoryMappedBytes
 	//MemoryMemAvailableBytes represents the amount of available memory.
@@ -62,6 +110,8 @@ const (
 	MemoryMemFreeBytes
 	// MemoryMemTotalBytes represents the amount of used memory.
 	MemoryMemTotalBytes
+	// MemoryOOMKillsTotal represents the amount of oom kills.
+	MemoryOOMKillsTotal
 	// MemoryRSSBytes represents the amount of anonymous and swap cache memory.
 	MemoryRSSBytes
 	// MemoryShmemBytes represents the amount of cached filesystem data that is swap-backed.
@@ -72,8 +122,6 @@ const (
 	MemoryUnevictableBytes
 	// MemoryWritebackBytes represents the amount of memory queued for syncing to disk.
 	MemoryWritebackBytes
-	// MemoryOOMKillsTotal represents the amount of oom kills.
-	MemoryOOMKillsTotal
 	// NetworkReceiveBytesTotal represents the amount of received bytes on a given interface.
 	NetworkReceiveBytesTotal
 	// NetworkReceiveDropTotal represents the amount of received dropped bytes on a given interface.
@@ -90,62 +138,14 @@ const (
 	NetworkTransmitErrsTotal
 	// NetworkTransmitPacketsTotal represents the amount of transmitted packets on a given interface.
 	NetworkTransmitPacketsTotal
-	// ProcsTotal represents the number of running processes.
-	ProcsTotal
 	// OperationsTotal represents the number of running operations.
 	OperationsTotal
-	// WarningsTotal represents the number of active warnings.
-	WarningsTotal
+	// ProcsTotal represents the number of running processes.
+	ProcsTotal
 	// UptimeSeconds represents the daemon uptime in seconds.
 	UptimeSeconds
-	// GoGoroutines represents the number of goroutines that currently exist..
-	GoGoroutines
-	// GoAllocBytes represents the number of bytes allocated and still in use.
-	GoAllocBytes
-	// GoAllocBytesTotal represents the total number of bytes allocated, even if freed.
-	GoAllocBytesTotal
-	// GoSysBytes represents the number of bytes obtained from system.
-	GoSysBytes
-	// GoLookupsTotal represents the total number of pointer lookups.
-	GoLookupsTotal
-	// GoMallocsTotal represents the total number of mallocs.
-	GoMallocsTotal
-	// GoFreesTotal represents the total number of frees.
-	GoFreesTotal
-	// GoHeapAllocBytes represents the number of heap bytes allocated and still in use.
-	GoHeapAllocBytes
-	// GoHeapSysBytes represents the number of heap bytes obtained from system.
-	GoHeapSysBytes
-	// GoHeapIdleBytes represents the number of heap bytes waiting to be used.
-	GoHeapIdleBytes
-	// GoHeapInuseBytes represents the number of heap bytes that are in use.
-	GoHeapInuseBytes
-	// GoHeapReleasedBytes represents the number of heap bytes released to OS.
-	GoHeapReleasedBytes
-	// GoHeapObjects represents the number of allocated objects.
-	GoHeapObjects
-	// GoStackInuseBytes represents the number of bytes in use by the stack allocator.
-	GoStackInuseBytes
-	// GoStackSysBytes represents the number of bytes obtained from system for stack allocator.
-	GoStackSysBytes
-	// GoMSpanInuseBytes represents the number of bytes in use by mspan structures.
-	GoMSpanInuseBytes
-	// GoMSpanSysBytes represents the number of bytes used for mspan structures obtained from system.
-	GoMSpanSysBytes
-	// GoMCacheInuseBytes represents the number of bytes in use by mcache structures.
-	GoMCacheInuseBytes
-	// GoMCacheSysBytes represents the number of bytes used for mcache structures obtained from system.
-	GoMCacheSysBytes
-	// GoBuckHashSysBytes represents the number of bytes used by the profiling bucket hash table.
-	GoBuckHashSysBytes
-	// GoGCSysBytes represents the number of bytes used for garbage collection system metadata.
-	GoGCSysBytes
-	// GoOtherSysBytes represents the number of bytes used for other system allocations.
-	GoOtherSysBytes
-	// GoNextGCBytes represents the number of heap bytes when next garbage collection will take place.
-	GoNextGCBytes
-	// Instances represents the instance count.
-	Instances
+	// WarningsTotal represents the number of active warnings.
+	WarningsTotal
 )
 
 // MetricNames associates a metric type to its name.

--- a/lxd/metrics/types.go
+++ b/lxd/metrics/types.go
@@ -108,7 +108,7 @@ const (
 	MemoryInactiveFileBytes
 	// MemoryMappedBytes represents the amount of mapped memory.
 	MemoryMappedBytes
-	//MemoryMemAvailableBytes represents the amount of available memory.
+	// MemoryMemAvailableBytes represents the amount of available memory.
 	MemoryMemAvailableBytes
 	// MemoryMemFreeBytes represents the amount of free memory.
 	MemoryMemFreeBytes

--- a/lxd/metrics/types.go
+++ b/lxd/metrics/types.go
@@ -16,8 +16,12 @@ type MetricSet struct {
 type MetricType int
 
 const (
+	// APICompletedRequests represents the total number completed requests.
+	APICompletedRequests MetricType = iota
+	// APIOngoingRequests represents the number of requests currently being handled.
+	APIOngoingRequests
 	// CPUs represents the total number of effective CPUs.
-	CPUs MetricType = iota
+	CPUs
 	// CPUSecondsTotal represents the total CPU seconds used.
 	CPUSecondsTotal
 	// DiskReadBytesTotal represents the read bytes for a disk.
@@ -150,6 +154,8 @@ const (
 
 // MetricNames associates a metric type to its name.
 var MetricNames = map[MetricType]string{
+	APICompletedRequests:        "lxd_api_requests_completed_total",
+	APIOngoingRequests:          "lxd_api_requests_ongoing",
 	CPUSecondsTotal:             "lxd_cpu_seconds_total",
 	CPUs:                        "lxd_cpu_effective_total",
 	DiskReadBytesTotal:          "lxd_disk_read_bytes_total",
@@ -219,6 +225,8 @@ var MetricNames = map[MetricType]string{
 
 // MetricHeaders represents the metric headers which contain help messages as specified by OpenMetrics.
 var MetricHeaders = map[MetricType]string{
+	APICompletedRequests:        "# HELP lxd_api_requests_completed_total The total number of completed API requests.",
+	APIOngoingRequests:          "# HELP lxd_api_requests_ongoing The number of API requests currently being handled.",
 	CPUSecondsTotal:             "# HELP lxd_cpu_seconds_total The total number of CPU time used in seconds.",
 	CPUs:                        "# HELP lxd_cpu_effective_total The total number of effective CPUs.",
 	DiskReadBytesTotal:          "# HELP lxd_disk_read_bytes_total The total number of bytes read.",

--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -644,5 +644,5 @@ func networkACLLogGet(d *Daemon, r *http.Request) response.Response {
 	ent.FileModified = time.Now()
 	ent.FileSize = int64(len(log))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
+	return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 }

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1099,7 +1099,7 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 	// First check if the query is for a local operation from this node
 	op, err := operations.OperationGetInternal(id)
 	if err == nil {
-		return operations.OperationWebSocket(r, op)
+		return operations.OperationWebSocket(op)
 	}
 
 	// Then check if the query is from an operation on another node, and, if so, forward it
@@ -1143,7 +1143,7 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	return operations.ForwardedOperationWebSocket(r, id, source)
+	return operations.ForwardedOperationWebSocket(id, source)
 }
 
 func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -983,17 +983,17 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 			// Wait for the operation.
 			err = op.Wait(ctx)
 			if err != nil {
-				_ = response.SmartError(err).Render(w)
+				_ = response.SmartError(err).Render(w, r)
 				return nil
 			}
 
 			_, body, err := op.Render()
 			if err != nil {
-				_ = response.SmartError(err).Render(w)
+				_ = response.SmartError(err).Render(w, r)
 				return nil
 			}
 
-			_ = response.SyncResponse(true, body).Render(w)
+			_ = response.SyncResponse(true, body).Render(w, r)
 			return nil
 		}
 

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/canonical/lxd/lxd/metrics"
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
@@ -103,7 +105,14 @@ func (r *forwardedOperationResponse) Render(w http.ResponseWriter, req *http.Req
 		debugLogger = logger.AddContext(logger.Ctx{"http_code": code})
 	}
 
-	return util.WriteJSON(w, body, debugLogger)
+	err := util.WriteJSON(w, body, debugLogger)
+
+	if err == nil {
+		// If there was an error on Render, the callback function will be called during the error handling.
+		request.MetricsCallback(req, metrics.Success)
+	}
+
+	return err
 }
 
 func (r *forwardedOperationResponse) String() string {

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -21,7 +21,7 @@ func OperationResponse(op *Operation) response.Response {
 	return &operationResponse{op}
 }
 
-func (r *operationResponse) Render(w http.ResponseWriter) error {
+func (r *operationResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	err := r.op.Start()
 	if err != nil {
 		return err
@@ -79,7 +79,7 @@ func ForwardedOperationResponse(project string, op *api.Operation) response.Resp
 	}
 }
 
-func (r *forwardedOperationResponse) Render(w http.ResponseWriter) error {
+func (r *forwardedOperationResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	url := fmt.Sprintf("/%s/operations/%s", version.APIVersion, r.op.ID)
 	if r.project != "" {
 		url += fmt.Sprintf("?project=%s", r.project)

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -23,6 +23,7 @@ func OperationResponse(op *Operation) response.Response {
 	return &operationResponse{op}
 }
 
+// Render builds operationResponse and writes it to http.ResponseWriter.
 func (r *operationResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	// Inject callback function on operation.
 	// If the operation was completed as expected or cancelled by an user, it is considered a success.
@@ -93,6 +94,7 @@ func ForwardedOperationResponse(project string, op *api.Operation) response.Resp
 	}
 }
 
+// Render builds forwardedOperationResponse and writes it to http.ResponseWriter.
 func (r *forwardedOperationResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	url := fmt.Sprintf("/%s/operations/%s", version.APIVersion, r.op.ID)
 	if r.project != "" {

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/canonical/lxd/lxd/metrics"
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared/ws"
 )
@@ -26,6 +28,12 @@ func (r *operationWebSocket) Render(w http.ResponseWriter, req *http.Request) er
 	}
 
 	err = <-chanErr
+
+	if err == nil {
+		// If there was an error on Render, the callback function will be called during the error handling.
+		request.MetricsCallback(req, metrics.Success)
+	}
+
 	return err
 }
 
@@ -61,6 +69,9 @@ func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter, req *http.Re
 	// Make sure both sides are closed.
 	_ = r.source.Close()
 	_ = target.Close()
+
+	// If there was an error on Render, the callback function will be called during the error handling.
+	request.MetricsCallback(req, metrics.Success)
 
 	return nil
 }

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -52,7 +52,7 @@ type forwardedOperationWebSocket struct {
 	source *websocket.Conn // Connection to the node were the operation is running
 }
 
-// ForwardedOperationWebSocket returns a new forwarted websocket operation.
+// ForwardedOperationWebSocket returns a new forwarded websocket operation.
 func ForwardedOperationWebSocket(id string, source *websocket.Conn) response.Response {
 	return &forwardedOperationWebSocket{id, source}
 }

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -11,17 +11,16 @@ import (
 )
 
 type operationWebSocket struct {
-	req *http.Request
-	op  *Operation
+	op *Operation
 }
 
 // OperationWebSocket returns a new websocket operation.
-func OperationWebSocket(req *http.Request, op *Operation) response.Response {
-	return &operationWebSocket{req, op}
+func OperationWebSocket(op *Operation) response.Response {
+	return &operationWebSocket{op}
 }
 
 func (r *operationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
-	chanErr, err := r.op.Connect(r.req, w)
+	chanErr, err := r.op.Connect(req, w)
 	if err != nil {
 		return err
 	}
@@ -40,19 +39,18 @@ func (r *operationWebSocket) String() string {
 }
 
 type forwardedOperationWebSocket struct {
-	req    *http.Request
 	id     string
 	source *websocket.Conn // Connection to the node were the operation is running
 }
 
 // ForwardedOperationWebSocket returns a new forwarted websocket operation.
-func ForwardedOperationWebSocket(req *http.Request, id string, source *websocket.Conn) response.Response {
-	return &forwardedOperationWebSocket{req, id, source}
+func ForwardedOperationWebSocket(id string, source *websocket.Conn) response.Response {
+	return &forwardedOperationWebSocket{id, source}
 }
 
 func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	// Upgrade target connection to websocket.
-	target, err := ws.Upgrader.Upgrade(w, r.req, nil)
+	target, err := ws.Upgrader.Upgrade(w, req, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -21,6 +21,7 @@ func OperationWebSocket(op *Operation) response.Response {
 	return &operationWebSocket{op}
 }
 
+// Render renders a websocket operation response.
 func (r *operationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	chanErr, err := r.op.Connect(req, w)
 	if err != nil {
@@ -56,6 +57,7 @@ func ForwardedOperationWebSocket(id string, source *websocket.Conn) response.Res
 	return &forwardedOperationWebSocket{id, source}
 }
 
+// Render renders a forwarded websocket operation response.
 func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	// Upgrade target connection to websocket.
 	target, err := ws.Upgrader.Upgrade(w, req, nil)

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -20,7 +20,7 @@ func OperationWebSocket(req *http.Request, op *Operation) response.Response {
 	return &operationWebSocket{req, op}
 }
 
-func (r *operationWebSocket) Render(w http.ResponseWriter) error {
+func (r *operationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	chanErr, err := r.op.Connect(r.req, w)
 	if err != nil {
 		return err
@@ -50,7 +50,7 @@ func ForwardedOperationWebSocket(req *http.Request, id string, source *websocket
 	return &forwardedOperationWebSocket{req, id, source}
 }
 
-func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter) error {
+func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	// Upgrade target connection to websocket.
 	target, err := ws.Upgrader.Upgrade(w, r.req, nil)
 	if err != nil {

--- a/lxd/request/const.go
+++ b/lxd/request/const.go
@@ -45,6 +45,9 @@ const (
 
 	// CtxTrusted is a boolean value that indicates whether the request was authenticated or not.
 	CtxTrusted CtxKey = "trusted"
+
+	// MetricsCallbackFunc is a callback function that can be called to mark the request as completed for the API metrics.
+	MetricsCallbackFunc CtxKey = "metrics_callback_function"
 )
 
 // Headers.

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -6,12 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"mime/multipart"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/lxd/metrics"
+	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/ucred"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
@@ -144,7 +147,7 @@ func SyncResponsePlain(success bool, compress bool, metadata string) Response {
 	return &syncResponse{success: success, metadata: metadata, plaintext: true, compress: compress}
 }
 
-func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
+func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
 	// Set an appropriate ETag header
 	if r.etag != nil {
 		etag, err := util.EtagHash(r.etag)
@@ -200,6 +203,18 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		}
 	}
 
+	// defer calling the callback function after possibly considering the response a SmartError.
+	defer func() {
+		// If there was an error on Render, the callback function will be called during the error handling.
+		if err == nil {
+			if r.success {
+				request.MetricsCallback(req, metrics.Success)
+			} else {
+				request.MetricsCallback(req, metrics.ErrorServer)
+			}
+		}
+	}()
+
 	// Handle plain text responses.
 	if r.plaintext {
 		if r.metadata != nil {
@@ -207,12 +222,12 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 				comp := gzip.NewWriter(w)
 				defer comp.Close()
 
-				_, err := comp.Write([]byte(r.metadata.(string)))
+				_, err = comp.Write([]byte(r.metadata.(string)))
 				if err != nil {
 					return err
 				}
 			} else {
-				_, err := w.Write([]byte(r.metadata.(string)))
+				_, err = w.Write([]byte(r.metadata.(string)))
 				if err != nil {
 					return err
 				}
@@ -235,7 +250,9 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		debugLogger = logger.AddContext(logger.Ctx{"http_code": code})
 	}
 
-	return util.WriteJSON(w, resp, debugLogger)
+	err = util.WriteJSON(w, resp, debugLogger)
+
+	return err
 }
 
 func (r *syncResponse) String() string {
@@ -344,6 +361,17 @@ func (r *errorResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		Code:  r.code, // Set the error code in the Code field of the response body.
 	}
 
+	defer func() {
+		// Use the callback function to count the request for the API metrics.
+		if r.code >= 400 && r.code < 500 {
+			// 4* codes are considered client errors on HTTP.
+			request.MetricsCallback(req, metrics.ErrorClient)
+		} else {
+			// Any other status code here shoud be higher than or equal to 500 and is considered a server error.
+			request.MetricsCallback(req, metrics.ErrorServer)
+		}
+	}()
+
 	err := json.NewEncoder(output).Encode(resp)
 
 	if err != nil {
@@ -395,12 +423,19 @@ func FileResponse(files []FileResponseEntry, headers map[string]string) Response
 	return &fileResponse{files, headers}
 }
 
-func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
+func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
 	if r.headers != nil {
 		for k, v := range r.headers {
 			w.Header().Set(k, v)
 		}
 	}
+
+	defer func() {
+		if err == nil {
+			// If there was an error on Render, the callback function will be called during the error handling.
+			request.MetricsCallback(req, metrics.Success)
+		}
+	}()
 
 	// No file, well, it's easy then
 	if len(r.files) == 0 {
@@ -413,7 +448,7 @@ func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		remoteTCP, _ := tcp.ExtractConn(remoteConn)
 		if remoteTCP != nil {
 			// Apply TCP timeouts if remote connection is TCP (rather than Unix).
-			err := tcp.SetTimeouts(remoteTCP, 10*time.Second)
+			err = tcp.SetTimeouts(remoteTCP, 10*time.Second)
 			if err != nil {
 				return api.StatusErrorf(http.StatusInternalServerError, "Failed setting TCP timeouts on remote connection: %w", err)
 			}
@@ -432,14 +467,16 @@ func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
 			mt = r.files[0].FileModified
 			sz = r.files[0].FileSize
 		} else {
-			f, err := os.Open(r.files[0].Path)
+			var f *os.File
+			f, err = os.Open(r.files[0].Path)
 			if err != nil {
 				return err
 			}
 
 			defer func() { _ = f.Close() }()
 
-			fi, err := f.Stat()
+			var fi fs.FileInfo
+			fi, err = f.Stat()
 			if err != nil {
 				return err
 			}
@@ -470,7 +507,8 @@ func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		if entry.File != nil {
 			rd = entry.File
 		} else {
-			fd, err := os.Open(entry.Path)
+			var fd *os.File
+			fd, err = os.Open(entry.Path)
 			if err != nil {
 				return err
 			}
@@ -480,7 +518,8 @@ func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
 			rd = fd
 		}
 
-		fw, err := mw.CreateFormFile(entry.Identifier, entry.Filename)
+		var fw io.Writer
+		fw, err = mw.CreateFormFile(entry.Identifier, entry.Filename)
 		if err != nil {
 			return err
 		}
@@ -495,7 +534,9 @@ func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		}
 	}
 
-	return mw.Close()
+	err = mw.Close()
+
+	return err
 }
 
 func (r *fileResponse) String() string {
@@ -566,7 +607,14 @@ func ManualResponse(hook func(w http.ResponseWriter) error) Response {
 }
 
 func (r *manualResponse) Render(w http.ResponseWriter, req *http.Request) error {
-	return r.hook(w)
+	err := r.hook(w)
+
+	if err == nil {
+		// If there was an error on Render, the callback function will be called during the error handling.
+		request.MetricsCallback(req, metrics.Success)
+	}
+
+	return err
 }
 
 func (r *manualResponse) String() string {

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -42,6 +42,7 @@ type devLxdResponse struct {
 	contentType string
 }
 
+// Render renders a response for requests against the /dev/lxd socket.
 func (r *devLxdResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	var err error
 
@@ -147,6 +148,7 @@ func SyncResponsePlain(success bool, compress bool, metadata string) Response {
 	return &syncResponse{success: success, metadata: metadata, plaintext: true, compress: compress}
 }
 
+// Render renders a synchronous response.
 func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
 	// Set an appropriate ETag header
 	if r.etag != nil {
@@ -344,6 +346,7 @@ func (r *errorResponse) String() string {
 	return r.msg
 }
 
+// Render renders a response that indicates an error on the request handling.
 func (r *errorResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	var output io.Writer
 
@@ -423,6 +426,7 @@ func FileResponse(files []FileResponseEntry, headers map[string]string) Response
 	return &fileResponse{files, headers}
 }
 
+// Render renders a file response.
 func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
 	if r.headers != nil {
 		for k, v := range r.headers {
@@ -555,6 +559,7 @@ func ForwardedResponse(client lxd.InstanceServer, request *http.Request) Respons
 	}
 }
 
+// Render renders a response for a forwarded request.
 func (r *forwardedResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	info, err := r.client.GetConnectionInfo()
 	if err != nil {
@@ -606,6 +611,7 @@ func ManualResponse(hook func(w http.ResponseWriter) error) Response {
 	return &manualResponse{hook: hook}
 }
 
+// Render renders a manual response.
 func (r *manualResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	err := r.hook(w)
 

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -775,5 +775,5 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 
 	s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRetrieved.Event(details.pool.Name(), details.volumeTypeName, fullName, effectiveProjectName, request.CreateRequestor(r), nil))
 
-	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil)
+	return response.FileResponse([]response.FileResponseEntry{ent}, nil)
 }

--- a/shared/entity/type_test.go
+++ b/shared/entity/type_test.go
@@ -224,4 +224,128 @@ func TestURL(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+
+	endpointTests := []struct {
+		name               string
+		rawURL             string
+		expectedEntityType Type
+	}{
+		{
+			name:               "not a LXD endpoint",
+			rawURL:             "/1.0/not/a/url",
+			expectedEntityType: TypeServer,
+		},
+		{
+			name:               "containers endpoint",
+			rawURL:             "/1.0/containers/my-container",
+			expectedEntityType: TypeInstance,
+		},
+		{
+			name:               "images endpoint",
+			rawURL:             "/1.0/images/fwirnoaiwnerfoiawnef",
+			expectedEntityType: TypeImage,
+		},
+		{
+			name:               "profiles endpoint",
+			rawURL:             "/1.0/profiles/my-profile",
+			expectedEntityType: TypeProfile,
+		},
+		{
+			name:               "projects endpoint",
+			rawURL:             "/1.0/projects/my-project",
+			expectedEntityType: TypeProject,
+		},
+		{
+			name:               "certificates endpoint",
+			rawURL:             "/1.0/certificates/foawienfoawnefkanwelfknsfl",
+			expectedEntityType: TypeIdentity,
+		},
+		{
+			name:               "instances endpoint",
+			rawURL:             "/1.0/instances/my-instance",
+			expectedEntityType: TypeInstance,
+		},
+		{
+			name:               "instance backup endpoint",
+			rawURL:             "/1.0/instances/my-instance/backups/my-backup",
+			expectedEntityType: TypeInstance,
+		},
+		{
+			name:               "instance snapshot endpoint",
+			rawURL:             "/1.0/instances/my-instance/snapshots/my-snapshot",
+			expectedEntityType: TypeInstance,
+		},
+		{
+			name:               "networks endpoint",
+			rawURL:             "/1.0/networks/my-network?project=my-project",
+			expectedEntityType: TypeNetwork,
+		},
+		{
+			name:               "network acls endpoint",
+			rawURL:             "/1.0/network-acls/my-network-acl",
+			expectedEntityType: TypeNetwork,
+		},
+		{
+			name:               "cluster members endpoint",
+			rawURL:             "/1.0/cluster/members/node01",
+			expectedEntityType: TypeClusterMember,
+		},
+		{
+			name:               "operation endpoint",
+			rawURL:             "/1.0/operations/3e75d1bf-30ed-45ce-9e02-267fa7338eb4",
+			expectedEntityType: TypeOperation,
+		},
+		{
+			name:               "storage pools endpoint",
+			rawURL:             "/1.0/storage-pools/my-storage-pool",
+			expectedEntityType: TypeStoragePool,
+		},
+		{
+			name:               "storage volumes endpoint",
+			rawURL:             "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume",
+			expectedEntityType: TypeStoragePool,
+		},
+		{
+			name:               "storage volume backups endpoint",
+			rawURL:             "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume/backups",
+			expectedEntityType: TypeStoragePool,
+		},
+		{
+			name:               "storage volume snapshots endpoint",
+			rawURL:             "/1.0/storage-pools/my-storage-pool/volumes/custom/my-storage-volume/snapshots",
+			expectedEntityType: TypeStoragePool,
+		},
+		{
+			name:               "list storage volumes endpoint",
+			rawURL:             "/1.0/storage-volumes",
+			expectedEntityType: TypeStoragePool,
+		},
+		{
+			name:               "storage buckets endpoint",
+			rawURL:             "/1.0/storage-pools/my-storage-pool/buckets/my-bucket",
+			expectedEntityType: TypeStoragePool,
+		},
+		{
+			name:               "warnings endpoint",
+			rawURL:             "/1.0/warnings/3e75d1bf-30ed-45ce-9e02-267fa7338eb4",
+			expectedEntityType: TypeWarning,
+		},
+		{
+			name:               "cluster groups endpoint",
+			rawURL:             "/1.0/cluster/groups/my-cluster-group",
+			expectedEntityType: TypeClusterMember,
+		},
+	}
+
+	apiMetricsEntityTypes := APIMetricsEntityTypes()
+	for _, tt := range endpointTests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.rawURL)
+			require.NoError(t, err)
+			actualEntityType := EndpointEntityType(*u)
+
+			assert.Equal(t, tt.expectedEntityType, actualEntityType)
+			assert.Contains(t, apiMetricsEntityTypes, actualEntityType)
+		})
+	}
 }

--- a/shared/entity/url.go
+++ b/shared/entity/url.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/version"
@@ -22,6 +23,25 @@ func nRequiredPathArguments(t typeInfo) int {
 	}
 
 	return nRequiredPathArguments
+}
+
+// EndpointEntityType derives the main entity type an endpoint is opertaing on from its URL.
+// This is used to label endpoints for the API rates metrics.
+func EndpointEntityType(url url.URL) Type {
+	// Extract the url prefix without slashes and the API version if present.
+	urlPrefix := strings.Split(strings.TrimPrefix(strings.TrimPrefix(url.Path, "/"+version.APIVersion), "/"), "/")[0]
+
+	// Match the extracted prefix with recognized entity types' prefixes.
+	for entityType, typeInfo := range entityTypes {
+		if shared.ValueInSlice(urlPrefix, typeInfo.apiMetricsURLPrefixes()) {
+			return entityType
+		}
+	}
+
+	// Use TypeServer as the default, is used for undefined URLs.
+	// This also applies to endpoints /, /{version}, /{version}/metrics, /{version}/events, /{version}/metadata and
+	// /{version}/resources.
+	return TypeServer
 }
 
 // URL returns a string URL for the Type.


### PR DESCRIPTION
This introduces API rates metrics for Disaster Recovery, the spec related to this should be published once this is merged.

Here is a raw output example of `/1.0/metrics` with the new metrics:
https://pastebin.canonical.com/p/wvhcnK7tq6/