### PR TITLE
shared/cmd: Allow a cmd asker to be created with a logger instance

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -89,7 +89,7 @@ For help with any of those, simply call them with --help.`))
 	app.CompletionOptions = cobra.CompletionOptions{DisableDefaultCmd: true}
 
 	// Global flags
-	globalCmd := cmdGlobal{cmd: app, asker: cli.NewAsker(bufio.NewReader(os.Stdin))}
+	globalCmd := cmdGlobal{cmd: app, asker: cli.NewAsker(bufio.NewReader(os.Stdin), nil)}
 	app.PersistentFlags().BoolVar(&globalCmd.flagVersion, "version", false, i18n.G("Print version number"))
 	app.PersistentFlags().BoolVarP(&globalCmd.flagHelp, "help", "h", false, i18n.G("Print help"))
 	app.PersistentFlags().BoolVar(&globalCmd.flagForceLocal, "force-local", false, i18n.G("Force using the local unix socket"))
@@ -358,7 +358,7 @@ func (c *cmdGlobal) PreRun(cmd *cobra.Command, args []string) error {
 
 	// Setup password helper
 	c.conf.PromptPassword = func(filename string) (string, error) {
-		return cli.AskPasswordOnce(fmt.Sprintf(i18n.G("Password for %s: "), filename)), nil
+		return c.asker.AskPasswordOnce(fmt.Sprintf(i18n.G("Password for %s: "), filename)), nil
 	}
 
 	// If the user is running a command that may attempt to connect to the local daemon

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -290,11 +291,12 @@ For help with any of those, simply call them with --help.`))
 	if err != nil {
 		// Handle non-Linux systems
 		if err == config.ErrNotLinux {
-			fmt.Fprintf(os.Stderr, i18n.G(`This client hasn't been configured to use a remote LXD server yet.
+			msg := i18n.G(`This client hasn't been configured to use a remote LXD server yet.
 As your platform can't run native Linux instances, you must connect to a remote LXD server.
 
 If you already added a remote server, make it the default with "lxc remote switch NAME".
-To easily setup a local LXD server in a virtual machine, consider using: https://multipass.run`)+"\n")
+To easily setup a local LXD server in a virtual machine, consider using: https://multipass.run`)
+			fmt.Fprintln(os.Stderr, msg)
 			os.Exit(1)
 		}
 
@@ -395,13 +397,15 @@ func (c *cmdGlobal) PreRun(cmd *cobra.Command, args []string) error {
 
 		flush := false
 		if runInit {
-			fmt.Fprintf(os.Stderr, i18n.G("If this is your first time running LXD on this machine, you should also run: lxd init")+"\n")
+			msg := i18n.G("If this is your first time running LXD on this machine, you should also run: lxd init")
+			fmt.Fprintln(os.Stderr, msg)
 			flush = true
 		}
 
 		if !shared.ValueInSlice(cmd.Name(), []string{"init", "launch"}) {
-			fmt.Fprintf(os.Stderr, i18n.G(`To start your first container, try: lxc launch ubuntu:24.04
-Or for a virtual machine: lxc launch ubuntu:24.04 --vm`)+"\n")
+			msg := i18n.G(`To start your first container, try: lxc launch ubuntu:24.04
+Or for a virtual machine: lxc launch ubuntu:24.04 --vm`)
+			fmt.Fprintln(os.Stderr, msg)
 			flush = true
 		}
 
@@ -495,7 +499,8 @@ func (c *cmdGlobal) CheckArgs(cmd *cobra.Command, args []string, minArgs int, ma
 			return true, nil
 		}
 
-		return true, fmt.Errorf(i18n.G("Invalid number of arguments"))
+		msg := i18n.G("Invalid number of arguments")
+		return true, errors.New(msg)
 	}
 
 	return false, nil

--- a/lxd-migrate/main.go
+++ b/lxd-migrate/main.go
@@ -28,7 +28,7 @@ func main() {
 	app.Args = cobra.ArbitraryArgs
 
 	// Global flags
-	globalCmd := cmdGlobal{asker: cli.NewAsker(bufio.NewReader(os.Stdin))}
+	globalCmd := cmdGlobal{asker: cli.NewAsker(bufio.NewReader(os.Stdin), nil)}
 	migrateCmd.global = &globalCmd
 	app.PersistentFlags().BoolVar(&globalCmd.flagVersion, "version", false, "Print version number")
 	app.PersistentFlags().BoolVarP(&globalCmd.flagHelp, "help", "h", false, "Print help")

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -33,6 +33,7 @@ type cmdGlobal struct {
 	flagLogVerbose bool
 }
 
+// Run is the main entry point for the LXD daemon command.
 func (c *cmdGlobal) Run(cmd *cobra.Command, args []string) error {
 	// Configure dqlite to *not* disable internal SQLite locking, since we
 	// use SQLite both through dqlite and through go-dqlite, potentially
@@ -91,7 +92,7 @@ func main() {
 	app.Args = cobra.ArbitraryArgs
 
 	// Global flags
-	globalCmd := cmdGlobal{cmd: app, asker: cli.NewAsker(bufio.NewReader(os.Stdin))}
+	globalCmd := cmdGlobal{cmd: app, asker: cli.NewAsker(bufio.NewReader(os.Stdin), nil)}
 	daemonCmd.global = &globalCmd
 	app.PersistentPreRunE = globalCmd.Run
 	app.PersistentFlags().BoolVar(&globalCmd.flagVersion, "version", false, "Print version number")


### PR DESCRIPTION
If a command asker is with a logger, the question and answer (even if it is invalid) are systematically logged to the logger destination. This will greatly help debugability in integration test suites like in MicroCloud which have a lot of interactions in the command line.