### PR TITLE
VM: Add support for extended attributes for virtiofs shares

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -505,6 +505,7 @@ func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Ins
 	// Start the virtiofsd process in non-daemon mode.
 	args := []string{
 		"--fd=3",
+		"--xattr",
 		"-o", fmt.Sprintf("source=%s", sharePath),
 	}
 


### PR DESCRIPTION
Sorry for the previous PR spam!

Unless there's a reason for the lack of extended attributes on `virtiofs` I'm not aware of, it would be nice to have this option enabled as there are some use-cases where read/writing extended attributes are needed on files within the mounted disk.