### PR TITLE
lxd/migration: Improve migration error handling

### DIFF
--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -152,7 +152,10 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 	})
 	if err != nil {
 		l.Error("Failed migration on source", logger.Ctx{"err": err})
-		return fmt.Errorf("Failed migration on source: %w", err)
+
+		errMsg := fmt.Errorf("Failed migration on source: %w", err)
+		s.sendControl(errMsg)
+		return errMsg
 	}
 
 	return nil
@@ -283,7 +286,10 @@ func (c *migrationSink) Do(state *state.State, instOp *operationlock.InstanceOpe
 	})
 	if err != nil {
 		l.Error("Failed migration on target", logger.Ctx{"err": err})
-		return fmt.Errorf("Failed migration on target: %w", err)
+
+		errMsg := fmt.Errorf("Failed migration on target: %w", err)
+		c.sendControl(errMsg)
+		return errMsg
 	}
 
 	return nil


### PR DESCRIPTION
This PR improves migration error handling by moving the check for `migration.stateful` after setting up migration connections and using control send, so that it can be returned properly to the user. It also includes a cherry-pick from incus for propagating migration errors to the user.