### PR TITLE
lxd/firewall/drivers: Fix netprio error message

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -682,7 +682,7 @@ func (d Nftables) InstanceSetupNetPrio(projectName string, instanceName string, 
 // InstanceClearNetPrio removes setting of skb->priority for the specified instance device on the host interface.
 func (d Nftables) InstanceClearNetPrio(projectName string, instanceName string, deviceName string) error {
 	if deviceName == "" {
-		return fmt.Errorf("Failed clearing netprio rules for instance %q in project %q: device name is empty", projectName, instanceName)
+		return fmt.Errorf("Failed clearing netprio rules for instance %q in project %q: device name is empty", instanceName, projectName)
 	}
 
 	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -1410,7 +1410,7 @@ func (d Xtables) InstanceSetupNetPrio(projectName string, instanceName string, d
 // InstanceClearNetPrio removes setting of skb->priority for the specified instance device on the host interface.
 func (d Xtables) InstanceClearNetPrio(projectName string, instanceName string, deviceName string) error {
 	if deviceName == "" {
-		return fmt.Errorf("Failed clearing netprio rules for instance %q in project %q: device name is empty", projectName, instanceName)
+		return fmt.Errorf("Failed clearing netprio rules for instance %q in project %q: device name is empty", instanceName, projectName)
 	}
 
 	comment := fmt.Sprintf("%s netprio", d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName))


### PR DESCRIPTION
This was confusing when I ran into it; initially thought PyLXD had mixed up some json fields...