### PR TITLE
lxd/device: Enabled support for xattr when using virtiofs

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -505,6 +505,7 @@ func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Ins
 	// Start the virtiofsd process in non-daemon mode.
 	args := []string{
 		"--fd=3",
+		"--xattr",
 		"-o", fmt.Sprintf("source=%s", sharePath),
 	}
 


### PR DESCRIPTION
I'm no expert in `virtiofs`, `virtio-9p` and other similar shared filesystems, but there are some cases where it would be useful to be able to get/set extended file attributes on mounted disks.

Right now I'm patching my custom LXD version to enable this, but if this change doesn't bring additional complexities I'm not aware of, maybe it wouldn't hurt to enable extended attributes on the `virtiofs` backend. 