### PR TITLE
Device: Use -o flag for xattr mode of virtiofsd for `disk` device

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -505,7 +505,8 @@ func DiskVMVirtiofsdStart(kernelVersion version.DottedVersion, inst instance.Ins
 	// Start the virtiofsd process in non-daemon mode.
 	args := []string{
 		"--fd=3",
-		"--xattr",
+		// use -o flags for support in wider versions of virtiofsd.
+		"-o", "xattr",
 		"-o", fmt.Sprintf("source=%s", sharePath),
 	}
 


### PR DESCRIPTION
To support more versions of virtiofsd.

Follows from https://github.com/canonical/lxd/pull/13828