### PR TITLE
VM: Don't fail event sending on missing agent (from Incus)

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8498,6 +8498,11 @@ func (d *qemu) devlxdEventSend(eventType string, eventMessage map[string]any) er
 
 	client, err := d.getAgentClient()
 	if err != nil {
+		// Don't fail if the VM simply doesn't have an agent.
+		if err == errQemuAgentOffline {
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
This PR adds a check for a missing/offline qemu agent in the notification logic, so that we can avoid returning an error when updating instance config.

Cherry picked from https://github.com/lxc/incus/pull/324.