### PR TITLE
Adds an API extension for image export over devlxd in VMs

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2446,3 +2446,9 @@ In this scenario, the creation and startup is part of a single background operat
 
 Enables setting the {config:option}`instance-security:security.protection.start` field which prevents instances
 from being started if set to `true`.
+
+## `devlxd_images_vm`
+
+Enables the {config:option}`instance-security:security.devlxd.images` configuration option for virtual machines.
+This controls the availability of a `/1.0/images/FINGERPRINT/export` API over `devlxd`.
+This can be used by a virtual machine running LXD to access raw images from the host.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -412,6 +412,7 @@ var APIExtensions = []string{
 	"instance_import_conversion",
 	"instance_create_start",
 	"instance_protection_start",
+	"devlxd_images_vm",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This isn't explicitly used in the client, but will be useful in testing.