### PR TITLE
Entity type refactor (simplified)

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -213,7 +213,7 @@ func projectUsedBy(ctx context.Context, tx *db.ClusterTx, project *cluster.Proje
 
 	entityURLs, err := cluster.GetEntityURLs(ctx, tx.Tx(), project.Name, reportedEntityTypes...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get project used-by URLs")
+		return nil, fmt.Errorf("Failed to get project used-by URLs: %w", err)
 	}
 
 	var usedBy []string

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
@@ -24,34 +23,120 @@ import (
 // database. It is not possible to read/write invalid entity types from/to the database when using this type.
 type EntityType string
 
+// entityTypeDBInfo defines how an entity type behaves at the database level.
+//
+// To create a new entity type, first create a new `(shared/entity).Type` then create a type that implements the methods
+// defined on entityTypeDBInfo.
+//
+// The code method must return a unique int64 for the entity type (see the entityTypeCode constants below). Other SQL
+// related method may return an empty string if the method is not applicable to the entity type. For example,
+// urlsByProjectQuery is only applicable to entity types that are project specific, so it is ok to return an empty string
+// from this method for the e.g. certificate entity type.
+type entityTypeDBInfo interface {
+	// code must return a unique int64 for the entity type.
+	code() int64
+
+	// allURLsQuery must return a SQL query that when executed, returns values in this order and format:
+	// 1. The type code of the entity type.
+	// 2. The ID of the entity in it's corresponding database table.
+	// 3. The project that contains the entity (or an empty string if the entity is not project specific).
+	// 4. The location of the entity (or an empty string if the entity is not localised to a specific member).
+	// 5. A JSON formatted array of path arguments that compose the URL of the entity.
+	//
+	// urlByIDQuery and urlsByProjectQuery must also follow this format. This is so that the three query types can be
+	// composed with a SQL UNION. Returning the code of the entity type as the first argument allows us to UNION these
+	// queries over multiple entity types. This reduces the total number of queries that need to be performed.
+	allURLsQuery() string
+
+	// urlByIDQuery must return a SQL query that when executed, returns values identically to allURLsQuery. The query
+	// must accept a single integer bind argument for the ID of the resource.
+	urlByIDQuery() string
+
+	// urlsByProjectQuery must return a SQL query that when executed, returns values identically to allURLsQuery. The
+	// query must accept a single string bind argument for the project name.
+	urlsByProjectQuery() string
+
+	// idFromURLQuery must return a SQL query that returns an identifier for the query, and the ID of the entity in the
+	// database. It expects the following bind arguments:
+	// 1. An identifier for this returned row. This is because these queries are designed to work in UNION with queries
+	//    of other entity types.
+	// 2. The project name (even if the entity is not project specific, this should be passed as an empty string).
+	// 3. The location (even if the entity is not location specific, this should be passed as an empty string).
+	// 4. All path arguments from the URL.
+	idFromURLQuery() string
+
+	// onDeleteTriggerSQL must return the SQL for a trigger that runs when an entity of this type is deleted. These
+	// triggers are in place so that warnings and group permissions do not contain stale entries. The first return value
+	// must be the name of the trigger, the second return value must be the SQL for creating the trigger.
+	onDeleteTriggerSQL() (name string, sql string)
+}
+
+var entityTypes = map[entity.Type]entityTypeDBInfo{
+	entity.TypeContainer:             entityTypeContainer{},
+	entity.TypeImage:                 entityTypeImage{},
+	entity.TypeProfile:               entityTypeProfile{},
+	entity.TypeProject:               entityTypeProject{},
+	entity.TypeCertificate:           entityTypeCertificate{},
+	entity.TypeInstance:              entityTypeInstance{},
+	entity.TypeInstanceBackup:        entityTypeInstanceBackup{},
+	entity.TypeInstanceSnapshot:      entityTypeInstanceSnapshot{},
+	entity.TypeNetwork:               entityTypeNetwork{},
+	entity.TypeNetworkACL:            entityTypeNetworkACL{},
+	entity.TypeNode:                  entityTypeClusterMember{},
+	entity.TypeOperation:             entityTypeOperation{},
+	entity.TypeStoragePool:           entityTypeStoragePool{},
+	entity.TypeStorageVolume:         entityTypeStorageVolume{},
+	entity.TypeStorageVolumeBackup:   entityTypeStorageVolumeBackup{},
+	entity.TypeStorageVolumeSnapshot: entityTypeStorageVolumeSnapshot{},
+	entity.TypeWarning:               entityTypeWarning{},
+	entity.TypeClusterGroup:          entityTypeClusterGroup{},
+	entity.TypeStorageBucket:         entityTypeStorageBucket{},
+	entity.TypeServer:                entityTypeServer{},
+	entity.TypeImageAlias:            entityTypeImageAlias{},
+	entity.TypeNetworkZone:           entityTypeNetworkZone{},
+	entity.TypeIdentity:              entityTypeIdentity{},
+	entity.TypeAuthGroup:             entityTypeAuthGroup{},
+	entity.TypeIdentityProviderGroup: entityTypeIdentityProviderGroup{},
+}
+
 const (
-	entityTypeNone                  int64 = -1
-	entityTypeContainer             int64 = 0
-	entityTypeImage                 int64 = 1
-	entityTypeProfile               int64 = 2
-	entityTypeProject               int64 = 3
-	entityTypeCertificate           int64 = 4
-	entityTypeInstance              int64 = 5
-	entityTypeInstanceBackup        int64 = 6
-	entityTypeInstanceSnapshot      int64 = 7
-	entityTypeNetwork               int64 = 8
-	entityTypeNetworkACL            int64 = 9
-	entityTypeNode                  int64 = 10
-	entityTypeOperation             int64 = 11
-	entityTypeStoragePool           int64 = 12
-	entityTypeStorageVolume         int64 = 13
-	entityTypeStorageVolumeBackup   int64 = 14
-	entityTypeStorageVolumeSnapshot int64 = 15
-	entityTypeWarning               int64 = 16
-	entityTypeClusterGroup          int64 = 17
-	entityTypeStorageBucket         int64 = 18
-	entityTypeNetworkZone           int64 = 19
-	entityTypeImageAlias            int64 = 20
-	entityTypeServer                int64 = 21
-	entityTypeAuthGroup             int64 = 22
-	entityTypeIdentityProviderGroup int64 = 23
-	entityTypeIdentity              int64 = 24
+	entityTypeCodeNone                  int64 = -1
+	entityTypeCodeContainer             int64 = 0
+	entityTypeCodeImage                 int64 = 1
+	entityTypeCodeProfile               int64 = 2
+	entityTypeCodeProject               int64 = 3
+	entityTypeCodeCertificate           int64 = 4
+	entityTypeCodeInstance              int64 = 5
+	entityTypeCodeInstanceBackup        int64 = 6
+	entityTypeCodeInstanceSnapshot      int64 = 7
+	entityTypeCodeNetwork               int64 = 8
+	entityTypeCodeNetworkACL            int64 = 9
+	entityTypeCodeClusterMember         int64 = 10
+	entityTypeCodeOperation             int64 = 11
+	entityTypeCodeStoragePool           int64 = 12
+	entityTypeCodeStorageVolume         int64 = 13
+	entityTypeCodeStorageVolumeBackup   int64 = 14
+	entityTypeCodeStorageVolumeSnapshot int64 = 15
+	entityTypeCodeWarning               int64 = 16
+	entityTypeCodeClusterGroup          int64 = 17
+	entityTypeCodeStorageBucket         int64 = 18
+	entityTypeCodeNetworkZone           int64 = 19
+	entityTypeCodeImageAlias            int64 = 20
+	entityTypeCodeServer                int64 = 21
+	entityTypeCodeAuthGroup             int64 = 22
+	entityTypeCodeIdentityProviderGroup int64 = 23
+	entityTypeCodeIdentity              int64 = 24
 )
+
+var entityTypeByCode = map[int64]EntityType{
+	entityTypeCodeNone: EntityType(""),
+}
+
+func init() {
+	for entityType, info := range entityTypes {
+		entityTypeByCode[info.code()] = EntityType(entityType)
+	}
+}
 
 // Scan implements sql.Scanner for EntityType. This converts the integer value back into the correct entity.Type
 // constant or returns an error.
@@ -71,513 +156,27 @@ func (e *EntityType) Scan(value any) error {
 		return fmt.Errorf("Entity should be an integer, got `%v` (%T)", intValue, intValue)
 	}
 
-	switch entityTypeInt {
-	case entityTypeNone:
-		*e = ""
-	case entityTypeContainer:
-		*e = EntityType(entity.TypeContainer)
-	case entityTypeImage:
-		*e = EntityType(entity.TypeImage)
-	case entityTypeProfile:
-		*e = EntityType(entity.TypeProfile)
-	case entityTypeProject:
-		*e = EntityType(entity.TypeProject)
-	case entityTypeCertificate:
-		*e = EntityType(entity.TypeCertificate)
-	case entityTypeInstance:
-		*e = EntityType(entity.TypeInstance)
-	case entityTypeInstanceBackup:
-		*e = EntityType(entity.TypeInstanceBackup)
-	case entityTypeInstanceSnapshot:
-		*e = EntityType(entity.TypeInstanceSnapshot)
-	case entityTypeNetwork:
-		*e = EntityType(entity.TypeNetwork)
-	case entityTypeNetworkACL:
-		*e = EntityType(entity.TypeNetworkACL)
-	case entityTypeNode:
-		*e = EntityType(entity.TypeNode)
-	case entityTypeOperation:
-		*e = EntityType(entity.TypeOperation)
-	case entityTypeStoragePool:
-		*e = EntityType(entity.TypeStoragePool)
-	case entityTypeStorageVolume:
-		*e = EntityType(entity.TypeStorageVolume)
-	case entityTypeStorageVolumeBackup:
-		*e = EntityType(entity.TypeStorageVolumeBackup)
-	case entityTypeStorageVolumeSnapshot:
-		*e = EntityType(entity.TypeStorageVolumeSnapshot)
-	case entityTypeWarning:
-		*e = EntityType(entity.TypeWarning)
-	case entityTypeClusterGroup:
-		*e = EntityType(entity.TypeClusterGroup)
-	case entityTypeStorageBucket:
-		*e = EntityType(entity.TypeStorageBucket)
-	case entityTypeNetworkZone:
-		*e = EntityType(entity.TypeNetworkZone)
-	case entityTypeImageAlias:
-		*e = EntityType(entity.TypeImageAlias)
-	case entityTypeServer:
-		*e = EntityType(entity.TypeServer)
-	case entityTypeAuthGroup:
-		*e = EntityType(entity.TypeAuthGroup)
-	case entityTypeIdentityProviderGroup:
-		*e = EntityType(entity.TypeIdentityProviderGroup)
-	case entityTypeIdentity:
-		*e = EntityType(entity.TypeIdentity)
-	default:
+	entityType, ok := entityTypeByCode[entityTypeInt]
+	if !ok {
 		return fmt.Errorf("Unknown entity type %d", entityTypeInt)
 	}
 
+	*e = entityType
 	return nil
 }
 
 // Value implements driver.Valuer for EntityType. This converts the EntityType into an integer or throws an error.
 func (e EntityType) Value() (driver.Value, error) {
-	switch e {
-	case "":
-		return entityTypeNone, nil
-	case EntityType(entity.TypeContainer):
-		return entityTypeContainer, nil
-	case EntityType(entity.TypeImage):
-		return entityTypeImage, nil
-	case EntityType(entity.TypeProfile):
-		return entityTypeProfile, nil
-	case EntityType(entity.TypeProject):
-		return entityTypeProject, nil
-	case EntityType(entity.TypeCertificate):
-		return entityTypeCertificate, nil
-	case EntityType(entity.TypeInstance):
-		return entityTypeInstance, nil
-	case EntityType(entity.TypeInstanceBackup):
-		return entityTypeInstanceBackup, nil
-	case EntityType(entity.TypeInstanceSnapshot):
-		return entityTypeInstanceSnapshot, nil
-	case EntityType(entity.TypeNetwork):
-		return entityTypeNetwork, nil
-	case EntityType(entity.TypeNetworkACL):
-		return entityTypeNetworkACL, nil
-	case EntityType(entity.TypeNode):
-		return entityTypeNode, nil
-	case EntityType(entity.TypeOperation):
-		return entityTypeOperation, nil
-	case EntityType(entity.TypeStoragePool):
-		return entityTypeStoragePool, nil
-	case EntityType(entity.TypeStorageVolume):
-		return entityTypeStorageVolume, nil
-	case EntityType(entity.TypeStorageVolumeBackup):
-		return entityTypeStorageVolumeBackup, nil
-	case EntityType(entity.TypeStorageVolumeSnapshot):
-		return entityTypeStorageVolumeSnapshot, nil
-	case EntityType(entity.TypeWarning):
-		return entityTypeWarning, nil
-	case EntityType(entity.TypeClusterGroup):
-		return entityTypeClusterGroup, nil
-	case EntityType(entity.TypeStorageBucket):
-		return entityTypeStorageBucket, nil
-	case EntityType(entity.TypeNetworkZone):
-		return entityTypeNetworkZone, nil
-	case EntityType(entity.TypeImageAlias):
-		return entityTypeImageAlias, nil
-	case EntityType(entity.TypeServer):
-		return entityTypeServer, nil
-	case EntityType(entity.TypeAuthGroup):
-		return entityTypeAuthGroup, nil
-	case EntityType(entity.TypeIdentityProviderGroup):
-		return entityTypeIdentityProviderGroup, nil
-	case EntityType(entity.TypeIdentity):
-		return entityTypeIdentity, nil
-	default:
+	if e == "" {
+		return entityTypeCodeNone, nil
+	}
+
+	info, ok := entityTypes[entity.Type(e)]
+	if !ok {
 		return nil, fmt.Errorf("Unknown entity type %q", e)
 	}
-}
 
-/*
-The following queries return the information required for generating a unique URL of an entity in a common format.
-Each row returned by all of these queries has the following format:
- 1. Entity type. Including the entity type in the result allows for querying multiple entity types at once by performing
-    a UNION of two or more queries.
- 2. Entity ID. The caller will likely have an entity type and an ID that they are trying to get a URL for (see warnings
-    API/table). In other cases the caller may want to list all URLs of a particular type, so returning the ID along with
-    the URL allows for subsequent mapping or usage.
- 3. The project name (empty if the entity is not project specific).
- 4. The location (target) of the entity. Some entities require this parameter for uniqueness (e.g. storage volumes and buckets).
- 5. Path arguments that comprise the URL of the entity. These are returned as a JSON array in the order that they appear
-    in the URL.
-*/
-
-// containerEntities returns all entities of type entity.TypeContainer. These are just instance entities with an addition type constraint.
-var containerEntities = fmt.Sprintf(`%s WHERE instances.type = %d`, instanceEntities, instancetype.Container)
-
-// containerEntityByID gets the entity of type entity.TypeContainer with a particular ID.
-var containerEntityByID = fmt.Sprintf(`%s AND instances.type = %d`, instanceEntityByID, instancetype.Container)
-
-// containerEntitiesByProjectName returns all entities of type entity.TypeContainer in a particular project.
-var containerEntitiesByProjectName = fmt.Sprintf(`%s AND instances.type = %d`, instanceEntitiesByProjectName, instancetype.Container)
-
-// imageEntities returns all entities of type entity.TypeImage.
-var imageEntities = fmt.Sprintf(`SELECT %d, images.id, projects.name, '', json_array(images.fingerprint) FROM images JOIN projects ON images.project_id = projects.id`, entityTypeImage)
-
-// imageEntities gets the entity of type entity.TypeImage with a particular ID.
-var imageEntityByID = fmt.Sprintf(`%s WHERE images.id = ?`, imageEntities)
-
-// imageEntities returns all entities of type entity.TypeImage in a particular project.
-var imageEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, imageEntities)
-
-// profileEntities returns all entities of type entity.TypeProfile.
-var profileEntities = fmt.Sprintf(`SELECT %d, profiles.id, projects.name, '', json_array(profiles.name) FROM profiles JOIN projects ON profiles.project_id = projects.id`, entityTypeProfile)
-
-// profileEntities gets the entity of type entity.TypeProfile with a particular ID.
-var profileEntityByID = fmt.Sprintf(`%s WHERE profiles.id = ?`, profileEntities)
-
-// profileEntities returns all entities of type entity.TypeProfile in a particular project.
-var profileEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, profileEntities)
-
-// projectEntities returns all entities of type entity.TypeProject.
-var projectEntities = fmt.Sprintf(`SELECT %d, projects.id, projects.name, '', json_array(projects.name) FROM projects`, entityTypeProject)
-
-// projectEntities gets the entity of type entity.TypeProject with a particular ID.
-var projectEntityByID = fmt.Sprintf(`%s WHERE id = ?`, projectEntities)
-
-// certificateEntities returns all entities of type entity.TypeCertificate.
-var certificateEntities = fmt.Sprintf(`SELECT %d, identities.id, '', '', json_array(identities.identifier) FROM identities WHERE auth_method = %d`, entityTypeCertificate, authMethodTLS)
-
-// certificateEntities gets the entity of type entity.TypeCertificate with a particular ID.
-var certificateEntityByID = fmt.Sprintf(`%s AND identities.id = ?`, certificateEntities)
-
-// instanceEntities returns all entities of type entity.TypeInstance.
-var instanceEntities = fmt.Sprintf(`SELECT %d, instances.id, projects.name, '', json_array(instances.name) FROM instances JOIN projects ON instances.project_id = projects.id`, entityTypeInstance)
-
-// instanceEntities gets the entity of type entity.TypeInstance with a particular ID.
-var instanceEntityByID = fmt.Sprintf(`%s WHERE instances.id = ?`, instanceEntities)
-
-// instanceEntities returns all entities of type entity.TypeInstance in a particular project.
-var instanceEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, instanceEntities)
-
-// instanceBackupEntities returns all entities of type entity.TypeInstanceBackup.
-var instanceBackupEntities = fmt.Sprintf(`SELECT %d, instances_backups.id, projects.name, '', json_array(instances.name, instances_backups.name) FROM instances_backups JOIN instances ON instances_backups.instance_id = instances.id JOIN projects ON instances.project_id = projects.id`, entityTypeInstanceBackup)
-
-// instanceBackupEntities gets the entity of type entity.TypeInstanceBackup with a particular ID.
-var instanceBackupEntityByID = fmt.Sprintf(`%s WHERE instances_backups.id = ?`, instanceBackupEntities)
-
-// instanceBackupEntities returns all entities of type entity.TypeInstanceBackup in a particular project.
-var instanceBackupEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, instanceBackupEntities)
-
-// instanceSnapshotEntities returns all entities of type entity.TypeInstanceSnapshot.
-var instanceSnapshotEntities = fmt.Sprintf(`SELECT %d, instances_snapshots.id, projects.name, '', json_array(instances.name, instances_snapshots.name) FROM instances_snapshots JOIN instances ON instances_snapshots.instance_id = instances.id JOIN projects ON instances.project_id = projects.id`, entityTypeInstanceBackup)
-
-// instanceSnapshotEntities gets the entity of type entity.TypeInstanceSnapshot with a particular ID.
-var instanceSnapshotEntityByID = fmt.Sprintf(`%s WHERE instances_snapshots.id = ?`, instanceSnapshotEntities)
-
-// instanceSnapshotEntities returns all entities of type entity.TypeInstanceSnapshot in a particular project.
-var instanceSnapshotEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, instanceSnapshotEntities)
-
-// networkEntities returns all entities of type entity.TypeNetwork.
-var networkEntities = fmt.Sprintf(`SELECT %d, networks.id, projects.name, '', json_array(networks.name) FROM networks JOIN projects ON networks.project_id = projects.id`, entityTypeNetwork)
-
-// networkEntities gets the entity of type entity.TypeNetwork with a particular ID.
-var networkEntityByID = fmt.Sprintf(`%s WHERE networks.id = ?`, networkEntities)
-
-// networkEntities returns all entities of type entity.TypeNetwork in a particular project.
-var networkEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, networkEntities)
-
-// networkACLEntities returns all entities of type entity.TypeNetworkACL.
-var networkACLEntities = fmt.Sprintf(`SELECT %d, networks_acls.id, projects.name, '', json_array(networks_acls.name) FROM networks_acls JOIN projects ON networks_acls.project_id = projects.id`, entityTypeNetworkACL)
-
-// networkACLEntities gets the entity of type entity.TypeNetworkACL with a particular ID.
-var networkACLEntityByID = fmt.Sprintf(`%s WHERE networks_acls.id = ?`, networkACLEntities)
-
-// networkACLEntities returns all entities of type entity.TypeNetworkACL in a particular project.
-var networkACLEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, networkACLEntities)
-
-// networkZoneEntities returns all entities of type entity.TypeNetworkZone.
-var networkZoneEntities = fmt.Sprintf(`SELECT %d, networks_zones.id, projects.name, '', json_array(networks_zones.name) FROM networks_zones JOIN projects ON networks_zones.project_id = projects.id`, entityTypeNetworkZone)
-
-// networkZoneEntityByID gets the entity of type entity.TypeNetworkZone with a particular ID.
-var networkZoneEntityByID = fmt.Sprintf(`%s WHERE networks_zones.id = ?`, networkZoneEntities)
-
-// networkZoneEntitiesByProjectName returns all entities of type entity.TypeNetworkZone in a particular project.
-var networkZoneEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, networkZoneEntities)
-
-// imageAliasEntities returns all entities of type entity.TypeImageAlias.
-var imageAliasEntities = fmt.Sprintf(`SELECT %d, images_aliases.id, projects.name, '', json_array(images_aliases.name) FROM images_aliases JOIN projects ON images_aliases.project_id = projects.id`, entityTypeImageAlias)
-
-// imageAliasEntityByID gets the entity of type entity.TypeImageAlias with a particular ID.
-var imageAliasEntityByID = fmt.Sprintf(`%s WHERE images_aliases.id = ?`, imageAliasEntities)
-
-// imageAliasEntitiesByProjectName returns all the entities of type entity.TypeImageAlias in a particular project.
-var imageAliasEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, imageAliasEntities)
-
-// nodeEntities returns all entities of type entity.TypeNode.
-var nodeEntities = fmt.Sprintf(`SELECT %d, nodes.id, '', '', json_array(nodes.name) FROM nodes`, entityTypeNode)
-
-// nodeEntities gets the entity of type entity.TypeNode with a particular ID.
-var nodeEntityByID = fmt.Sprintf(`%s WHERE nodes.id = ?`, nodeEntities)
-
-// operationEntities returns all entities of type entity.TypeOperation.
-var operationEntities = fmt.Sprintf(`SELECT %d, operations.id, coalesce(projects.name, ''), '', json_array(operations.uuid) FROM operations LEFT JOIN projects ON operations.project_id = projects.id`, entityTypeOperation)
-
-// operationEntities gets the entity of type entity.TypeOperation with a particular ID.
-var operationEntityByID = fmt.Sprintf(`%s WHERE operations.id = ?`, operationEntities)
-
-// operationEntities returns all entities of type entity.TypeOperation in a particular project.
-var operationEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, strings.Replace(operationEntities, "LEFT JOIN projects", "JOIN projects", 1))
-
-// storagePoolEntities returns all entities of type entity.TypeStoragePool.
-var storagePoolEntities = fmt.Sprintf(`SELECT %d, storage_pools.id, '', '', json_array(storage_pools.name) FROM storage_pools`, entityTypeStoragePool)
-
-// storagePoolEntities gets the entity of type entity.TypeStoragePool with a particular ID.
-var storagePoolEntityByID = fmt.Sprintf(`%s WHERE storage_pools.id = ?`, storagePoolEntities)
-
-// storageVolumeEntities returns all entities of type entity.TypeStorageVolume.
-var storageVolumeEntities = fmt.Sprintf(`
-SELECT 
-	%d, 
-	storage_volumes.id, 
-	projects.name, 
-	replace(coalesce(nodes.name, ''), 'none', ''), 
-	json_array(
-		storage_pools.name,
-		CASE storage_volumes.type
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-		END,
-		storage_volumes.name
-	)
-FROM storage_volumes
-	JOIN projects ON storage_volumes.project_id = projects.id
-	JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
-	LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
-`,
-	entityTypeStorageVolume,
-	StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
-	StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
-	StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
-	StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM,
-)
-
-// storageVolumeEntities gets the entity of type entity.TypeStorageVolume with a particular ID.
-var storageVolumeEntityByID = fmt.Sprintf(`%s WHERE storage_volumes.id = ?`, storageVolumeEntities)
-
-// storageVolumeEntities returns all entities of type entity.TypeStorageVolume in a particular project.
-var storageVolumeEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, storageVolumeEntities)
-
-// storageVolumeBackupEntities returns all entities of type entity.TypeStorageVolumeBackup.
-var storageVolumeBackupEntities = fmt.Sprintf(`
-SELECT 
-	%d, 
-	storage_volumes_backups.id, 
-	projects.name, 
-	replace(coalesce(nodes.name, ''), 'none', ''), 
-	json_array(
-		storage_pools.name,
-		CASE storage_volumes.type
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-		END,
-		storage_volumes.name,
-		storage_volumes_backups.name
-	)
-FROM storage_volumes_backups
-	JOIN storage_volumes ON storage_volumes_backups.storage_volume_id = storage_volumes.id
-	JOIN projects ON storage_volumes.project_id = projects.id
-	JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
-	LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
-`,
-	entityTypeStorageVolumeBackup,
-	StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
-	StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
-	StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
-	StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM,
-)
-
-// storageVolumeBackupEntities gets the entity of type entity.TypeStorageVolumeBackup with a particular ID.
-var storageVolumeBackupEntityByID = fmt.Sprintf(`%s WHERE storage_volumes_backups.id = ?`, storageVolumeBackupEntities)
-
-// storageVolumeBackupEntities returns all entities of type entity.TypeStorageVolumeBackup in a particular project.
-var storageVolumeBackupEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, storageVolumeBackupEntities)
-
-// storageVolumeSnapshotEntities returns all entities of type entity.TypeStorageVolumeSnapshot.
-var storageVolumeSnapshotEntities = fmt.Sprintf(`
-SELECT 
-	%d, 
-	storage_volumes_snapshots.id, 
-	projects.name, 
-	replace(coalesce(nodes.name, ''), 'none', ''), 
-	json_array(
-		storage_pools.name,
-		CASE storage_volumes.type
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-		END,
-		storage_volumes.name,
-		storage_volumes_snapshots.name
-	)
-FROM storage_volumes_snapshots
-	JOIN storage_volumes ON storage_volumes_snapshots.storage_volume_id = storage_volumes.id
-	JOIN projects ON storage_volumes.project_id = projects.id
-	JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
-	LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
-`,
-	entityTypeStorageVolumeSnapshot,
-	StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
-	StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
-	StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
-	StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM,
-)
-
-// storageVolumeSnapshotEntities gets the entity of type entity.TypeStorageVolumeSnapshot with a particular ID.
-var storageVolumeSnapshotEntityByID = fmt.Sprintf(`%s WHERE storage_volumes_snapshots.id = ?`, storageVolumeSnapshotEntities)
-
-// storageVolumeSnapshotEntities returns all entities of type entity.TypeStorageVolumeSnapshot in a particular project.
-var storageVolumeSnapshotEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, storageVolumeSnapshotEntities)
-
-// warningEntities returns all entities of type entity.TypeWarning.
-var warningEntities = fmt.Sprintf(`SELECT %d, warnings.id, coalesce(projects.name, ''), replace(coalesce(nodes.name, ''), 'none', ''), json_array(warnings.uuid) FROM warnings LEFT JOIN projects ON warnings.project_id = projects.id LEFT JOIN nodes ON warnings.node_id = nodes.id`, entityTypeWarning)
-
-// warningEntities gets the entity of type entity.TypeWarning with a particular ID.
-var warningEntityByID = fmt.Sprintf(`%s WHERE warnings.id = ?`, warningEntities)
-
-// warningEntities returns all entities of type entity.TypeWarning in a particular project.
-var warningEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, strings.Replace(warningEntities, "LEFT JOIN projects", "JOIN projects", 1))
-
-// clusterGroupEntities returns all entities of type entity.TypeClusterGroup.
-var clusterGroupEntities = fmt.Sprintf(`SELECT %d, cluster_groups.id, '', '', json_array(cluster_groups.name) FROM cluster_groups`, entityTypeClusterGroup)
-
-// clusterGroupEntities gets the entity of type entity.TypeClusterGroup with a particular ID.
-var clusterGroupEntityByID = fmt.Sprintf(`%s WHERE cluster_groups.id = ?`, clusterGroupEntities)
-
-// storageBucketEntities returns all entities of type entity.TypeStorageBucket.
-var storageBucketEntities = fmt.Sprintf(`
-SELECT %d, storage_buckets.id, projects.name, replace(coalesce(nodes.name, ''), 'none', ''), json_array(storage_pools.name, storage_buckets.name)
-FROM storage_buckets
-	JOIN projects ON storage_buckets.project_id = projects.id
-	JOIN storage_pools ON storage_buckets.storage_pool_id = storage_pools.id
-	LEFT JOIN nodes ON storage_buckets.node_id = nodes.id
-`, entityTypeStorageBucket,
-)
-
-// storageBucketEntityByID gets the entity of type entity.TypeStorageBucket with a particular ID.
-var storageBucketEntityByID = fmt.Sprintf(`%s WHERE storage_buckets.id = ?`, storageBucketEntities)
-
-// storageBucketEntities returns all entities of type entity.TypeStorageBucket in a particular project.
-var storageBucketEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, storageBucketEntities)
-
-// authGroupEntities returns all entities of type entity.TypeGroup.
-var authGroupEntities = fmt.Sprintf(`SELECT %d, auth_groups.id, '', '', json_array(auth_groups.name) FROM auth_groups`, entityTypeAuthGroup)
-
-// authGroupEntityByID gets the entity of type entity.TypeGroup with a particular ID.
-var authGroupEntityByID = fmt.Sprintf(`%s WHERE auth_groups.id = ?`, authGroupEntities)
-
-// identityProviderGroupEntities returns all entities of type entity.TypeIdentityProviderGroup.
-var identityProviderGroupEntities = fmt.Sprintf(`SELECT %d, identity_provider_groups.id, '', '', json_array(identity_provider_groups.name) FROM identity_provider_groups`, entityTypeIdentityProviderGroup)
-
-// identityProviderGroupByEntityID gets the entity of type entity.TypeIdentityProviderGroup with a particular ID.
-var identityProviderGroupEntityByID = fmt.Sprintf(`%s WHERE identity_provider_groups.id = ?`, identityProviderGroupEntities)
-
-// identityEntities returns all entities of type entity.TypeIdentity.
-var identityEntities = fmt.Sprintf(`
-SELECT 
-	%d, 
-	identities.id, 
-	'', 
-	'', 
-	json_array(
-		CASE identities.auth_method
-			WHEN %d THEN '%s'
-			WHEN %d THEN '%s'
-		END,
-		identities.identifier
-	) 
-FROM identities
-`,
-	entityTypeIdentity,
-	authMethodTLS, api.AuthenticationMethodTLS,
-	authMethodOIDC, api.AuthenticationMethodOIDC,
-)
-
-// identityEntityByID gets the entity of type entity.TypeIdentity with a particular ID.
-var identityEntityByID = fmt.Sprintf(`%s WHERE identities.id = ?`, identityEntities)
-
-// entityStatementsAll is a map of entity type to the statement which queries for all URL information for entities of that type.
-var entityStatementsAll = map[entity.Type]string{
-	entity.TypeContainer:             containerEntities,
-	entity.TypeImage:                 imageEntities,
-	entity.TypeProfile:               profileEntities,
-	entity.TypeProject:               projectEntities,
-	entity.TypeCertificate:           certificateEntities,
-	entity.TypeInstance:              instanceEntities,
-	entity.TypeInstanceBackup:        instanceBackupEntities,
-	entity.TypeInstanceSnapshot:      instanceSnapshotEntities,
-	entity.TypeNetwork:               networkEntities,
-	entity.TypeNetworkACL:            networkACLEntities,
-	entity.TypeNode:                  nodeEntities,
-	entity.TypeOperation:             operationEntities,
-	entity.TypeStoragePool:           storagePoolEntities,
-	entity.TypeStorageVolume:         storageVolumeEntities,
-	entity.TypeStorageVolumeBackup:   storageVolumeBackupEntities,
-	entity.TypeStorageVolumeSnapshot: storageVolumeSnapshotEntities,
-	entity.TypeWarning:               warningEntities,
-	entity.TypeClusterGroup:          clusterGroupEntities,
-	entity.TypeStorageBucket:         storageBucketEntities,
-	entity.TypeImageAlias:            imageAliasEntities,
-	entity.TypeNetworkZone:           networkZoneEntities,
-	entity.TypeAuthGroup:             authGroupEntities,
-	entity.TypeIdentityProviderGroup: identityProviderGroupEntities,
-	entity.TypeIdentity:              identityEntities,
-}
-
-// entityStatementsByID is a map of entity type to the statement which queries for all URL information for a single entity of that type with a given ID.
-var entityStatementsByID = map[entity.Type]string{
-	entity.TypeContainer:             containerEntityByID,
-	entity.TypeImage:                 imageEntityByID,
-	entity.TypeProfile:               profileEntityByID,
-	entity.TypeProject:               projectEntityByID,
-	entity.TypeCertificate:           certificateEntityByID,
-	entity.TypeInstance:              instanceEntityByID,
-	entity.TypeInstanceBackup:        instanceBackupEntityByID,
-	entity.TypeInstanceSnapshot:      instanceSnapshotEntityByID,
-	entity.TypeNetwork:               networkEntityByID,
-	entity.TypeNetworkACL:            networkACLEntityByID,
-	entity.TypeNode:                  nodeEntityByID,
-	entity.TypeOperation:             operationEntityByID,
-	entity.TypeStoragePool:           storagePoolEntityByID,
-	entity.TypeStorageVolume:         storageVolumeEntityByID,
-	entity.TypeStorageVolumeBackup:   storageVolumeBackupEntityByID,
-	entity.TypeStorageVolumeSnapshot: storageVolumeSnapshotEntityByID,
-	entity.TypeWarning:               warningEntityByID,
-	entity.TypeClusterGroup:          clusterGroupEntityByID,
-	entity.TypeStorageBucket:         storageBucketEntityByID,
-	entity.TypeImageAlias:            imageAliasEntityByID,
-	entity.TypeNetworkZone:           networkZoneEntityByID,
-	entity.TypeAuthGroup:             authGroupEntityByID,
-	entity.TypeIdentityProviderGroup: identityProviderGroupEntityByID,
-	entity.TypeIdentity:              identityEntityByID,
-}
-
-// entityStatementsByProjectName is a map of entity type to the statement which queries for all URL information for all entities of that type within a given project.
-var entityStatementsByProjectName = map[entity.Type]string{
-	entity.TypeContainer:             containerEntitiesByProjectName,
-	entity.TypeImage:                 imageEntitiesByProjectName,
-	entity.TypeProfile:               profileEntitiesByProjectName,
-	entity.TypeInstance:              instanceEntitiesByProjectName,
-	entity.TypeInstanceBackup:        instanceBackupEntitiesByProjectName,
-	entity.TypeInstanceSnapshot:      instanceSnapshotEntitiesByProjectName,
-	entity.TypeNetwork:               networkEntitiesByProjectName,
-	entity.TypeNetworkACL:            networkACLEntitiesByProjectName,
-	entity.TypeOperation:             operationEntitiesByProjectName,
-	entity.TypeStorageVolume:         storageVolumeEntitiesByProjectName,
-	entity.TypeStorageVolumeBackup:   storageVolumeBackupEntitiesByProjectName,
-	entity.TypeStorageVolumeSnapshot: storageVolumeSnapshotEntitiesByProjectName,
-	entity.TypeWarning:               warningEntitiesByProjectName,
-	entity.TypeStorageBucket:         storageBucketEntitiesByProjectName,
-	entity.TypeImageAlias:            imageAliasEntitiesByProjectName,
-	entity.TypeNetworkZone:           networkZoneEntitiesByProjectName,
+	return info.code(), nil
 }
 
 // EntityRef represents the expected format of entity URL queries.
@@ -621,8 +220,13 @@ func GetEntityURL(ctx context.Context, tx *sql.Tx, entityType entity.Type, entit
 		return entity.ServerURL(), nil
 	}
 
-	stmt, ok := entityStatementsByID[entityType]
+	info, ok := entityTypes[entityType]
 	if !ok {
+		return nil, fmt.Errorf("Could not get entity URL: Unknown entity type %q", entityType)
+	}
+
+	stmt := info.urlByIDQuery()
+	if stmt == "" {
 		return nil, fmt.Errorf("Could not get entity URL: No statement found for entity type %q", entityType)
 	}
 
@@ -642,7 +246,7 @@ func GetEntityURL(ctx context.Context, tx *sql.Tx, entityType entity.Type, entit
 // This method combines the above queries into a single query using the UNION operator. If no entity types are given, this function will
 // return URLs for all entity types. If no project name is given, this function will return URLs for all projects. This may result in
 // stupendously large queries, so use with caution!
-func GetEntityURLs(ctx context.Context, tx *sql.Tx, projectName string, entityTypes ...entity.Type) (map[entity.Type]map[int]*api.URL, error) { //nolint:unused // This will be used in a forthcoming feature.
+func GetEntityURLs(ctx context.Context, tx *sql.Tx, projectName string, filteringEntityTypes ...entity.Type) (map[entity.Type]map[int]*api.URL, error) { //nolint:unused // This will be used in a forthcoming feature.
 	var stmts []string
 	var args []any
 	result := make(map[entity.Type]map[int]*api.URL)
@@ -650,11 +254,11 @@ func GetEntityURLs(ctx context.Context, tx *sql.Tx, projectName string, entityTy
 	// If the server entity type is in the list of entity types, or if we are getting all entity types and
 	// not filtering by project, we need to add a server URL to the result. The entity ID of the server entity type is
 	// always zero.
-	if shared.ValueInSlice(entity.TypeServer, entityTypes) || (len(entityTypes) == 0 && projectName == "") {
+	if shared.ValueInSlice(entity.TypeServer, filteringEntityTypes) || (len(filteringEntityTypes) == 0 && projectName == "") {
 		result[entity.TypeServer] = map[int]*api.URL{0: entity.ServerURL()}
 
 		// Return early if there are no other entity types in the list (no queries to execute).
-		if len(entityTypes) == 1 {
+		if len(filteringEntityTypes) == 1 {
 			return result, nil
 		}
 	}
@@ -663,45 +267,65 @@ func GetEntityURLs(ctx context.Context, tx *sql.Tx, projectName string, entityTy
 	// If the project is not empty, each statement will need an argument for the project name.
 	// Additionally, pre-populate the result map as we know the entity types in advance (this is so that we don't have
 	// to check and assign on each loop iteration when scanning rows).
-	if len(entityTypes) == 0 && projectName == "" {
-		for entityType, stmt := range entityStatementsAll {
-			stmts = append(stmts, stmt)
+	if len(filteringEntityTypes) == 0 && projectName == "" {
+		for entityType, info := range entityTypes {
+			q := info.allURLsQuery()
+			if q == "" {
+				continue
+			}
+
+			stmts = append(stmts, q)
 			result[entityType] = make(map[int]*api.URL)
 		}
-	} else if len(entityTypes) == 0 && projectName != "" {
-		for entityType, stmt := range entityStatementsByProjectName {
-			stmts = append(stmts, stmt)
+	} else if len(filteringEntityTypes) == 0 && projectName != "" {
+		for entityType, info := range entityTypes {
+			q := info.urlsByProjectQuery()
+			if q == "" {
+				continue
+			}
+
+			stmts = append(stmts, q)
 			args = append(args, projectName)
 			result[entityType] = make(map[int]*api.URL)
 		}
 	} else if projectName == "" {
-		for _, entityType := range entityTypes {
+		for _, entityType := range filteringEntityTypes {
 			// We've already added the server url to the result.
 			if entityType == entity.TypeServer {
 				continue
 			}
 
-			stmt, ok := entityStatementsAll[entityType]
+			info, ok := entityTypes[entityType]
 			if !ok {
+				return nil, fmt.Errorf("Could not get entity URLs: Unknown entity type %q", entityType)
+			}
+
+			q := info.allURLsQuery()
+			if q == "" {
 				return nil, fmt.Errorf("Could not get entity URLs: No statement found for entity type %q", entityType)
 			}
 
-			stmts = append(stmts, stmt)
+			stmts = append(stmts, q)
 			result[entityType] = make(map[int]*api.URL)
 		}
 	} else {
-		for _, entityType := range entityTypes {
+		for _, entityType := range filteringEntityTypes {
 			// We've already added the server url to the result.
 			if entityType == entity.TypeServer {
 				continue
 			}
 
-			stmt, ok := entityStatementsByProjectName[entityType]
+			info, ok := entityTypes[entityType]
 			if !ok {
+				return nil, fmt.Errorf("Could not get entity URLs: Unknown entity type %q", entityType)
+			}
+
+			q := info.urlsByProjectQuery()
+			if q == "" {
 				return nil, fmt.Errorf("Could not get entity URLs: No statement found for entity type %q", entityType)
 			}
 
-			stmts = append(stmts, stmt)
+			stmts = append(stmts, q)
 			args = append(args, projectName)
 			result[entityType] = make(map[int]*api.URL)
 		}
@@ -730,314 +354,6 @@ func GetEntityURLs(ctx context.Context, tx *sql.Tx, projectName string, entityTy
 	}
 
 	return result, nil
-}
-
-/*
-The following queries return the ID of an entity by the information contained in its unique URL in a common format.
-These queries are not used in isolation, they are used together as part of a larger UNION query.
-Because of this, all of the below queries expect as arguments the project name, the location, and the path arguments of
-the URL.
-Some entity types don't require a project name or location, so that's why they explicitly check for an empty project
-name or location being passed in.
-Additionally, all of the queries accept an index number as their first binding so that the results can be correlated in
-the calling function (see PopulateEntityReferencesFromURLs below).
-
-TODO: We could avoid a query snippet per entity by making these snippets support multiple entities for a single entity type.
-(e.g. `WHERE projects.name IN (?, ...) AND instances.name IN (?, ...)` we'd need to be very careful!).
-*/
-
-// containerIDFromURL gets the ID of a container from its URL.
-var containerIDFromURL = fmt.Sprintf(`
-SELECT ?, instances.id 
-FROM instances 
-JOIN projects ON instances.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND instances.name = ? 
-	AND instances.type = %d
-`, instancetype.Container)
-
-// imageIDFromURL gets the ID of an image from its URL.
-var imageIDFromURL = `
-SELECT ?, images.id 
-FROM images 
-JOIN projects ON images.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND images.fingerprint = ?`
-
-// profileIDFromURL gets the ID of a profile from its URL.
-var profileIDFromURL = `
-SELECT ?, profiles.id 
-FROM profiles 
-JOIN projects ON profiles.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND profiles.name = ?`
-
-// projectIDFromURL gets the ID of a project from its URL.
-var projectIDFromURL = `
-SELECT ?, projects.id 
-FROM projects 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND projects.name = ?`
-
-// certificateIDFromURL gets the ID of a certificate from its URL.
-var certificateIDFromURL = fmt.Sprintf(`
-SELECT ?, identities.id 
-FROM identities 
-WHERE '' = ? 
-	AND '' = ? 
-	AND identities.identifier = ? 
-	AND identities.auth_method = %d
-`, authMethodTLS)
-
-// instanceIDFromURL gets the ID of an instance from its URL.
-var instanceIDFromURL = `
-SELECT ?, instances.id 
-FROM instances 
-JOIN projects ON instances.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND instances.name = ?`
-
-// instanceBackupIDFromURL gets the ID of an instance backup from its URL.
-var instanceBackupIDFromURL = `
-SELECT ?, instances_backups.id 
-FROM instances_backups 
-JOIN instances ON instances_backups.instance_id = instances.id 
-JOIN projects ON instances.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND instances.name = ? 
-	AND instances_backups.name = ?`
-
-// instanceSnapshotIDFromURL gets the ID of an instance snapshot from its URL.
-var instanceSnapshotIDFromURL = `
-SELECT ?, instances_snapshots.id 
-FROM instances_snapshots 
-JOIN instances ON instances_snapshots.instance_id = instances.id 
-JOIN projects ON instances.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND instances.name = ? 
-	AND instances_snapshots.name = ?`
-
-// networkIDFromURL gets the ID of a network from its URL.
-var networkIDFromURL = `
-SELECT ?, networks.id 
-FROM networks 
-JOIN projects ON networks.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND networks.name = ?`
-
-// networkACLIDFromURL gets the ID of a network ACL from its URL.
-var networkACLIDFromURL = `
-SELECT ?, networks_acls.id 
-FROM networks_acls 
-JOIN projects ON networks_acls.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND networks_acls.name = ?`
-
-// nodeIDFromURL gets the ID of a node from its URL.
-var nodeIDFromURL = `
-SELECT ?, nodes.id 
-FROM nodes 
-WHERE '' = ? 
-	AND '' = ? 
-	AND nodes.name = ?`
-
-// operationIDFromURL gets the ID of an operation from its URL.
-var operationIDFromURL = `
-SELECT ?, operations.id 
-FROM operations 
-LEFT JOIN projects ON operations.project_id = projects.id 
-WHERE coalesce(projects.name, '') = ? 
-	AND '' = ? 
-	AND operations.uuid = ?`
-
-// storagePoolIDFromURL gets the ID of a storage pool from its URL.
-var storagePoolIDFromURL = `
-SELECT ?, storage_pools.id 
-FROM storage_pools 
-WHERE '' = ? 
-	AND '' = ? 
-	AND storage_pools.name = ?`
-
-// storageVolumeIDFromURL gets the ID of a storage volume from its URL.
-var storageVolumeIDFromURL = fmt.Sprintf(`
-SELECT ?, storage_volumes.id 
-FROM storage_volumes
-JOIN projects ON storage_volumes.project_id = projects.id
-JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
-LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
-WHERE projects.name = ? 
-	AND replace(coalesce(nodes.name, ''), 'none', '') = ? 
-	AND storage_pools.name = ? 
-	AND CASE storage_volumes.type 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-	END = ? 
-	AND storage_volumes.name = ?
-`, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
-	StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
-	StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
-	StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM)
-
-// storageVolumeBackupIDFromURL gets the ID of a storageVolumeBackup from its URL.
-var storageVolumeBackupIDFromURL = fmt.Sprintf(`
-SELECT ?, storage_volumes_backups.id 
-FROM storage_volumes_backups
-JOIN storage_volumes ON storage_volumes_backups.storage_volume_id = storage_volumes.id
-JOIN projects ON storage_volumes.project_id = projects.id
-JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
-LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
-WHERE projects.name = ? 
-	AND replace(coalesce(nodes.name, ''), 'none', '') = ? 
-	AND storage_pools.name = ? 
-	AND CASE storage_volumes.type 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-	END = ? 
-	AND storage_volumes.name = ? 
-	AND storage_volumes_backups.name = ?
-`, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
-	StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
-	StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
-	StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM)
-
-// storageVolumeSnapshotIDFromURL gets the ID of a storageVolumeSnapshot from its URL.
-var storageVolumeSnapshotIDFromURL = fmt.Sprintf(`
-SELECT ?, storage_volumes_snapshots.id 
-FROM storage_volumes_snapshots
-JOIN storage_volumes ON storage_volumes_snapshots.storage_volume_id = storage_volumes.id
-JOIN projects ON storage_volumes.project_id = projects.id
-JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
-LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
-WHERE projects.name = ? 
-	AND replace(coalesce(nodes.name, ''), 'none', '') = ? 
-	AND storage_pools.name = ? 
-	AND CASE storage_volumes.type
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-	END = ? 
-	AND storage_volumes.name = ? 
-	AND storage_volumes_snapshots.name = ?
-`, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer, StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage, StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom, StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM)
-
-// warningIDFromURL gets the ID of a warning from its URL.
-var warningIDFromURL = `
-SELECT ?, warnings.id 
-FROM warnings 
-LEFT JOIN projects ON warnings.project_id = projects.id 
-WHERE coalesce(projects.name, '') = ? 
-	AND '' = ? 
-	AND warnings.uuid = ?`
-
-// clusterGroupIDFromURL gets the ID of a clusterGroup from its URL.
-var clusterGroupIDFromURL = `
-SELECT ?, cluster_groups.id 
-FROM cluster_groups 
-WHERE '' = ? 
-	AND '' = ? 
-	AND cluster_groups.name = ?`
-
-// storageBucketIDFromURL gets the ID of a storageBucket from its URL.
-var storageBucketIDFromURL = `
-SELECT ?, storage_buckets.id 
-FROM storage_buckets
-JOIN projects ON storage_buckets.project_id = projects.id
-JOIN storage_pools ON storage_buckets.storage_pool_id = storage_pools.id
-LEFT JOIN nodes ON storage_buckets.node_id = nodes.id
-WHERE projects.name = ? 
-	AND replace(coalesce(nodes.name, ''), 'none', '') = ? 
-	AND storage_pools.name = ? 
-	AND storage_buckets.name = ?
-`
-
-// networkZoneIDFromURL gets the ID of a networkZone from its URL.
-var networkZoneIDFromURL = `
-SELECT ?, networks_zones.id 
-FROM networks_zones 
-JOIN projects ON networks_zones.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND networks_zones.name = ?`
-
-// imageAliasIDFromURL gets the ID of a imageAlias from its URL.
-var imageAliasIDFromURL = `
-SELECT ?, images_aliases.id 
-FROM images_aliases 
-JOIN projects ON images_aliases.project_id = projects.id 
-WHERE projects.name = ? 
-	AND '' = ? 
-	AND images_aliases.name = ? `
-
-// authGroupIDFromURL gets the ID of a group from its URL.
-var authGroupIDFromURL = `
-SELECT ?, auth_groups.id 
-FROM auth_groups 
-WHERE '' = ? 
-	AND '' = ? 
-	AND auth_groups.name = ?`
-
-// identityProviderGroupIDFromURL gets the ID of a identityProviderGroup from its URL.
-var identityProviderGroupIDFromURL = `
-SELECT ?, identity_provider_groups.id 
-FROM identity_provider_groups 
-WHERE '' = ? 
-	AND '' = ? 
-	AND identity_provider_groups.name = ?`
-
-// identityIDFromURL gets the ID of a identity from its URL.
-var identityIDFromURL = fmt.Sprintf(`
-SELECT ?, identities.id 
-FROM identities 
-WHERE '' = ? 
-	AND '' = ? 
-	AND CASE identities.auth_method 
-		WHEN %d THEN '%s' 
-		WHEN %d THEN '%s' 
-	END = ? 
-	AND identities.identifier = ?
-`, authMethodTLS, api.AuthenticationMethodTLS,
-	authMethodOIDC, api.AuthenticationMethodOIDC)
-
-// identityIDFromURLStatements is a map of entity.Type to a statement that can be used to get the ID of the entity from its URL.
-var entityIDFromURLStatements = map[entity.Type]string{
-	entity.TypeContainer:             containerIDFromURL,
-	entity.TypeImage:                 imageIDFromURL,
-	entity.TypeProfile:               profileIDFromURL,
-	entity.TypeProject:               projectIDFromURL,
-	entity.TypeCertificate:           certificateIDFromURL,
-	entity.TypeInstance:              instanceIDFromURL,
-	entity.TypeInstanceBackup:        instanceBackupIDFromURL,
-	entity.TypeInstanceSnapshot:      instanceSnapshotIDFromURL,
-	entity.TypeNetwork:               networkIDFromURL,
-	entity.TypeNetworkACL:            networkACLIDFromURL,
-	entity.TypeNode:                  nodeIDFromURL,
-	entity.TypeOperation:             operationIDFromURL,
-	entity.TypeStoragePool:           storagePoolIDFromURL,
-	entity.TypeStorageVolume:         storageVolumeIDFromURL,
-	entity.TypeStorageVolumeBackup:   storageVolumeBackupIDFromURL,
-	entity.TypeStorageVolumeSnapshot: storageVolumeSnapshotIDFromURL,
-	entity.TypeWarning:               warningIDFromURL,
-	entity.TypeClusterGroup:          clusterGroupIDFromURL,
-	entity.TypeStorageBucket:         storageBucketIDFromURL,
-	entity.TypeImageAlias:            imageAliasIDFromURL,
-	entity.TypeNetworkZone:           networkZoneIDFromURL,
-	entity.TypeAuthGroup:             authGroupIDFromURL,
-	entity.TypeIdentityProviderGroup: identityProviderGroupIDFromURL,
-	entity.TypeIdentity:              identityIDFromURL,
 }
 
 // PopulateEntityReferencesFromURLs populates the values in the given map with entity references corresponding to the api.URL keys.
@@ -1076,9 +392,14 @@ func PopulateEntityReferencesFromURLs(ctx context.Context, tx *sql.Tx, entityURL
 			continue
 		}
 
-		// Get the statement corresponding to the entity type.
-		stmt, ok := entityIDFromURLStatements[entityType]
+		info, ok := entityTypes[entityType]
 		if !ok {
+			return fmt.Errorf("Could not get entity IDs from URLs: Unknown entity type %q", entityType)
+		}
+
+		// Get the statement corresponding to the entity type.
+		stmt := info.idFromURLQuery()
+		if stmt == "" {
 			return fmt.Errorf("Could not get entity IDs from URLs: No statement found for entity type %q", entityType)
 		}
 
@@ -1162,9 +483,14 @@ func GetEntityReferenceFromURL(ctx context.Context, tx *sql.Tx, entityURL *api.U
 		return entityRef, nil
 	}
 
-	// Get the statement corresponding to the entity type.
-	stmt, ok := entityIDFromURLStatements[entityType]
+	info, ok := entityTypes[entityType]
 	if !ok {
+		return nil, fmt.Errorf("Could not get entity ID from URL: Unknown entity type %q", entityType)
+	}
+
+	// Get the statement corresponding to the entity type.
+	stmt := info.idFromURLQuery()
+	if stmt == "" {
 		return nil, fmt.Errorf("Could not get entity ID from URL: No statement found for entity type %q", entityType)
 	}
 
@@ -1192,353 +518,3 @@ func GetEntityReferenceFromURL(ctx context.Context, tx *sql.Tx, entityURL *api.U
 
 	return entityRef, nil
 }
-
-var entityDeletionTriggers = map[entity.Type]string{
-	entity.TypeImage:                 imageDeletionTrigger,
-	entity.TypeProfile:               profileDeletionTrigger,
-	entity.TypeProject:               projectDeletionTrigger,
-	entity.TypeInstance:              instanceDeletionTrigger,
-	entity.TypeInstanceBackup:        instanceBackupDeletionTrigger,
-	entity.TypeInstanceSnapshot:      instanceSnapshotDeletionTrigger,
-	entity.TypeNetwork:               networkDeletionTrigger,
-	entity.TypeNetworkACL:            networkACLDeletionTrigger,
-	entity.TypeNode:                  nodeDeletionTrigger,
-	entity.TypeOperation:             operationDeletionTrigger,
-	entity.TypeStoragePool:           storagePoolDeletionTrigger,
-	entity.TypeStorageVolume:         storageVolumeDeletionTrigger,
-	entity.TypeStorageVolumeBackup:   storageVolumeBackupDeletionTrigger,
-	entity.TypeStorageVolumeSnapshot: storageVolumeSnapshotDeletionTrigger,
-	entity.TypeWarning:               warningDeletionTrigger,
-	entity.TypeClusterGroup:          clusterGroupDeletionTrigger,
-	entity.TypeStorageBucket:         storageBucketDeletionTrigger,
-	entity.TypeImageAlias:            imageAliasDeletionTrigger,
-	entity.TypeNetworkZone:           networkZoneDeletionTrigger,
-	entity.TypeAuthGroup:             authGroupDeletionTrigger,
-	entity.TypeIdentityProviderGroup: identityProviderGroupDeletionTrigger,
-	entity.TypeIdentity:              identityDeletionTrigger,
-}
-
-// imageDeletionTrigger deletes any permissions or warnings associated with an image when it is deleted.
-var imageDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_image_delete;
-CREATE TRIGGER on_image_delete
-	AFTER DELETE ON images
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeImage, entityTypeImage)
-
-// profileDeletionTrigger deletes any permissions or warnings associated with a profile when it is deleted.
-var profileDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_profile_delete;
-CREATE TRIGGER on_profile_delete
-	AFTER DELETE ON profiles
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeProfile, entityTypeProfile)
-
-// projectDeletionTrigger deletes any permissions or warnings associated with a project when it is deleted.
-var projectDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_project_delete;
-CREATE TRIGGER on_project_delete
-	AFTER DELETE ON projects
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeProject, entityTypeProject)
-
-// instanceDeletionTrigger deletes any permissions or warnings associated with an instance when it is deleted.
-var instanceDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_instance_delete;
-CREATE TRIGGER on_instance_delete
-	AFTER DELETE ON instances
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeInstance, entityTypeInstance)
-
-// instanceBackupDeletionTrigger deletes any permissions or warnings associated with an instance backup when it is deleted.
-var instanceBackupDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_instance_backup_delete;
-CREATE TRIGGER on_instance_backup_delete
-	AFTER DELETE ON instances_backups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeInstanceBackup, entityTypeInstanceBackup)
-
-// instanceSnapshotDeletionTrigger deletes any permissions or warnings associated with an instance snapshot when it is deleted.
-var instanceSnapshotDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_instance_snaphot_delete;
-CREATE TRIGGER on_instance_snaphot_delete
-	AFTER DELETE ON instances_snapshots
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeInstanceSnapshot, entityTypeInstanceSnapshot)
-
-// networkDeletionTrigger deletes any permissions or warnings associated with a network when it is deleted.
-var networkDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_network_delete;
-CREATE TRIGGER on_network_delete
-	AFTER DELETE ON networks
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeNetwork, entityTypeNetwork)
-
-// networkACLDeletionTrigger deletes any permissions or warnings associated with a network ACL when it is deleted.
-var networkACLDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_network_acl_delete;
-CREATE TRIGGER on_network_acl_delete
-	AFTER DELETE ON networks_acls
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeNetworkACL, entityTypeNetworkACL)
-
-// nodeDeletionTrigger deletes any permissions or warnings associated with a node when it is deleted.
-var nodeDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_node_delete;
-CREATE TRIGGER on_node_delete
-	AFTER DELETE ON nodes
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeNode, entityTypeNode)
-
-// operationDeletionTrigger deletes any permissions or warnings associated with an operation when it is deleted.
-var operationDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_operation_delete;
-CREATE TRIGGER on_operation_delete
-	AFTER DELETE ON operations
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeOperation, entityTypeOperation)
-
-// storagePoolDeletionTrigger deletes any permissions or warnings associated with a storage pool when it is deleted.
-var storagePoolDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_storage_pool_delete;
-CREATE TRIGGER on_storage_pool_delete
-	AFTER DELETE ON storage_pools
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeStoragePool, entityTypeStoragePool)
-
-// storageVolumeDeletionTrigger deletes any permissions or warnings associated with a storage volume when it is deleted.
-var storageVolumeDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_storage_volume_delete;
-CREATE TRIGGER on_storage_volume_delete
-	AFTER DELETE ON storage_volumes
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeStorageVolume, entityTypeStorageVolume)
-
-// storageVolumeBackupDeletionTrigger deletes any permissions or warnings associated with a storage volume backup when it is deleted.
-var storageVolumeBackupDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_storage_volume_backup_delete;
-CREATE TRIGGER on_storage_volume_backup_delete
-	AFTER DELETE ON storage_volumes_backups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeStorageVolumeBackup, entityTypeStorageVolumeBackup)
-
-// storageVolumeSnapshotDeletionTrigger deletes any permissions or warnings associated with a storage volume snapshot when it is deleted.
-var storageVolumeSnapshotDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_storage_volume_snapshot_delete;
-CREATE TRIGGER on_storage_volume_snapshot_delete
-	AFTER DELETE ON storage_volumes_snapshots
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeStorageVolumeSnapshot, entityTypeStorageVolumeSnapshot)
-
-// warningDeletionTrigger deletes any permissions associated with a warning when it is deleted.
-var warningDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_warning_delete;
-CREATE TRIGGER on_warning_delete
-	AFTER DELETE ON warnings
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	END
-`, entityTypeWarning)
-
-// clusterGroupDeletionTrigger deletes any permissions or warnings associated with a cluster group when it is deleted.
-var clusterGroupDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_cluster_group_delete;
-CREATE TRIGGER on_cluster_group_delete
-	AFTER DELETE ON cluster_groups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeClusterGroup, entityTypeClusterGroup)
-
-// storageBucketDeletionTrigger deletes any permissions or warnings associated with a storage bucket when it is deleted.
-var storageBucketDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_storage_bucket_delete;
-CREATE TRIGGER on_storage_bucket_delete
-	AFTER DELETE ON storage_buckets
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeStorageBucket, entityTypeStorageBucket)
-
-// networkZoneDeletionTrigger deletes any permissions or warnings associated with a network zone when it is deleted.
-var networkZoneDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_network_zone_delete;
-CREATE TRIGGER on_network_zone_delete
-	AFTER DELETE ON networks_zones
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeNetworkZone, entityTypeNetworkZone)
-
-// imageAliasDeletionTrigger deletes any permissions or warnings associated with an image alias when it is deleted.
-var imageAliasDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_image_alias_delete;
-CREATE TRIGGER on_image_alias_delete
-	AFTER DELETE ON images_aliases
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeImageAlias, entityTypeImageAlias)
-
-// authGroupDeletionTrigger deletes any warnings associated with an auth group when it is deleted. Permissions are
-// related to auth groups via foreign key and will have already been deleted.
-var authGroupDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_auth_group_delete;
-CREATE TRIGGER on_auth_group_delete
-	AFTER DELETE ON auth_groups
-	BEGIN
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeAuthGroup)
-
-// identityProviderGroupDeletionTrigger deletes any permissions or warnings associated with an identity provider group when it is deleted.
-var identityProviderGroupDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_identity_provider_group_delete;
-CREATE TRIGGER on_identity_provider_group_delete
-	AFTER DELETE ON identity_provider_groups
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeIdentityProviderGroup, entityTypeIdentityProviderGroup)
-
-// identityDeletionTrigger deletes any permissions or warnings associated with an identity when it is deleted.
-var identityDeletionTrigger = fmt.Sprintf(`
-DROP TRIGGER IF EXISTS on_identity_delete;
-CREATE TRIGGER on_identity_delete
-	AFTER DELETE ON identities
-	BEGIN
-	DELETE FROM auth_groups_permissions 
-		WHERE entity_type = %d 
-		AND entity_id = OLD.id;
-	DELETE FROM warnings
-		WHERE entity_type_code = %d
-		AND entity_id = OLD.id;
-	END
-`, entityTypeIdentity, entityTypeIdentity)

--- a/lxd/db/cluster/entities_test.go
+++ b/lxd/db/cluster/entities_test.go
@@ -13,36 +13,76 @@ func TestEntityStatementValidity(t *testing.T) {
 	db, err := schema.ExerciseUpdate(71, nil)
 	require.NoError(t, err)
 
-	for entityType, stmt := range entityStatementsAll {
-		_, err := db.Prepare(stmt)
+	for entityType, info := range entityTypes {
+		allURLsQuery := info.allURLsQuery()
+		if allURLsQuery == "" {
+			continue
+		}
+
+		_, err := db.Prepare(allURLsQuery)
 		assert.NoErrorf(t, err, "Entity statements %q (all): %v", entityType, err)
 	}
 
-	for entityType, stmt := range entityStatementsByID {
-		_, err := db.Prepare(stmt)
+	for entityType, info := range entityTypes {
+		urlByIDQuery := info.urlByIDQuery()
+		if urlByIDQuery == "" {
+			continue
+		}
+
+		_, err := db.Prepare(urlByIDQuery)
 		assert.NoErrorf(t, err, "Entity statements %q (by ID): %v", entityType, err)
 	}
 
-	for entityType, stmt := range entityStatementsByProjectName {
-		_, err := db.Prepare(stmt)
+	for entityType, info := range entityTypes {
+		urlsByProjectQuery := info.urlsByProjectQuery()
+		if urlsByProjectQuery == "" {
+			continue
+		}
+
+		_, err := db.Prepare(urlsByProjectQuery)
 		assert.NoErrorf(t, err, "Entity statements %q (by project): %v", entityType, err)
 	}
 
-	for outerEntityType, outerStmt := range entityStatementsByProjectName {
-		for middleEntityType, middleStmt := range entityStatementsByID {
-			for innerEntityType, innerStmt := range entityStatementsAll {
-				unionStmt := strings.Join([]string{outerStmt, middleStmt, innerStmt}, " UNION ")
-				_, err := db.Prepare(unionStmt)
+	for outerEntityType, outerEntityInfo := range entityTypes {
+		outerQuery := outerEntityInfo.urlsByProjectQuery()
+		if outerQuery == "" {
+			continue
+		}
+
+		for middleEntityType, middleEntityInfo := range entityTypes {
+			middleQuery := middleEntityInfo.urlByIDQuery()
+			if middleQuery == "" {
+				continue
+			}
+
+			for innerEntityType, innerEntityInfo := range entityTypes {
+				innerQuery := innerEntityInfo.allURLsQuery()
+				if innerQuery == "" {
+					continue
+				}
+
+				unionQuery := strings.Join([]string{outerQuery, middleQuery, innerQuery}, " UNION ")
+				_, err := db.Prepare(unionQuery)
 				assert.NoErrorf(t, err, "Union statement (outer: %q; middle: %q; inner: %q): %v", outerEntityType, middleEntityType, innerEntityType, err)
 			}
 		}
 	}
 
-	for outerEntityType, outerStmt := range entityIDFromURLStatements {
-		_, err := db.Prepare(outerStmt)
+	for outerEntityType, outerEntityInfo := range entityTypes {
+		outerQuery := outerEntityInfo.idFromURLQuery()
+		if outerQuery == "" {
+			continue
+		}
+
+		_, err := db.Prepare(outerQuery)
 		assert.NoErrorf(t, err, "Entity ID from URL statement %q: %v", outerEntityType, err)
-		for innerEntityType, innerStmt := range entityIDFromURLStatements {
-			_, err = db.Prepare(strings.Join([]string{outerStmt, innerStmt}, " UNION "))
+		for innerEntityType, innerEntityInfo := range entityTypes {
+			innerQuery := innerEntityInfo.idFromURLQuery()
+			if innerQuery == "" {
+				continue
+			}
+
+			_, err = db.Prepare(strings.Join([]string{outerQuery, innerQuery}, " UNION "))
 			assert.NoErrorf(t, err, "Union entity ID from URL statement (outer: %q; inner: %q): %v", outerEntityType, innerEntityType, err)
 		}
 	}

--- a/lxd/db/cluster/entity_type_auth_group.go
+++ b/lxd/db/cluster/entity_type_auth_group.go
@@ -1,0 +1,46 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeAuthGroup implements entityTypeDBInfo for an AuthGroup.
+type entityTypeAuthGroup struct{}
+
+func (e entityTypeAuthGroup) code() int64 {
+	return entityTypeCodeAuthGroup
+}
+
+func (e entityTypeAuthGroup) allURLsQuery() string {
+	return fmt.Sprintf(`SELECT %d, auth_groups.id, '', '', json_array(auth_groups.name) FROM auth_groups`, e.code())
+}
+
+func (e entityTypeAuthGroup) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeAuthGroup) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE auth_groups.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeAuthGroup) idFromURLQuery() string {
+	return `
+SELECT ?, auth_groups.id 
+FROM auth_groups 
+WHERE '' = ? 
+	AND '' = ? 
+	AND auth_groups.name = ?`
+}
+
+func (e entityTypeAuthGroup) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_auth_group_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON auth_groups
+	BEGIN
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code())
+}

--- a/lxd/db/cluster/entity_type_certificate.go
+++ b/lxd/db/cluster/entity_type_certificate.go
@@ -1,0 +1,39 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeCertificate implements entityTypeDBInfo for a Certificate.
+type entityTypeCertificate struct{}
+
+func (e entityTypeCertificate) code() int64 {
+	return entityTypeCodeCertificate
+}
+
+func (e entityTypeCertificate) allURLsQuery() string {
+	return fmt.Sprintf(`SELECT %d, identities.id, '', '', json_array(identities.identifier) FROM identities WHERE auth_method = %d`, e.code(), authMethodTLS)
+}
+
+func (e entityTypeCertificate) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeCertificate) urlByIDQuery() string {
+	return fmt.Sprintf(`%s AND identities.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeCertificate) idFromURLQuery() string {
+	return fmt.Sprintf(`
+SELECT ?, identities.id 
+FROM identities 
+WHERE '' = ? 
+	AND '' = ? 
+	AND identities.identifier = ? 
+	AND identities.auth_method = %d
+`, authMethodTLS)
+}
+
+func (e entityTypeCertificate) onDeleteTriggerSQL() (name string, sql string) {
+	return "", ""
+}

--- a/lxd/db/cluster/entity_type_cluster_group.go
+++ b/lxd/db/cluster/entity_type_cluster_group.go
@@ -1,0 +1,49 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeClusterGroup implements entityTypeDBInfo for a ClusterGroup.
+type entityTypeClusterGroup struct{}
+
+func (e entityTypeClusterGroup) code() int64 {
+	return entityTypeCodeClusterGroup
+}
+
+func (e entityTypeClusterGroup) allURLsQuery() string {
+	return fmt.Sprintf(`SELECT %d, cluster_groups.id, '', '', json_array(cluster_groups.name) FROM cluster_groups`, e.code())
+}
+
+func (e entityTypeClusterGroup) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeClusterGroup) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE cluster_groups.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeClusterGroup) idFromURLQuery() string {
+	return `
+SELECT ?, cluster_groups.id 
+FROM cluster_groups 
+WHERE '' = ? 
+	AND '' = ? 
+	AND cluster_groups.name = ?`
+}
+
+func (e entityTypeClusterGroup) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_cluster_group_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON cluster_groups
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_cluster_member.go
+++ b/lxd/db/cluster/entity_type_cluster_member.go
@@ -1,0 +1,49 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeClusterMember implements entityTypeDBInfo for a ClusterMember.
+type entityTypeClusterMember struct{}
+
+func (e entityTypeClusterMember) code() int64 {
+	return entityTypeCodeClusterMember
+}
+
+func (e entityTypeClusterMember) allURLsQuery() string {
+	return fmt.Sprintf(`SELECT %d, nodes.id, '', '', json_array(nodes.name) FROM nodes`, e.code())
+}
+
+func (e entityTypeClusterMember) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeClusterMember) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE nodes.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeClusterMember) idFromURLQuery() string {
+	return `
+SELECT ?, nodes.id 
+FROM nodes 
+WHERE '' = ? 
+	AND '' = ? 
+	AND nodes.name = ?`
+}
+
+func (e entityTypeClusterMember) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_node_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON nodes
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_container.go
+++ b/lxd/db/cluster/entity_type_container.go
@@ -1,0 +1,47 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/canonical/lxd/lxd/instance/instancetype"
+)
+
+// entityTypeContainer implements entityTypeDBInfo for a Container.
+type entityTypeContainer struct{}
+
+func (e entityTypeContainer) code() int64 {
+	return entityTypeCodeContainer
+}
+
+func (e entityTypeContainer) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, instances.id, projects.name, '', json_array(instances.name) 
+FROM instances 
+JOIN projects ON instances.project_id = projects.id 
+WHERE instances.type = %d
+`, e.code(), instancetype.Container)
+}
+
+func (e entityTypeContainer) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s AND projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeContainer) urlByIDQuery() string {
+	return fmt.Sprintf(`%s AND instances.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeContainer) idFromURLQuery() string {
+	return fmt.Sprintf(`
+SELECT ?, instances.id 
+FROM instances 
+JOIN projects ON instances.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND instances.name = ? 
+	AND instances.type = %d
+`, instancetype.Container)
+}
+
+func (e entityTypeContainer) onDeleteTriggerSQL() (name string, sql string) {
+	return "", ""
+}

--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -1,0 +1,75 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+// entityTypeIdentity implements entityTypeDBInfo for an Identity.
+type entityTypeIdentity struct{}
+
+func (e entityTypeIdentity) code() int64 {
+	return entityTypeCodeIdentity
+}
+
+func (e entityTypeIdentity) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT 
+	%d, 
+	identities.id, 
+	'', 
+	'', 
+	json_array(
+		CASE identities.auth_method
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+		END,
+		identities.identifier
+	) 
+FROM identities
+`,
+		e.code(),
+		authMethodTLS, api.AuthenticationMethodTLS,
+		authMethodOIDC, api.AuthenticationMethodOIDC,
+	)
+}
+
+func (e entityTypeIdentity) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeIdentity) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE identities.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeIdentity) idFromURLQuery() string {
+	return fmt.Sprintf(`
+SELECT ?, identities.id 
+FROM identities 
+WHERE '' = ? 
+	AND '' = ? 
+	AND CASE identities.auth_method 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+	END = ? 
+	AND identities.identifier = ?
+`, authMethodTLS, api.AuthenticationMethodTLS,
+		authMethodOIDC, api.AuthenticationMethodOIDC)
+}
+
+func (e entityTypeIdentity) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_identity_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON identities
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_identity_provider_group.go
+++ b/lxd/db/cluster/entity_type_identity_provider_group.go
@@ -1,0 +1,49 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeIdentityProviderGroup implements entityTypeDBInfo for an IdentityProviderGroup.
+type entityTypeIdentityProviderGroup struct{}
+
+func (e entityTypeIdentityProviderGroup) code() int64 {
+	return entityTypeCodeIdentityProviderGroup
+}
+
+func (e entityTypeIdentityProviderGroup) allURLsQuery() string {
+	return fmt.Sprintf(`SELECT %d, identity_provider_groups.id, '', '', json_array(identity_provider_groups.name) FROM identity_provider_groups`, e.code())
+}
+
+func (e entityTypeIdentityProviderGroup) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeIdentityProviderGroup) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE identity_provider_groups.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeIdentityProviderGroup) idFromURLQuery() string {
+	return `
+SELECT ?, identity_provider_groups.id 
+FROM identity_provider_groups 
+WHERE '' = ? 
+	AND '' = ? 
+	AND identity_provider_groups.name = ?`
+}
+
+func (e entityTypeIdentityProviderGroup) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_identity_provider_group_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON identity_provider_groups
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_image.go
+++ b/lxd/db/cluster/entity_type_image.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeImage implements entityTypeDBInfo for an Image.
+type entityTypeImage struct{}
+
+func (e entityTypeImage) code() int64 {
+	return entityTypeCodeImage
+}
+
+func (e entityTypeImage) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, images.id, projects.name, '', json_array(images.fingerprint) 
+FROM images 
+JOIN projects ON images.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeImage) urlsByProjectQuery() string {
+	return fmt.Sprintf("%s WHERE projects.name = ?", e.allURLsQuery())
+}
+
+func (e entityTypeImage) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE images.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeImage) idFromURLQuery() string {
+	return `
+SELECT ?, images.id 
+FROM images 
+JOIN projects ON images.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND images.fingerprint = ?`
+}
+
+func (e entityTypeImage) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_image_delete"
+	return name, fmt.Sprintf(`CREATE TRIGGER %s
+	AFTER DELETE ON images
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_image_alias.go
+++ b/lxd/db/cluster/entity_type_image_alias.go
@@ -1,0 +1,53 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeImageAlias implements entityTypeDBInfo for an ImageAlias.
+type entityTypeImageAlias struct{}
+
+func (e entityTypeImageAlias) code() int64 {
+	return entityTypeCodeImageAlias
+}
+
+func (e entityTypeImageAlias) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, images_aliases.id, projects.name, '', json_array(images_aliases.name) 
+FROM images_aliases 
+JOIN projects ON images_aliases.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeImageAlias) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeImageAlias) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE images_aliases.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeImageAlias) idFromURLQuery() string {
+	return `
+SELECT ?, images_aliases.id 
+FROM images_aliases 
+JOIN projects ON images_aliases.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND images_aliases.name = ? `
+}
+
+func (e entityTypeImageAlias) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_image_alias_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON images_aliases
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_instance.go
+++ b/lxd/db/cluster/entity_type_instance.go
@@ -1,0 +1,53 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeInstance implements entityTypeDBInfo for an Instance.
+type entityTypeInstance struct{}
+
+func (e entityTypeInstance) code() int64 {
+	return entityTypeCodeInstance
+}
+
+func (e entityTypeInstance) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, instances.id, projects.name, '', json_array(instances.name) 
+FROM instances 
+JOIN projects ON instances.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeInstance) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeInstance) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE instances.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeInstance) idFromURLQuery() string {
+	return `
+SELECT ?, instances.id 
+FROM instances 
+JOIN projects ON instances.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND instances.name = ?`
+}
+
+func (e entityTypeInstance) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_instance_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON instances
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_instance_backup.go
+++ b/lxd/db/cluster/entity_type_instance_backup.go
@@ -1,0 +1,56 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeInstanceBackup implements entityTypeDBInfo for an InstanceBackup.
+type entityTypeInstanceBackup struct{}
+
+func (e entityTypeInstanceBackup) code() int64 {
+	return entityTypeCodeInstanceBackup
+}
+
+func (e entityTypeInstanceBackup) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, instances_backups.id, projects.name, '', json_array(instances.name, instances_backups.name)
+FROM instances_backups 
+JOIN instances ON instances_backups.instance_id = instances.id 
+JOIN projects ON instances.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeInstanceBackup) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeInstanceBackup) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE instances_backups.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeInstanceBackup) idFromURLQuery() string {
+	return `
+SELECT ?, instances_backups.id 
+FROM instances_backups 
+JOIN instances ON instances_backups.instance_id = instances.id 
+JOIN projects ON instances.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND instances.name = ? 
+	AND instances_backups.name = ?`
+}
+
+func (e entityTypeInstanceBackup) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_instance_backup_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON instances_backups
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_instance_snapshot.go
+++ b/lxd/db/cluster/entity_type_instance_snapshot.go
@@ -1,0 +1,56 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeInstanceSnapshot implements entityTypeDBInfo for an InstanceSnapshot.
+type entityTypeInstanceSnapshot struct{}
+
+func (e entityTypeInstanceSnapshot) code() int64 {
+	return entityTypeCodeInstanceSnapshot
+}
+
+func (e entityTypeInstanceSnapshot) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, instances_snapshots.id, projects.name, '', json_array(instances.name, instances_snapshots.name) 
+FROM instances_snapshots 
+JOIN instances ON instances_snapshots.instance_id = instances.id 
+JOIN projects ON instances.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeInstanceSnapshot) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeInstanceSnapshot) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeInstanceSnapshot) idFromURLQuery() string {
+	return `
+SELECT ?, instances_snapshots.id 
+FROM instances_snapshots 
+JOIN instances ON instances_snapshots.instance_id = instances.id 
+JOIN projects ON instances.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND instances.name = ? 
+	AND instances_snapshots.name = ?`
+}
+
+func (e entityTypeInstanceSnapshot) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_instance_snaphot_delete" // TODO: Spelling was wrong originally. We need a patch to fix this.
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON instances_snapshots
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_network.go
+++ b/lxd/db/cluster/entity_type_network.go
@@ -1,0 +1,53 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeNetwork implements entityTypeDBInfo for a Network.
+type entityTypeNetwork struct{}
+
+func (e entityTypeNetwork) code() int64 {
+	return entityTypeCodeNetwork
+}
+
+func (e entityTypeNetwork) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, networks.id, projects.name, '', json_array(networks.name) 
+FROM networks 
+JOIN projects ON networks.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeNetwork) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeNetwork) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE networks.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeNetwork) idFromURLQuery() string {
+	return `
+SELECT ?, networks.id 
+FROM networks 
+JOIN projects ON networks.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND networks.name = ?`
+}
+
+func (e entityTypeNetwork) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_network_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON networks
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_network_acl.go
+++ b/lxd/db/cluster/entity_type_network_acl.go
@@ -1,0 +1,53 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeNetworkACL implements entityTypeDBInfo for a NetworkACL.
+type entityTypeNetworkACL struct{}
+
+func (e entityTypeNetworkACL) code() int64 {
+	return entityTypeCodeNetworkACL
+}
+
+func (e entityTypeNetworkACL) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, networks_acls.id, projects.name, '', json_array(networks_acls.name) 
+FROM networks_acls 
+JOIN projects ON networks_acls.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeNetworkACL) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeNetworkACL) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE networks_acls.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeNetworkACL) idFromURLQuery() string {
+	return `
+SELECT ?, networks_acls.id 
+FROM networks_acls 
+JOIN projects ON networks_acls.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND networks_acls.name = ?`
+}
+
+func (e entityTypeNetworkACL) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_network_acl_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON networks_acls
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_network_zone.go
+++ b/lxd/db/cluster/entity_type_network_zone.go
@@ -1,0 +1,53 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeNetworkZone implements entityTypeDBInfo for a NetworkZone.
+type entityTypeNetworkZone struct{}
+
+func (e entityTypeNetworkZone) code() int64 {
+	return entityTypeCodeNetworkZone
+}
+
+func (e entityTypeNetworkZone) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, networks_zones.id, projects.name, '', json_array(networks_zones.name) 
+FROM networks_zones 
+JOIN projects ON networks_zones.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeNetworkZone) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeNetworkZone) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE networks_zones.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeNetworkZone) idFromURLQuery() string {
+	return `
+SELECT ?, networks_zones.id 
+FROM networks_zones 
+JOIN projects ON networks_zones.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND networks_zones.name = ?`
+}
+
+func (e entityTypeNetworkZone) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_network_zone_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON networks_zones
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_operation.go
+++ b/lxd/db/cluster/entity_type_operation.go
@@ -1,0 +1,54 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+)
+
+// entityTypeOperation implements entityTypeDBInfo for an Operation.
+type entityTypeOperation struct{}
+
+func (e entityTypeOperation) code() int64 {
+	return entityTypeCodeOperation
+}
+
+func (e entityTypeOperation) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, operations.id, coalesce(projects.name, ''), '', json_array(operations.uuid) 
+FROM operations 
+LEFT JOIN projects ON operations.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeOperation) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, strings.Replace(e.allURLsQuery(), "LEFT JOIN projects", "JOIN projects", 1))
+}
+
+func (e entityTypeOperation) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE operations.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeOperation) idFromURLQuery() string {
+	return `
+SELECT ?, operations.id 
+FROM operations 
+LEFT JOIN projects ON operations.project_id = projects.id 
+WHERE coalesce(projects.name, '') = ? 
+	AND '' = ? 
+	AND operations.uuid = ?`
+}
+
+func (e entityTypeOperation) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_operation_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON operations
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_profile.go
+++ b/lxd/db/cluster/entity_type_profile.go
@@ -1,0 +1,53 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeProfile implements entityTypeDBInfo for a Profile.
+type entityTypeProfile struct{}
+
+func (e entityTypeProfile) code() int64 {
+	return entityTypeCodeProfile
+}
+
+func (e entityTypeProfile) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, profiles.id, projects.name, '', json_array(profiles.name) 
+FROM profiles 
+JOIN projects ON profiles.project_id = projects.id`, e.code())
+}
+
+func (e entityTypeProfile) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeProfile) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE profiles.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeProfile) idFromURLQuery() string {
+	return `
+SELECT ?, profiles.id 
+FROM profiles 
+JOIN projects ON profiles.project_id = projects.id 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND profiles.name = ?`
+}
+
+func (e entityTypeProfile) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_profile_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON profiles
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_project.go
+++ b/lxd/db/cluster/entity_type_project.go
@@ -1,0 +1,49 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeProject implements entityTypeDBInfo for a Project.
+type entityTypeProject struct{}
+
+func (e entityTypeProject) code() int64 {
+	return entityTypeCodeProject
+}
+
+func (e entityTypeProject) allURLsQuery() string {
+	return fmt.Sprintf(`SELECT %d, projects.id, projects.name, '', json_array(projects.name) FROM projects`, e.code())
+}
+
+func (e entityTypeProject) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeProject) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeProject) idFromURLQuery() string {
+	return `
+SELECT ?, projects.id 
+FROM projects 
+WHERE projects.name = ? 
+	AND '' = ? 
+	AND projects.name = ?`
+}
+
+func (e entityTypeProject) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_project_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON projects
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_server.go
+++ b/lxd/db/cluster/entity_type_server.go
@@ -1,0 +1,30 @@
+package cluster
+
+// entityTypeServer implements entityTypeDBInfo for a Server.
+type entityTypeServer struct{}
+
+func (e entityTypeServer) code() int64 {
+	return entityTypeCodeServer
+}
+
+// allURLsQuery returns an empty string because there are no Server entities in the database.
+func (e entityTypeServer) allURLsQuery() string {
+	return ""
+}
+
+func (e entityTypeServer) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeServer) urlByIDQuery() string {
+	return ""
+}
+
+// idFromURLQuery returns an empty string because there are no Server entities in the database.
+func (e entityTypeServer) idFromURLQuery() string {
+	return ""
+}
+
+func (e entityTypeServer) onDeleteTriggerSQL() (name string, sql string) {
+	return "", ""
+}

--- a/lxd/db/cluster/entity_type_storage_bucket.go
+++ b/lxd/db/cluster/entity_type_storage_bucket.go
@@ -1,0 +1,61 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeStorageBucket implements entityTypeDBInfo for a StorageBucket.
+type entityTypeStorageBucket struct{}
+
+func (e entityTypeStorageBucket) code() int64 {
+	return entityTypeCodeStorageBucket
+}
+
+func (e entityTypeStorageBucket) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, storage_buckets.id, projects.name, replace(coalesce(nodes.name, ''), 'none', ''), json_array(storage_pools.name, storage_buckets.name)
+FROM storage_buckets
+	JOIN projects ON storage_buckets.project_id = projects.id
+	JOIN storage_pools ON storage_buckets.storage_pool_id = storage_pools.id
+	LEFT JOIN nodes ON storage_buckets.node_id = nodes.id
+`, e.code(),
+	)
+}
+
+func (e entityTypeStorageBucket) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStorageBucket) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE storage_buckets.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStorageBucket) idFromURLQuery() string {
+	return `
+SELECT ?, storage_buckets.id 
+FROM storage_buckets
+JOIN projects ON storage_buckets.project_id = projects.id
+JOIN storage_pools ON storage_buckets.storage_pool_id = storage_pools.id
+LEFT JOIN nodes ON storage_buckets.node_id = nodes.id
+WHERE projects.name = ? 
+	AND replace(coalesce(nodes.name, ''), 'none', '') = ? 
+	AND storage_pools.name = ? 
+	AND storage_buckets.name = ?
+`
+}
+
+func (e entityTypeStorageBucket) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_storage_bucket_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON storage_buckets
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_storage_pool.go
+++ b/lxd/db/cluster/entity_type_storage_pool.go
@@ -1,0 +1,49 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeStoragePool implements entityTypeDBInfo for a StoragePool.
+type entityTypeStoragePool struct{}
+
+func (e entityTypeStoragePool) code() int64 {
+	return entityTypeCodeStoragePool
+}
+
+func (e entityTypeStoragePool) allURLsQuery() string {
+	return fmt.Sprintf(`SELECT %d, storage_pools.id, '', '', json_array(storage_pools.name) FROM storage_pools`, e.code())
+}
+
+func (e entityTypeStoragePool) urlsByProjectQuery() string {
+	return ""
+}
+
+func (e entityTypeStoragePool) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE storage_pools.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStoragePool) idFromURLQuery() string {
+	return `
+SELECT ?, storage_pools.id 
+FROM storage_pools 
+WHERE '' = ? 
+	AND '' = ? 
+	AND storage_pools.name = ?`
+}
+
+func (e entityTypeStoragePool) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_storage_pool_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON storage_pools
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_storage_volume.go
+++ b/lxd/db/cluster/entity_type_storage_volume.go
@@ -1,0 +1,89 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeStorageVolume implements entityTypeDBInfo for a StorageVolume.
+type entityTypeStorageVolume struct{}
+
+func (e entityTypeStorageVolume) code() int64 {
+	return entityTypeCodeStorageVolume
+}
+
+func (e entityTypeStorageVolume) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT 
+	%d, 
+	storage_volumes.id, 
+	projects.name, 
+	replace(coalesce(nodes.name, ''), 'none', ''), 
+	json_array(
+		storage_pools.name,
+		CASE storage_volumes.type
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+		END,
+		storage_volumes.name
+	)
+FROM storage_volumes
+	JOIN projects ON storage_volumes.project_id = projects.id
+	JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
+	LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
+`,
+		e.code(),
+		StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
+		StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
+		StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
+		StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM,
+	)
+}
+
+func (e entityTypeStorageVolume) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStorageVolume) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE storage_volumes.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStorageVolume) idFromURLQuery() string {
+	return fmt.Sprintf(`
+SELECT ?, storage_volumes.id 
+FROM storage_volumes
+JOIN projects ON storage_volumes.project_id = projects.id
+JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
+LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
+WHERE projects.name = ? 
+	AND replace(coalesce(nodes.name, ''), 'none', '') = ? 
+	AND storage_pools.name = ? 
+	AND CASE storage_volumes.type 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+	END = ? 
+	AND storage_volumes.name = ?
+`, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
+		StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
+		StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
+		StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM)
+}
+
+func (e entityTypeStorageVolume) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_storage_volume_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON storage_volumes
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_storage_volume_backup.go
+++ b/lxd/db/cluster/entity_type_storage_volume_backup.go
@@ -1,0 +1,93 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeStorageVolumeBackup implements entityTypeDBInfo for a StorageVolumeBackup.
+type entityTypeStorageVolumeBackup struct{}
+
+func (e entityTypeStorageVolumeBackup) code() int64 {
+	return entityTypeCodeStorageVolumeBackup
+}
+
+func (e entityTypeStorageVolumeBackup) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT 
+	%d, 
+	storage_volumes_backups.id, 
+	projects.name, 
+	replace(coalesce(nodes.name, ''), 'none', ''), 
+	json_array(
+		storage_pools.name,
+		CASE storage_volumes.type
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+		END,
+		storage_volumes.name,
+		storage_volumes_backups.name
+	)
+FROM storage_volumes_backups
+	JOIN storage_volumes ON storage_volumes_backups.storage_volume_id = storage_volumes.id
+	JOIN projects ON storage_volumes.project_id = projects.id
+	JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
+	LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
+`,
+		e.code(),
+		StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
+		StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
+		StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
+		StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM,
+	)
+}
+
+func (e entityTypeStorageVolumeBackup) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStorageVolumeBackup) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE storage_volumes_backups.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStorageVolumeBackup) idFromURLQuery() string {
+	return fmt.Sprintf(`
+SELECT ?, storage_volumes_backups.id 
+FROM storage_volumes_backups
+JOIN storage_volumes ON storage_volumes_backups.storage_volume_id = storage_volumes.id
+JOIN projects ON storage_volumes.project_id = projects.id
+JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
+LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
+WHERE projects.name = ? 
+	AND replace(coalesce(nodes.name, ''), 'none', '') = ? 
+	AND storage_pools.name = ? 
+	AND CASE storage_volumes.type 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+	END = ? 
+	AND storage_volumes.name = ? 
+	AND storage_volumes_backups.name = ?
+`, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
+		StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
+		StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
+		StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM)
+}
+
+func (e entityTypeStorageVolumeBackup) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_storage_volume_backup_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON storage_volumes_backups
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_storage_volume_snapshot.go
+++ b/lxd/db/cluster/entity_type_storage_volume_snapshot.go
@@ -1,0 +1,93 @@
+package cluster
+
+import (
+	"fmt"
+)
+
+// entityTypeStorageVolumeSnapshot implements entityTypeDBInfo for a StorageVolumeSnapshot.
+type entityTypeStorageVolumeSnapshot struct{}
+
+func (e entityTypeStorageVolumeSnapshot) code() int64 {
+	return entityTypeCodeStorageVolumeSnapshot
+}
+
+func (e entityTypeStorageVolumeSnapshot) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT 
+	%d, 
+	storage_volumes_snapshots.id, 
+	projects.name, 
+	replace(coalesce(nodes.name, ''), 'none', ''), 
+	json_array(
+		storage_pools.name,
+		CASE storage_volumes.type
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+			WHEN %d THEN '%s'
+		END,
+		storage_volumes.name,
+		storage_volumes_snapshots.name
+	)
+FROM storage_volumes_snapshots
+	JOIN storage_volumes ON storage_volumes_snapshots.storage_volume_id = storage_volumes.id
+	JOIN projects ON storage_volumes.project_id = projects.id
+	JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
+	LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
+`,
+		e.code(),
+		StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
+		StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
+		StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
+		StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM,
+	)
+}
+
+func (e entityTypeStorageVolumeSnapshot) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStorageVolumeSnapshot) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE storage_volumes_snapshots.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeStorageVolumeSnapshot) idFromURLQuery() string {
+	return fmt.Sprintf(`
+SELECT ?, storage_volumes_snapshots.id 
+FROM storage_volumes_snapshots
+JOIN storage_volumes ON storage_volumes_snapshots.storage_volume_id = storage_volumes.id
+JOIN projects ON storage_volumes.project_id = projects.id
+JOIN storage_pools ON storage_volumes.storage_pool_id = storage_pools.id
+LEFT JOIN nodes ON storage_volumes.node_id = nodes.id
+WHERE projects.name = ? 
+	AND replace(coalesce(nodes.name, ''), 'none', '') = ? 
+	AND storage_pools.name = ? 
+	AND CASE storage_volumes.type
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+		WHEN %d THEN '%s' 
+	END = ? 
+	AND storage_volumes.name = ? 
+	AND storage_volumes_snapshots.name = ?
+`, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeNameContainer,
+		StoragePoolVolumeTypeImage, StoragePoolVolumeTypeNameImage,
+		StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeNameCustom,
+		StoragePoolVolumeTypeVM, StoragePoolVolumeTypeNameVM)
+}
+
+func (e entityTypeStorageVolumeSnapshot) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_storage_volume_snapshot_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON storage_volumes_snapshots
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	DELETE FROM warnings
+		WHERE entity_type_code = %d
+		AND entity_id = OLD.id;
+	END
+`, name, e.code(), e.code())
+}

--- a/lxd/db/cluster/entity_type_warning.go
+++ b/lxd/db/cluster/entity_type_warning.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+)
+
+// entityTypeWarning implements entityTypeDBInfo for a Warning.
+type entityTypeWarning struct{}
+
+func (e entityTypeWarning) code() int64 {
+	return entityTypeCodeWarning
+}
+
+func (e entityTypeWarning) allURLsQuery() string {
+	return fmt.Sprintf(`
+SELECT %d, warnings.id, coalesce(projects.name, ''), replace(coalesce(nodes.name, ''), 'none', ''), json_array(warnings.uuid) 
+FROM warnings 
+LEFT JOIN projects ON warnings.project_id = projects.id 
+LEFT JOIN nodes ON warnings.node_id = nodes.id`, e.code())
+}
+
+func (e entityTypeWarning) urlsByProjectQuery() string {
+	return fmt.Sprintf(`%s WHERE projects.name = ?`, strings.Replace(e.allURLsQuery(), "LEFT JOIN projects", "JOIN projects", 1))
+}
+
+func (e entityTypeWarning) urlByIDQuery() string {
+	return fmt.Sprintf(`%s WHERE warnings.id = ?`, e.allURLsQuery())
+}
+
+func (e entityTypeWarning) idFromURLQuery() string {
+	return `
+SELECT ?, warnings.id 
+FROM warnings 
+LEFT JOIN projects ON warnings.project_id = projects.id 
+WHERE coalesce(projects.name, '') = ? 
+	AND '' = ? 
+	AND warnings.uuid = ?`
+}
+
+func (e entityTypeWarning) onDeleteTriggerSQL() (name string, sql string) {
+	name = "on_warning_delete"
+	return name, fmt.Sprintf(`
+CREATE TRIGGER %s
+	AFTER DELETE ON warnings
+	BEGIN
+	DELETE FROM auth_groups_permissions 
+		WHERE entity_type = %d 
+		AND entity_id = OLD.id;
+	END
+`, name, e.code())
+}

--- a/shared/entity/type.go
+++ b/shared/entity/type.go
@@ -2,18 +2,23 @@ package entity
 
 import (
 	"fmt"
-	"net/url"
-	"runtime"
-	"strings"
-
-	"github.com/canonical/lxd/shared"
-	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/lxd/shared/version"
 )
 
 // Type represents a resource type in LXD that is addressable via the API.
 type Type string
+
+// typeInfo represents common attributes an entity type must have.
+//
+// To create a new entity type, add a new const Type, then create a type that implements typeInfo and add it to the
+// entityTypes map.
+type typeInfo interface {
+	// requiresProject returns whether the Type requires a project to be uniquely specified, e.g. true if it is project
+	// specific, false if not.
+	requiresProject() bool
+
+	// path returns the API path for the resource. The pathPlaceholder constant should be used in place of mux variables.
+	path() []string
+}
 
 const (
 	// TypeContainer represents container resources.
@@ -97,34 +102,6 @@ const (
 	pathPlaceholder = "{pathArgument}"
 )
 
-var entityTypes = []Type{
-	TypeContainer,
-	TypeImage,
-	TypeProfile,
-	TypeProject,
-	TypeCertificate,
-	TypeInstance,
-	TypeInstanceBackup,
-	TypeInstanceSnapshot,
-	TypeNetwork,
-	TypeNetworkACL,
-	TypeNode,
-	TypeOperation,
-	TypeStoragePool,
-	TypeStorageVolume,
-	TypeStorageVolumeBackup,
-	TypeStorageVolumeSnapshot,
-	TypeWarning,
-	TypeClusterGroup,
-	TypeStorageBucket,
-	TypeServer,
-	TypeImageAlias,
-	TypeNetworkZone,
-	TypeIdentity,
-	TypeAuthGroup,
-	TypeIdentityProviderGroup,
-}
-
 // String implements fmt.Stringer for Type.
 func (t Type) String() string {
 	return string(t)
@@ -133,7 +110,8 @@ func (t Type) String() string {
 // Validate returns an error if the Type is not in the list of allowed types. If the allowEmpty argument is set to true
 // an empty string is allowed. This is to accommodate that warnings may not refer to a specific entity type.
 func (t Type) Validate() error {
-	if !shared.ValueInSlice(t, entityTypes) {
+	_, ok := entityTypes[t]
+	if !ok {
 		return fmt.Errorf("Unknown entity type %q", t)
 	}
 
@@ -148,317 +126,284 @@ func (t Type) RequiresProject() (bool, error) {
 		return false, err
 	}
 
-	return !shared.ValueInSlice(t, []Type{TypeProject, TypeCertificate, TypeNode, TypeOperation, TypeStoragePool, TypeWarning, TypeClusterGroup, TypeServer, TypeAuthGroup, TypeIdentityProviderGroup, TypeIdentity}), nil
+	return entityTypes[t].requiresProject(), nil
 }
 
-// nRequiredPathArguments returns the number of path arguments (mux variables) that are required to create a unique URL
-// for the given Type.
-func (t Type) nRequiredPathArguments() (int, error) {
-	err := t.Validate()
-	if err != nil {
-		return 0, err
-	}
-
-	typePath, err := t.path()
-	if err != nil {
-		return 0, err
-	}
-
-	nRequiredPathArguments := 0
-	for _, element := range typePath {
-		if element == pathPlaceholder {
-			nRequiredPathArguments++
-		}
-	}
-
-	return nRequiredPathArguments, nil
+// entityTypes is the source of truth for available entity types in LXD. This should never be modified at runtime.
+var entityTypes = map[Type]typeInfo{
+	TypeContainer:             container{},
+	TypeImage:                 image{},
+	TypeProfile:               profile{},
+	TypeProject:               project{},
+	TypeCertificate:           certificate{},
+	TypeInstance:              instance{},
+	TypeInstanceBackup:        instanceBackup{},
+	TypeInstanceSnapshot:      instanceSnapshot{},
+	TypeNetwork:               network{},
+	TypeNetworkACL:            networkACL{},
+	TypeNode:                  clusterMember{},
+	TypeOperation:             operation{},
+	TypeStoragePool:           storagePool{},
+	TypeStorageVolume:         storageVolume{},
+	TypeStorageVolumeBackup:   storageVolumeBackup{},
+	TypeStorageVolumeSnapshot: storageVolumeSnapshot{},
+	TypeWarning:               warning{},
+	TypeClusterGroup:          clusterGroup{},
+	TypeStorageBucket:         storageBucket{},
+	TypeServer:                server{},
+	TypeImageAlias:            imageAlias{},
+	TypeNetworkZone:           networkZone{},
+	TypeIdentity:              identity{},
+	TypeAuthGroup:             authGroup{},
+	TypeIdentityProviderGroup: identityProviderGroup{},
 }
 
-// URL returns a string URL for the Type.
-//
-// If the Type is project specific and no project name is given, the project name will be set to api.ProjectDefaultName.
-//
-// Warning: All arguments to this function will be URL encoded. They must not be URL encoded before calling this method.
-func (t Type) URL(projectName string, location string, pathArguments ...string) (*api.URL, error) {
-	requiresProject, err := t.RequiresProject()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to check if entity type %q is project specific: %w", t, err)
-	}
+type container struct{}
 
-	if requiresProject && projectName == "" {
-		projectName = api.ProjectDefaultName
-	}
-
-	nRequiredPathArguments, err := t.nRequiredPathArguments()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to check number of required path arguments for entity type %q: %w", t, err)
-	}
-
-	if len(pathArguments) != nRequiredPathArguments {
-		return nil, fmt.Errorf("Entity type %q requires `%d` path arguments but `%d` were given", t, nRequiredPathArguments, len(pathArguments))
-	}
-
-	pathParts, err := t.path()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get path template for entity type %q: %w", t, err)
-	}
-
-	argIdx := 0
-	path := []string{version.APIVersion}
-	for _, pathPart := range pathParts {
-		if pathPart == pathPlaceholder {
-			pathPart = pathArguments[argIdx]
-			argIdx++
-		}
-
-		path = append(path, pathPart)
-	}
-
-	u := api.NewURL().Path(path...)
-
-	// Set project parameter if provided and the entity type is not TypeProject (operations and warnings may be project
-	// specific but it is not a requirement).
-	if projectName != "" && t != TypeProject {
-		u = u.WithQuery("project", projectName)
-	}
-
-	// Always set location if provided (empty or "none" locations are ignored).
-	u = u.Target(location)
-	return u, nil
+func (container) requiresProject() bool {
+	return true
 }
 
-// path returns the elements of the path that comprise the url of the Type. Placeholders are used where path arguments
-// are expected.
-func (t Type) path() ([]string, error) {
-	switch t {
-	case TypeContainer:
-		return []string{"containers", pathPlaceholder}, nil
-	case TypeImage:
-		return []string{"images", pathPlaceholder}, nil
-	case TypeProfile:
-		return []string{"profiles", pathPlaceholder}, nil
-	case TypeProject:
-		return []string{"projects", pathPlaceholder}, nil
-	case TypeCertificate:
-		return []string{"certificates", pathPlaceholder}, nil
-	case TypeInstance:
-		return []string{"instances", pathPlaceholder}, nil
-	case TypeInstanceBackup:
-		return []string{"instances", pathPlaceholder, "backups", pathPlaceholder}, nil
-	case TypeInstanceSnapshot:
-		return []string{"instances", pathPlaceholder, "snapshots", pathPlaceholder}, nil
-	case TypeNetwork:
-		return []string{"networks", pathPlaceholder}, nil
-	case TypeNetworkACL:
-		return []string{"network-acls", pathPlaceholder}, nil
-	case TypeNode:
-		return []string{"cluster", "members", pathPlaceholder}, nil
-	case TypeOperation:
-		return []string{"operations", pathPlaceholder}, nil
-	case TypeStoragePool:
-		return []string{"storage-pools", pathPlaceholder}, nil
-	case TypeStorageVolume:
-		return []string{"storage-pools", pathPlaceholder, "volumes", pathPlaceholder, pathPlaceholder}, nil
-	case TypeStorageVolumeBackup:
-		return []string{"storage-pools", pathPlaceholder, "volumes", pathPlaceholder, pathPlaceholder, "backups", pathPlaceholder}, nil
-	case TypeStorageVolumeSnapshot:
-		return []string{"storage-pools", pathPlaceholder, "volumes", pathPlaceholder, pathPlaceholder, "snapshots", pathPlaceholder}, nil
-	case TypeStorageBucket:
-		return []string{"storage-pools", pathPlaceholder, "buckets", pathPlaceholder}, nil
-	case TypeWarning:
-		return []string{"warnings", pathPlaceholder}, nil
-	case TypeClusterGroup:
-		return []string{"cluster", "groups", pathPlaceholder}, nil
-	case TypeServer:
-		return []string{}, nil
-	case TypeImageAlias:
-		return []string{"images", "aliases", pathPlaceholder}, nil
-	case TypeNetworkZone:
-		return []string{"network-zones", pathPlaceholder}, nil
-	case TypeIdentity:
-		return []string{"auth", "identities", pathPlaceholder, pathPlaceholder}, nil
-	case TypeAuthGroup:
-		return []string{"auth", "groups", pathPlaceholder}, nil
-	case TypeIdentityProviderGroup:
-		return []string{"auth", "identity-provider-groups", pathPlaceholder}, nil
-	default:
-		return nil, fmt.Errorf("Missing path definition for entity type %q", t)
-	}
+func (container) path() []string {
+	return []string{"containers", pathPlaceholder}
 }
 
-// ParseURL parses a raw URL string and returns the Type, project, location, and path arguments (mux vars).
-//
-// Path arguments are returned in the order they are found in the URL. If there is no project query parameter and the
-// Type requires a project, then api.ProjectDefaultName is returned as the project name. The returned location is the
-// value of the "target" query parameter. All returned values are unescaped.
-func ParseURL(u url.URL) (entityType Type, projectName string, location string, pathArguments []string, err error) {
-	if u.Path == "/"+version.APIVersion {
-		return TypeServer, "", "", nil, nil
-	}
+type image struct{}
 
-	path := u.Path
-	if u.RawPath != "" {
-		path = u.RawPath
-	}
-
-	if !strings.HasPrefix(path, "/"+version.APIVersion+"/") {
-		return "", "", "", nil, fmt.Errorf("URL %q does not contain LXD API version", u.String())
-	}
-
-	pathParts := strings.Split(strings.TrimPrefix(path, "/"+version.APIVersion+"/"), "/")
-
-entityTypeLoop:
-	for _, currentEntityType := range entityTypes {
-		entityPath, err := currentEntityType.path()
-		if err != nil {
-			return "", "", "", nil, fmt.Errorf("Failed to get path of entity type %q: %w", currentEntityType, err)
-		}
-
-		// Skip if we don't have the same number of slashes.
-		if len(pathParts) != len(entityPath) {
-			continue
-		}
-
-		var pathArgs []string
-		for i, entityPathPart := range entityPath {
-			if entityPathPart == pathPlaceholder {
-				pathArgument, err := url.PathUnescape(pathParts[i])
-				if err != nil {
-					return "", "", "", nil, fmt.Errorf("Failed to unescape path element %q from url %q: %w", pathParts[i], u.String(), err)
-				}
-
-				pathArgs = append(pathArgs, pathArgument)
-				continue
-			}
-
-			if entityPathPart != pathParts[i] {
-				continue entityTypeLoop
-			}
-		}
-
-		pathArguments = pathArgs
-		entityType = currentEntityType
-		break
-	}
-
-	if entityType == "" {
-		return "", "", "", nil, fmt.Errorf("Failed to match entity URL %q", u.String())
-	}
-
-	requiresProject, _ := entityType.RequiresProject()
-	projectName = ""
-	if requiresProject {
-		projectName = u.Query().Get("project")
-		if projectName == "" {
-			projectName = api.ProjectDefaultName
-		}
-	}
-
-	// If it's a project URL the project name is not a query parameter, it's in the path.
-	if entityType == TypeProject {
-		projectName = pathArguments[0]
-	}
-
-	return entityType, projectName, u.Query().Get("target"), pathArguments, nil
+func (image) requiresProject() bool {
+	return true
 }
 
-// urlMust is used internally when we know that creation of an *api.URL ought to succeed. If an error does occur an
-// empty string is return and the error is logged with as much context as possible, including the file and line number
-// of the caller.
-func (t Type) urlMust(projectName string, location string, pathArguments ...string) *api.URL {
-	ref, err := t.URL(projectName, location, pathArguments...)
-	if err != nil {
-		logCtx := logger.Ctx{"entity_type": t, "project_name": projectName, "location": location, "path_aguments": pathArguments}
-
-		// Get the second caller (we expect the first caller to be internal to this package since this method is not exported).
-		_, file, line, ok := runtime.Caller(2)
-		if ok {
-			logCtx["caller"] = fmt.Sprintf("%s#%d", file, line)
-		}
-
-		logger.Error("Failed to create entity URL", logCtx)
-		return api.NewURL()
-	}
-
-	return ref
+func (image) path() []string {
+	return []string{"images", pathPlaceholder}
 }
 
-// ProjectURL returns an *api.URL to a Project.
-func ProjectURL(projectName string) *api.URL {
-	return TypeProject.urlMust("", "", projectName)
+type profile struct{}
+
+func (profile) requiresProject() bool {
+	return true
 }
 
-// InstanceURL returns an *api.URL to an instance.
-func InstanceURL(projectName string, instanceName string) *api.URL {
-	return TypeInstance.urlMust(projectName, "", instanceName)
+func (profile) path() []string {
+	return []string{"profiles", pathPlaceholder}
 }
 
-// ServerURL returns an *api.URL to the server.
-func ServerURL() *api.URL {
-	return TypeServer.urlMust("", "")
+type project struct{}
+
+func (project) requiresProject() bool {
+	return false
 }
 
-// CertificateURL returns an *api.URL to a certificate.
-func CertificateURL(fingerprint string) *api.URL {
-	return TypeCertificate.urlMust("", "", fingerprint)
+func (project) path() []string {
+	return []string{"projects", pathPlaceholder}
 }
 
-// ImageURL returns an *api.URL to an image.
-func ImageURL(projectName string, imageName string) *api.URL {
-	return TypeImage.urlMust(projectName, "", imageName)
+type certificate struct{}
+
+func (certificate) requiresProject() bool {
+	return false
 }
 
-// ImageAliasURL returns an *api.URL to an image alias.
-func ImageAliasURL(projectName string, imageAliasName string) *api.URL {
-	return TypeImageAlias.urlMust(projectName, "", imageAliasName)
+func (certificate) path() []string {
+	return []string{"certificates", pathPlaceholder}
 }
 
-// ProfileURL returns an *api.URL to a profile.
-func ProfileURL(projectName string, profileName string) *api.URL {
-	return TypeProfile.urlMust(projectName, "", profileName)
+type instance struct{}
+
+func (instance) requiresProject() bool {
+	return true
 }
 
-// NetworkURL returns an *api.URL to a network.
-func NetworkURL(projectName string, networkName string) *api.URL {
-	return TypeNetwork.urlMust(projectName, "", networkName)
+func (instance) path() []string {
+	return []string{"instances", pathPlaceholder}
 }
 
-// NetworkACLURL returns an *api.URL to a network ACL.
-func NetworkACLURL(projectName string, networkACLName string) *api.URL {
-	return TypeNetworkACL.urlMust(projectName, "", networkACLName)
+type instanceBackup struct{}
+
+func (instanceBackup) requiresProject() bool {
+	return true
 }
 
-// NetworkZoneURL returns an *api.URL to a network zone.
-func NetworkZoneURL(projectName string, networkZoneName string) *api.URL {
-	return TypeNetworkZone.urlMust(projectName, "", networkZoneName)
+func (instanceBackup) path() []string {
+	return []string{"instances", pathPlaceholder, "backups", pathPlaceholder}
 }
 
-// StoragePoolURL returns an *api.URL to a storage pool.
-func StoragePoolURL(storagePoolName string) *api.URL {
-	return TypeStoragePool.urlMust("", "", storagePoolName)
+type instanceSnapshot struct{}
+
+func (instanceSnapshot) requiresProject() bool {
+	return true
 }
 
-// StorageVolumeURL returns an *api.URL to a storage volume.
-func StorageVolumeURL(projectName string, location string, storagePoolName string, storageVolumeType string, storageVolumeName string) *api.URL {
-	return TypeStorageVolume.urlMust(projectName, location, storagePoolName, storageVolumeType, storageVolumeName)
+func (instanceSnapshot) path() []string {
+	return []string{"instances", pathPlaceholder, "snapshots", pathPlaceholder}
 }
 
-// StorageBucketURL returns an *api.URL to a storage bucket.
-func StorageBucketURL(projectName string, location string, storagePoolName string, storageBucketName string) *api.URL {
-	return TypeStorageBucket.urlMust(projectName, location, storagePoolName, storageBucketName)
+type network struct{}
+
+func (network) requiresProject() bool {
+	return true
 }
 
-// IdentityURL returns an *api.URL to an identity.
-func IdentityURL(authenticationMethod string, identifier string) *api.URL {
-	return TypeIdentity.urlMust("", "", authenticationMethod, identifier)
+func (network) path() []string {
+	return []string{"networks", pathPlaceholder}
 }
 
-// AuthGroupURL returns an *api.URL to a group.
-func AuthGroupURL(groupName string) *api.URL {
-	return TypeAuthGroup.urlMust("", "", groupName)
+type networkACL struct{}
+
+func (networkACL) requiresProject() bool {
+	return true
 }
 
-// IdentityProviderGroupURL returns an *api.URL to an identity provider group.
-func IdentityProviderGroupURL(identityProviderGroupName string) *api.URL {
-	return TypeIdentityProviderGroup.urlMust("", "", identityProviderGroupName)
+func (networkACL) path() []string {
+	return []string{"network-acls", pathPlaceholder}
+}
+
+type clusterMember struct{}
+
+func (clusterMember) requiresProject() bool {
+	return false
+}
+
+func (clusterMember) path() []string {
+	return []string{"cluster", "members", pathPlaceholder}
+}
+
+type operation struct{}
+
+func (operation) requiresProject() bool {
+	return false
+}
+
+func (operation) path() []string {
+	return []string{"operations", pathPlaceholder}
+}
+
+type storagePool struct{}
+
+func (storagePool) requiresProject() bool {
+	return false
+}
+
+func (storagePool) path() []string {
+	return []string{"storage-pools", pathPlaceholder}
+}
+
+type storageVolume struct{}
+
+func (storageVolume) requiresProject() bool {
+	return true
+}
+
+func (storageVolume) path() []string {
+	return []string{"storage-pools", pathPlaceholder, "volumes", pathPlaceholder, pathPlaceholder}
+}
+
+type storageVolumeBackup struct{}
+
+func (storageVolumeBackup) requiresProject() bool {
+	return true
+}
+
+func (storageVolumeBackup) path() []string {
+	return []string{"storage-pools", pathPlaceholder, "volumes", pathPlaceholder, pathPlaceholder, "backups", pathPlaceholder}
+}
+
+type storageVolumeSnapshot struct{}
+
+func (storageVolumeSnapshot) requiresProject() bool {
+	return true
+}
+
+func (storageVolumeSnapshot) path() []string {
+	return []string{"storage-pools", pathPlaceholder, "volumes", pathPlaceholder, pathPlaceholder, "snapshots", pathPlaceholder}
+}
+
+type warning struct{}
+
+func (warning) requiresProject() bool {
+	return false
+}
+
+func (warning) path() []string {
+	return []string{"warnings", pathPlaceholder}
+}
+
+type clusterGroup struct{}
+
+func (clusterGroup) requiresProject() bool {
+	return false
+}
+
+func (clusterGroup) path() []string {
+	return []string{"cluster", "groups", pathPlaceholder}
+}
+
+type storageBucket struct{}
+
+func (storageBucket) requiresProject() bool {
+	return true
+}
+
+func (storageBucket) path() []string {
+	return []string{"storage-pools", pathPlaceholder, "buckets", pathPlaceholder}
+}
+
+type server struct{}
+
+func (server) requiresProject() bool {
+	return false
+}
+
+func (server) path() []string {
+	return []string{}
+}
+
+type imageAlias struct{}
+
+func (imageAlias) requiresProject() bool {
+	return true
+}
+
+func (imageAlias) path() []string {
+	return []string{"images", "aliases", pathPlaceholder}
+}
+
+type networkZone struct{}
+
+func (networkZone) requiresProject() bool {
+	return true
+}
+
+func (networkZone) path() []string {
+	return []string{"network-zones", pathPlaceholder}
+}
+
+type identity struct{}
+
+func (identity) requiresProject() bool {
+	return false
+}
+
+func (identity) path() []string {
+	return []string{"auth", "identities", pathPlaceholder, pathPlaceholder}
+}
+
+type authGroup struct{}
+
+func (authGroup) requiresProject() bool {
+	return false
+}
+
+func (authGroup) path() []string {
+	return []string{"auth", "groups", pathPlaceholder}
+}
+
+type identityProviderGroup struct{}
+
+func (identityProviderGroup) requiresProject() bool {
+	return false
+}
+
+func (identityProviderGroup) path() []string {
+	return []string{"auth", "identity-provider-groups", pathPlaceholder}
 }

--- a/shared/entity/url.go
+++ b/shared/entity/url.go
@@ -1,0 +1,245 @@
+package entity
+
+import (
+	"fmt"
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/version"
+)
+
+// nRequiredPathArguments returns the number of path arguments (mux variables) that are required to create a unique URL
+// for the given typeInfo.
+func nRequiredPathArguments(t typeInfo) int {
+	nRequiredPathArguments := 0
+	for _, element := range t.path() {
+		if element == pathPlaceholder {
+			nRequiredPathArguments++
+		}
+	}
+
+	return nRequiredPathArguments
+}
+
+// URL returns a string URL for the Type.
+//
+// If the Type is project specific and no project name is given, the project name will be set to api.ProjectDefaultName.
+//
+// Warning: All arguments to this function will be URL encoded. They must not be URL encoded before calling this method.
+func (t Type) URL(projectName string, location string, pathArguments ...string) (*api.URL, error) {
+	info, ok := entityTypes[t]
+	if !ok {
+		return nil, fmt.Errorf("Invalid entity type %q", t)
+	}
+
+	if info.requiresProject() && projectName == "" {
+		projectName = api.ProjectDefaultName
+	}
+
+	nPathArgs := nRequiredPathArguments(info)
+	if len(pathArguments) != nPathArgs {
+		return nil, fmt.Errorf("Entity type %q requires `%d` path arguments but `%d` were given", t, nPathArgs, len(pathArguments))
+	}
+
+	pathParts := info.path()
+	argIdx := 0
+	path := []string{version.APIVersion}
+	for _, pathPart := range pathParts {
+		if pathPart == pathPlaceholder {
+			pathPart = pathArguments[argIdx]
+			argIdx++
+		}
+
+		path = append(path, pathPart)
+	}
+
+	u := api.NewURL().Path(path...)
+
+	// Set project parameter if provided and the entity type is not TypeProject (operations and warnings may be project
+	// specific but it is not a requirement).
+	if projectName != "" && t != TypeProject {
+		u = u.WithQuery("project", projectName)
+	}
+
+	// Always set location if provided (empty or "none" locations are ignored).
+	u = u.Target(location)
+	return u, nil
+}
+
+// ParseURL parses a raw URL string and returns the Type, project, location, and path arguments (mux vars).
+//
+// Path arguments are returned in the order they are found in the URL. If there is no project query parameter and the
+// Type requires a project, then api.ProjectDefaultName is returned as the project name. The returned location is the
+// value of the "target" query parameter. All returned values are unescaped.
+func ParseURL(u url.URL) (entityType Type, projectName string, location string, pathArguments []string, err error) {
+	if u.Path == "/"+version.APIVersion {
+		return TypeServer, "", "", nil, nil
+	}
+
+	path := u.Path
+	if u.RawPath != "" {
+		path = u.RawPath
+	}
+
+	if !strings.HasPrefix(path, "/"+version.APIVersion+"/") {
+		return "", "", "", nil, fmt.Errorf("URL %q does not contain LXD API version", u.String())
+	}
+
+	pathParts := strings.Split(strings.TrimPrefix(path, "/"+version.APIVersion+"/"), "/")
+	var entityTypeImpl typeInfo
+entityTypeLoop:
+	for t, info := range entityTypes {
+		entityPath := info.path()
+
+		// Skip if we don't have the same number of slashes.
+		if len(pathParts) != len(entityPath) {
+			continue
+		}
+
+		var pathArgs []string
+		for i, entityPathPart := range entityPath {
+			if entityPathPart == pathPlaceholder {
+				pathArgument, err := url.PathUnescape(pathParts[i])
+				if err != nil {
+					return "", "", "", nil, fmt.Errorf("Failed to unescape path element %q from url %q: %w", pathParts[i], u.String(), err)
+				}
+
+				pathArgs = append(pathArgs, pathArgument)
+				continue
+			}
+
+			if entityPathPart != pathParts[i] {
+				continue entityTypeLoop
+			}
+		}
+
+		pathArguments = pathArgs
+		entityType = t
+		entityTypeImpl = info
+		break
+	}
+
+	if entityType == "" {
+		return "", "", "", nil, fmt.Errorf("Failed to match entity URL %q", u.String())
+	}
+
+	requiresProject := entityTypeImpl.requiresProject()
+	projectName = ""
+	if requiresProject {
+		projectName = u.Query().Get("project")
+		if projectName == "" {
+			projectName = api.ProjectDefaultName
+		}
+	}
+
+	// If it's a project URL the project name is not a query parameter, it's in the path.
+	if entityType == TypeProject {
+		projectName = pathArguments[0]
+	}
+
+	return entityType, projectName, u.Query().Get("target"), pathArguments, nil
+}
+
+// urlMust is used internally when we know that creation of an *api.URL ought to succeed. If an error does occur an
+// empty string is return and the error is logged with as much context as possible, including the file and line number
+// of the caller.
+func (t Type) urlMust(projectName string, location string, pathArguments ...string) *api.URL {
+	ref, err := t.URL(projectName, location, pathArguments...)
+	if err != nil {
+		logCtx := logger.Ctx{"entity_type": t, "project_name": projectName, "location": location, "path_aguments": pathArguments}
+
+		// Get the second caller (we expect the first caller to be internal to this package since this method is not exported).
+		_, file, line, ok := runtime.Caller(2)
+		if ok {
+			logCtx["caller"] = fmt.Sprintf("%s#%d", file, line)
+		}
+
+		logger.Error("Failed to create entity URL", logCtx)
+		return api.NewURL()
+	}
+
+	return ref
+}
+
+// ProjectURL returns an *api.URL to a Project.
+func ProjectURL(projectName string) *api.URL {
+	return TypeProject.urlMust("", "", projectName)
+}
+
+// InstanceURL returns an *api.URL to an instance.
+func InstanceURL(projectName string, instanceName string) *api.URL {
+	return TypeInstance.urlMust(projectName, "", instanceName)
+}
+
+// ServerURL returns an *api.URL to the server.
+func ServerURL() *api.URL {
+	return TypeServer.urlMust("", "")
+}
+
+// CertificateURL returns an *api.URL to a certificate.
+func CertificateURL(fingerprint string) *api.URL {
+	return TypeCertificate.urlMust("", "", fingerprint)
+}
+
+// ImageURL returns an *api.URL to an image.
+func ImageURL(projectName string, imageName string) *api.URL {
+	return TypeImage.urlMust(projectName, "", imageName)
+}
+
+// ImageAliasURL returns an *api.URL to an image alias.
+func ImageAliasURL(projectName string, imageAliasName string) *api.URL {
+	return TypeImageAlias.urlMust(projectName, "", imageAliasName)
+}
+
+// ProfileURL returns an *api.URL to a profile.
+func ProfileURL(projectName string, profileName string) *api.URL {
+	return TypeProfile.urlMust(projectName, "", profileName)
+}
+
+// NetworkURL returns an *api.URL to a network.
+func NetworkURL(projectName string, networkName string) *api.URL {
+	return TypeNetwork.urlMust(projectName, "", networkName)
+}
+
+// NetworkACLURL returns an *api.URL to a network ACL.
+func NetworkACLURL(projectName string, networkACLName string) *api.URL {
+	return TypeNetworkACL.urlMust(projectName, "", networkACLName)
+}
+
+// NetworkZoneURL returns an *api.URL to a network zone.
+func NetworkZoneURL(projectName string, networkZoneName string) *api.URL {
+	return TypeNetworkZone.urlMust(projectName, "", networkZoneName)
+}
+
+// StoragePoolURL returns an *api.URL to a storage pool.
+func StoragePoolURL(storagePoolName string) *api.URL {
+	return TypeStoragePool.urlMust("", "", storagePoolName)
+}
+
+// StorageVolumeURL returns an *api.URL to a storage volume.
+func StorageVolumeURL(projectName string, location string, storagePoolName string, storageVolumeType string, storageVolumeName string) *api.URL {
+	return TypeStorageVolume.urlMust(projectName, location, storagePoolName, storageVolumeType, storageVolumeName)
+}
+
+// StorageBucketURL returns an *api.URL to a storage bucket.
+func StorageBucketURL(projectName string, location string, storagePoolName string, storageBucketName string) *api.URL {
+	return TypeStorageBucket.urlMust(projectName, location, storagePoolName, storageBucketName)
+}
+
+// IdentityURL returns an *api.URL to an identity.
+func IdentityURL(authenticationMethod string, identifier string) *api.URL {
+	return TypeIdentity.urlMust("", "", authenticationMethod, identifier)
+}
+
+// AuthGroupURL returns an *api.URL to a group.
+func AuthGroupURL(groupName string) *api.URL {
+	return TypeAuthGroup.urlMust("", "", groupName)
+}
+
+// IdentityProviderGroupURL returns an *api.URL to an identity provider group.
+func IdentityProviderGroupURL(identityProviderGroupName string) *api.URL {
+	return TypeIdentityProviderGroup.urlMust("", "", identityProviderGroupName)
+}


### PR DESCRIPTION
@tomponline @hamistao this is a much more concise entity type refactor that I think works much better. (Thanks Tom for the idea of keeping the types as they are, but storing them in a map the returns a struct/interface with relevant fields/methods).

With this change, I think it should be easy to add the URL prefix classification by:
1. Adding a `PrefixMatch() []string` method to `typeImpl` that returns a slice of URL prefixes to match the entity type against.
2. Adding a function `MatchURLPrefix` which iterates over the `entityType` map, and iterates over the `PrefixMatch()` array for each `typeImpl`, then returns the entity type if `strings.HasPrefix(u.Path, prefix)`.

Closes #13262
Closes #12928