### PR TITLE
Effective project handling

### DIFF
--- a/doc/explanation/projects.md
+++ b/doc/explanation/projects.md
@@ -46,6 +46,15 @@ To edit them, you must remove all instances first.
 New features that are added in an upgrade are disabled for existing projects.
 ```
 
+```{important}
+In a multi-tenant environment, unless using {ref}`fine-grained-authorization`, all projects should have all features enabled.
+Otherwise, clients with {ref}`restricted-tls-certs` are able to create, edit, and delete resources in the default project. This might affect other tenants.
+
+For example, if project "foo" is created and `features.networks` is not set to true, then a restricted client certificate with access to "foo" can view, edit, and delete networks in the default project.
+
+Conversely, if a client's permissions are managed via {ref}`fine-grained-authorization`, resources may be inherited from the default project but access to those resources is not automatically granted.
+```
+
 (projects-confined)=
 ## Confined projects in a multi-user environment
 

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -113,7 +113,19 @@ func (e *embeddedOpenFGA) load(ctx context.Context, identityCache *identity.Cach
 }
 
 // CheckPermission checks whether the user who sent the request has the given entitlement on the given entity using the
-// embedded OpenFGA server.
+// embedded OpenFGA server. A http.StatusNotFound error is returned when the entity does not exist, or when the entity
+// exists but the caller does not have permission to view it. A http.StatusForbidden error is returned if the caller has
+// permission to view the entity, but does not have the given entitlement.
+//
+// Note: Internally we call (openfgav1.OpenFGAServiceServer).Check to implement this. Since our implementation of
+// storage.OpenFGADatastore pulls data directly from the database, we need to be careful about the handling of entities
+// contained within projects that do not have features enabled. For example, if the given entity URL is for a network in
+// project "foo", but project "foo" does not have `features.networks=true`, then we must not use project "foo" in our
+// authorization check because this network does not exist in the database. We will always expect the given entity URL
+// to contain the request project name, but we expect that request.CtxEffectiveProjectName will be set in the request
+// context. The driver will rewrite the project name with the effective project name for the purpose of the authorization
+// check, but will not automatically allow "punching through" to the effective (default) project. An administrator can
+// allow specific permissions against those entities.
 func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.URL, entitlement auth.Entitlement) error {
 	logCtx := logger.Ctx{"entity_url": entityURL.String(), "entitlement": entitlement}
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -278,7 +290,12 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 	return nil
 }
 
-// GetPermissionChecker returns a PermissionChecker using the embedded OpenFGA server.
+// GetPermissionChecker returns an auth.PermissionChecker using the embedded OpenFGA server.
+//
+// Note: As with CheckPermission, we need to be careful about the usage of this function for entity types that may not
+// be enabled within a project. For these cases request.CtxEffectiveProjectName must be set in the given context before
+// this function is called. The returned auth.PermissionChecker will expect entity URLs to contain the request URL. These
+// will be re-written to contain the effective project if set, so that they correspond to the list returned by OpenFGA.
 func (e *embeddedOpenFGA) GetPermissionChecker(ctx context.Context, entitlement auth.Entitlement, entityType entity.Type) (auth.PermissionChecker, error) {
 	logCtx := logger.Ctx{"entity_type": entityType, "entitlement": entitlement}
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -133,7 +133,7 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 
 	// Untrusted requests are denied.
 	if !auth.IsTrusted(ctx) {
-		return api.StatusErrorf(http.StatusForbidden, http.StatusText(http.StatusForbidden))
+		return api.StatusErrorf(http.StatusForbidden, "%s", http.StatusText(http.StatusForbidden))
 	}
 
 	isRoot, err := auth.IsServerAdmin(ctx, e.identityCache)
@@ -284,7 +284,7 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 			l.Info("Access denied", logger.Ctx{"http_code": responseCode})
 		}
 
-		return api.StatusErrorf(responseCode, http.StatusText(responseCode))
+		return api.StatusErrorf(responseCode, "%s", http.StatusText(responseCode))
 	}
 
 	return nil

--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/identity"
-	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
@@ -148,8 +147,6 @@ func (t *tls) GetPermissionChecker(ctx context.Context, entitlement auth.Entitle
 		return allowFunc(false), nil
 	}
 
-	effectiveProject, _ := request.GetCtxValue[string](ctx, request.CtxEffectiveProjectName)
-
 	// Filter objects by project.
 	return func(entityURL *api.URL) bool {
 		eType, project, _, _, err := entity.ParseURL(entityURL.URL)
@@ -162,11 +159,6 @@ func (t *tls) GetPermissionChecker(ctx context.Context, entitlement auth.Entitle
 		if eType != entityType {
 			logger.Warn("Permission checker received URL with unexpected entity type", logger.Ctx{"expected": entityType, "actual": eType, "entity_url": entityURL})
 			return false
-		}
-
-		// If an effective project has been set in the request context. We expect all entities to be in that project.
-		if effectiveProject != "" {
-			return project == effectiveProject
 		}
 
 		// Otherwise, check if the project is in the list of allowed projects for the entity.

--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -43,7 +43,7 @@ func (t *tls) load(ctx context.Context, identityCache *identity.Cache, opts Opts
 func (t *tls) CheckPermission(ctx context.Context, entityURL *api.URL, entitlement auth.Entitlement) error {
 	// Untrusted requests are denied.
 	if !auth.IsTrusted(ctx) {
-		return api.StatusErrorf(http.StatusForbidden, http.StatusText(http.StatusForbidden))
+		return api.StatusErrorf(http.StatusForbidden, "%s", http.StatusText(http.StatusForbidden))
 	}
 
 	isRoot, err := auth.IsServerAdmin(ctx, t.identities)

--- a/lxd/auth/types.go
+++ b/lxd/auth/types.go
@@ -34,9 +34,20 @@ type PermissionChecker func(entityURL *api.URL) bool
 
 // Authorizer is the primary external API for this package.
 type Authorizer interface {
+	// Driver returns the driver name.
 	Driver() string
 
+	// CheckPermission checks if the caller has the given entitlement on the entity found at the given URL.
+	//
+	// Note: When a project does not have a feature enabled, the given URL should contain the request project, and the
+	// effective project for the entity should be set in the given context as request.CtxEffectiveProjectName.
 	CheckPermission(ctx context.Context, entityURL *api.URL, entitlement Entitlement) error
+
+	// GetPermissionChecker returns a PermissionChecker for a particular entity.Type.
+	//
+	// Note: As with CheckPermission, arguments to the returned PermissionChecker should contain the request project for
+	// the entity. The effective project for the entity must be set in the request context as request.CtxEffectiveProjectName
+	// *before* the call to GetPermissionChecker.
 	GetPermissionChecker(ctx context.Context, entitlement Entitlement, entityType entity.Type) (PermissionChecker, error)
 }
 

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -61,6 +61,14 @@ func eventsSocket(s *state.State, r *http.Request, w http.ResponseWriter) error 
 		}
 	}
 
+	// Notes on authorization for events:
+	// - Checks are currently performed at the project level. Fine-grained auth uses `can_view_events` on the project,
+	//   TLS auth checks if a restricted identity has access to the project against which the event is defined.
+	// - If project "foo" does not have a particular feature enabled, say 'features.networks', if a network is updated
+	//   via project "foo", no events will be emitted in project "foo" relating to the network. They will only be emitted
+	//   in project "default". In order to get all related events, TLS users must be granted access to the default project,
+	//   fine-grained users can be granted `can_view_events` on the default project. Both must call the events API with
+	//   `all-projects=true`.
 	var projectPermissionFunc auth.PermissionChecker
 	if projectName != "" {
 		err := s.Authorizer.CheckPermission(r.Context(), entity.ProjectURL(projectName), auth.EntitlementCanViewEvents)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -66,46 +66,147 @@ var imagesCmd = APIEndpoint{
 var imageCmd = APIEndpoint{
 	Path: "images/{fingerprint}",
 
-	Delete: APIEndpointAction{Handler: imageDelete, AccessHandler: allowPermission(entity.TypeImage, auth.EntitlementCanDelete, "fingerprint")},
+	Delete: APIEndpointAction{Handler: imageDelete, AccessHandler: imageAccessHandler(auth.EntitlementCanDelete)},
 	Get:    APIEndpointAction{Handler: imageGet, AllowUntrusted: true},
-	Patch:  APIEndpointAction{Handler: imagePatch, AccessHandler: allowPermission(entity.TypeImage, auth.EntitlementCanEdit, "fingerprint")},
-	Put:    APIEndpointAction{Handler: imagePut, AccessHandler: allowPermission(entity.TypeImage, auth.EntitlementCanEdit, "fingerprint")},
+	Patch:  APIEndpointAction{Handler: imagePatch, AccessHandler: imageAccessHandler(auth.EntitlementCanEdit)},
+	Put:    APIEndpointAction{Handler: imagePut, AccessHandler: imageAccessHandler(auth.EntitlementCanEdit)},
 }
 
 var imageExportCmd = APIEndpoint{
 	Path: "images/{fingerprint}/export",
 
 	Get:  APIEndpointAction{Handler: imageExport, AllowUntrusted: true},
-	Post: APIEndpointAction{Handler: imageExportPost, AccessHandler: allowPermission(entity.TypeImage, auth.EntitlementCanEdit, "fingerprint")},
+	Post: APIEndpointAction{Handler: imageExportPost, AccessHandler: imageAccessHandler(auth.EntitlementCanEdit)},
 }
 
 var imageSecretCmd = APIEndpoint{
 	Path: "images/{fingerprint}/secret",
 
-	Post: APIEndpointAction{Handler: imageSecret, AccessHandler: allowPermission(entity.TypeImage, auth.EntitlementCanEdit, "fingerprint")},
+	Post: APIEndpointAction{Handler: imageSecret, AccessHandler: imageAccessHandler(auth.EntitlementCanEdit)},
 }
 
 var imageRefreshCmd = APIEndpoint{
 	Path: "images/{fingerprint}/refresh",
 
-	Post: APIEndpointAction{Handler: imageRefresh, AccessHandler: allowPermission(entity.TypeImage, auth.EntitlementCanEdit, "fingerprint")},
+	Post: APIEndpointAction{Handler: imageRefresh, AccessHandler: imageAccessHandler(auth.EntitlementCanEdit)},
 }
 
 var imageAliasesCmd = APIEndpoint{
 	Path: "images/aliases",
 
-	Get:  APIEndpointAction{Handler: imageAliasesGet, AccessHandler: allowAuthenticated},
+	Get:  APIEndpointAction{Handler: imageAliasesGet, AccessHandler: allowProjectResourceList},
 	Post: APIEndpointAction{Handler: imageAliasesPost, AccessHandler: allowPermission(entity.TypeProject, auth.EntitlementCanCreateImageAliases)},
 }
 
 var imageAliasCmd = APIEndpoint{
 	Path: "images/aliases/{name:.*}",
 
-	Delete: APIEndpointAction{Handler: imageAliasDelete, AccessHandler: allowPermission(entity.TypeImageAlias, auth.EntitlementCanDelete, "name")},
+	Delete: APIEndpointAction{Handler: imageAliasDelete, AccessHandler: imageAliasAccessHandler(auth.EntitlementCanDelete)},
 	Get:    APIEndpointAction{Handler: imageAliasGet, AllowUntrusted: true},
-	Patch:  APIEndpointAction{Handler: imageAliasPatch, AccessHandler: allowPermission(entity.TypeImageAlias, auth.EntitlementCanEdit, "name")},
-	Post:   APIEndpointAction{Handler: imageAliasPost, AccessHandler: allowPermission(entity.TypeImageAlias, auth.EntitlementCanEdit, "name")},
-	Put:    APIEndpointAction{Handler: imageAliasPut, AccessHandler: allowPermission(entity.TypeImageAlias, auth.EntitlementCanEdit, "name")},
+	Patch:  APIEndpointAction{Handler: imageAliasPatch, AccessHandler: imageAliasAccessHandler(auth.EntitlementCanEdit)},
+	Post:   APIEndpointAction{Handler: imageAliasPost, AccessHandler: imageAliasAccessHandler(auth.EntitlementCanEdit)},
+	Put:    APIEndpointAction{Handler: imageAliasPut, AccessHandler: imageAliasAccessHandler(auth.EntitlementCanEdit)},
+}
+
+const ctxImageDetails request.CtxKey = "image-details"
+
+// imageDetails contains fields that are determined prior to the access check. This is set in the request context when
+// addImageDetailsToRequestContext is called.
+type imageDetails struct {
+	imageFingerprintPrefix string
+	imageID                int
+	image                  api.Image
+}
+
+// addImageDetailsToRequestContext sets request.CtxEffectiveProjectName (string) and ctxImageDetails (imageDetails)
+// in the request context.
+func addImageDetailsToRequestContext(s *state.State, r *http.Request) error {
+	imageFingerprintPrefix, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
+	if err != nil {
+		return err
+	}
+
+	requestProjectName := request.ProjectParam(r)
+	effectiveProjectName := requestProjectName
+	var imageID int
+	var image *api.Image
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), requestProjectName)
+		if err != nil {
+			return err
+		}
+
+		imageID, image, err = tx.GetImageByFingerprintPrefix(ctx, imageFingerprintPrefix, dbCluster.ImageFilter{Project: &requestProjectName})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to check project %q image feature: %w", requestProjectName, err)
+	}
+
+	request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
+	request.SetCtxValue(r, ctxImageDetails, imageDetails{
+		imageFingerprintPrefix: imageFingerprintPrefix,
+		imageID:                imageID,
+		image:                  *image,
+	})
+
+	return nil
+}
+
+func imageAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
+	return func(d *Daemon, r *http.Request) response.Response {
+		s := d.State()
+		err := addImageDetailsToRequestContext(s, r)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		details, err := request.GetCtxValue[imageDetails](r.Context(), ctxImageDetails)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		err = s.Authorizer.CheckPermission(r.Context(), entity.ImageURL(request.ProjectParam(r), details.image.Fingerprint), entitlement)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		return response.EmptySyncResponse
+	}
+}
+
+func imageAliasAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
+	return func(d *Daemon, r *http.Request) response.Response {
+		imageAliasName, err := url.PathUnescape(mux.Vars(r)["name"])
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		requestProjectName := request.ProjectParam(r)
+		var effectiveProjectName string
+		s := d.State()
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), requestProjectName)
+			return err
+		})
+		if err != nil && api.StatusErrorCheck(err, http.StatusNotFound) {
+			return response.NotFound(nil)
+		} else if err != nil {
+			return response.SmartError(err)
+		}
+
+		request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
+		err = s.Authorizer.CheckPermission(r.Context(), entity.ImageAliasURL(requestProjectName, imageAliasName), entitlement)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		return response.EmptySyncResponse
+	}
 }
 
 /*
@@ -1615,16 +1716,9 @@ func imagesGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 	var effectiveProjectName string
 	err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		hasImages, err := dbCluster.ProjectHasImages(ctx, tx.Tx(), projectName)
-		if err != nil {
-			return err
-		}
-
-		if !hasImages {
-			effectiveProjectName = api.ProjectDefaultName
-		}
-
-		return nil
+		var err error
+		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
+		return err
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -2655,21 +2749,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 
 	projectName := request.ProjectParam(r)
 
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	var imgID int
-	var imgInfo *api.Image
-
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		// Use the fingerprint we received in a LIKE query and use the full
-		// fingerprint we receive from the database in all further queries.
-		imgID, imgInfo, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
-
-		return err
-	})
+	details, err := request.GetCtxValue[imageDetails](r.Context(), ctxImageDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2677,7 +2757,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 	do := func(op *operations.Operation) error {
 		// Lock this operation to ensure that concurrent image operations don't conflict.
 		// Other operations will wait for this one to finish.
-		unlock, err := imageOperationLock(imgInfo.Fingerprint)
+		unlock, err := imageOperationLock(details.image.Fingerprint)
 		if err != nil {
 			return err
 		}
@@ -2689,7 +2769,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Check image still exists and another request hasn't removed it since we resolved the image
 			// fingerprint above.
-			exist, err = tx.ImageExists(ctx, projectName, imgInfo.Fingerprint)
+			exist, err = tx.ImageExists(ctx, projectName, details.image.Fingerprint)
 
 			return err
 		})
@@ -2709,13 +2789,13 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 				// referenced by other projects. In that case we don't want to
 				// physically delete it just yet, but just to remove the
 				// relevant database entry.
-				referenced, err = tx.ImageIsReferencedByOtherProjects(ctx, projectName, imgInfo.Fingerprint)
+				referenced, err = tx.ImageIsReferencedByOtherProjects(ctx, projectName, details.image.Fingerprint)
 				if err != nil {
 					return err
 				}
 
 				if referenced {
-					err = tx.DeleteImage(ctx, imgID)
+					err = tx.DeleteImage(ctx, details.imageID)
 					if err != nil {
 						return fmt.Errorf("Error deleting image info from the database: %w", err)
 					}
@@ -2738,7 +2818,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 			}
 
 			err = notifier(func(client lxd.InstanceServer) error {
-				op, err := client.UseProject(projectName).DeleteImage(imgInfo.Fingerprint)
+				op, err := client.UseProject(projectName).DeleteImage(details.image.Fingerprint)
 				if err != nil {
 					return fmt.Errorf("Failed to request to delete image from peer node: %w", err)
 				}
@@ -2760,7 +2840,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Delete the pool volumes.
-			poolIDs, err = tx.GetPoolsWithImage(ctx, imgInfo.Fingerprint)
+			poolIDs, err = tx.GetPoolsWithImage(ctx, details.image.Fingerprint)
 			if err != nil {
 				return err
 			}
@@ -2779,14 +2859,14 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 		for _, poolName := range poolNames {
 			pool, err := storagePools.LoadByName(s, poolName)
 			if err != nil {
-				return fmt.Errorf("Error loading storage pool %q to delete image %q: %w", poolName, imgInfo.Fingerprint, err)
+				return fmt.Errorf("Error loading storage pool %q to delete image %q: %w", poolName, details.image.Fingerprint, err)
 			}
 
 			// Only perform the deletion of remote volumes on the server handling the request.
 			if !isClusterNotification(r) || !pool.Driver().Info().Remote {
-				err = pool.DeleteImage(imgInfo.Fingerprint, op)
+				err = pool.DeleteImage(details.image.Fingerprint, op)
 				if err != nil {
-					return fmt.Errorf("Error deleting image %q from storage pool %q: %w", imgInfo.Fingerprint, pool.Name(), err)
+					return fmt.Errorf("Error deleting image %q from storage pool %q: %w", details.image.Fingerprint, pool.Name(), err)
 				}
 			}
 		}
@@ -2794,7 +2874,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 		// Remove the database entry.
 		if !isClusterNotification(r) {
 			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				return tx.DeleteImage(ctx, imgID)
+				return tx.DeleteImage(ctx, details.imageID)
 			})
 			if err != nil {
 				return fmt.Errorf("Error deleting image info from the database: %w", err)
@@ -2802,15 +2882,15 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Remove main image file from disk.
-		imageDeleteFromDisk(imgInfo.Fingerprint)
+		imageDeleteFromDisk(details.image.Fingerprint)
 
-		s.Events.SendLifecycle(projectName, lifecycle.ImageDeleted.Event(imgInfo.Fingerprint, projectName, op.Requestor(), nil))
+		s.Events.SendLifecycle(projectName, lifecycle.ImageDeleted.Event(details.image.Fingerprint, projectName, op.Requestor(), nil))
 
 		return nil
 	}
 
 	resources := map[string][]api.URL{}
-	resources["images"] = []api.URL{*api.NewURL().Path(version.APIVersion, "images", imgInfo.Fingerprint)}
+	resources["images"] = []api.URL{*api.NewURL().Path(version.APIVersion, "images", details.image.Fingerprint)}
 
 	op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.ImageDelete, resources, nil, do, nil, nil, r)
 	if err != nil {
@@ -3001,7 +3081,13 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 	// Get the image. We need to do this before the permission check because the URL in the permission check will not
 	// work with partial fingerprints.
 	var info *api.Image
+	effectiveProjectName := projectName
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return err
+		}
+
 		info, err = doImageGet(ctx, tx, projectName, fingerprint, publicOnly)
 		if err != nil {
 			return err
@@ -3040,6 +3126,7 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 			userCanViewImage = true
 		} else {
 			// Otherwise perform an access check with the full image fingerprint.
+			request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
 			err = s.Authorizer.CheckPermission(r.Context(), entity.ImageURL(projectName, info.Fingerprint), auth.EntitlementCanView)
 			if err != nil && !auth.IsDeniedError(err) {
 				return response.SmartError(err)
@@ -3097,25 +3184,13 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 
 	// Get current value
 	projectName := request.ProjectParam(r)
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	var id int
-	var info *api.Image
-
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		id, info, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
-
-		return err
-	})
+	details, err := request.GetCtxValue[imageDetails](r.Context(), ctxImageDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	// Validate ETag
-	etag := []any{info.Public, info.AutoUpdate, info.Properties}
+	etag := []any{details.image.Public, details.image.AutoUpdate, details.image.Properties}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)
@@ -3129,7 +3204,7 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 
 	// Get ExpiresAt
 	if !req.ExpiresAt.IsZero() {
-		info.ExpiresAt = req.ExpiresAt
+		details.image.ExpiresAt = req.ExpiresAt
 	}
 
 	// Get profile IDs
@@ -3151,7 +3226,7 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 			profileIDs[i] = profileID
 		}
 
-		return tx.UpdateImage(ctx, id, info.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, req.Properties, projectName, profileIDs)
+		return tx.UpdateImage(ctx, details.imageID, details.image.Filename, details.image.Size, req.Public, req.AutoUpdate, details.image.Architecture, details.image.CreatedAt, details.image.ExpiresAt, req.Properties, projectName, profileIDs)
 	})
 	if err != nil {
 		if response.IsNotFoundError(err) {
@@ -3162,7 +3237,7 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	s.Events.SendLifecycle(projectName, lifecycle.ImageUpdated.Event(info.Fingerprint, projectName, requestor, nil))
+	s.Events.SendLifecycle(projectName, lifecycle.ImageUpdated.Event(details.image.Fingerprint, projectName, requestor, nil))
 
 	return response.EmptySyncResponse
 }
@@ -3206,25 +3281,13 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 
 	// Get current value
 	projectName := request.ProjectParam(r)
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	var id int
-	var info *api.Image
-
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		id, info, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
-
-		return err
-	})
+	details, err := request.GetCtxValue[imageDetails](r.Context(), ctxImageDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	// Validate ETag
-	etag := []any{info.Public, info.AutoUpdate, info.Properties}
+	etag := []any{details.image.Public, details.image.AutoUpdate, details.image.Properties}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)
@@ -3253,37 +3316,38 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 	// Get AutoUpdate
 	autoUpdate, err := reqRaw.GetBool("auto_update")
 	if err == nil {
-		info.AutoUpdate = autoUpdate
+		details.image.AutoUpdate = autoUpdate
 	}
 
 	// Get Public
 	public, err := reqRaw.GetBool("public")
 	if err == nil {
-		info.Public = public
+		details.image.Public = public
 	}
 
 	// Get Properties
 	_, ok := reqRaw["properties"]
 	if ok {
 		properties := req.Properties
-		for k, v := range info.Properties {
+		for k, v := range details.image.Properties {
 			_, ok := req.Properties[k]
 			if !ok {
 				properties[k] = v
 			}
 		}
-		info.Properties = properties
+
+		details.image.Properties = properties
 	}
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return tx.UpdateImage(ctx, id, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, "", nil)
+		return tx.UpdateImage(ctx, details.imageID, details.image.Filename, details.image.Size, details.image.Public, details.image.AutoUpdate, details.image.Architecture, details.image.CreatedAt, details.image.ExpiresAt, details.image.Properties, "", nil)
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	requestor := request.CreateRequestor(r)
-	s.Events.SendLifecycle(projectName, lifecycle.ImageUpdated.Event(info.Fingerprint, projectName, requestor, nil))
+	s.Events.SendLifecycle(projectName, lifecycle.ImageUpdated.Event(details.image.Fingerprint, projectName, requestor, nil))
 
 	return response.EmptySyncResponse
 }
@@ -3468,16 +3532,9 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
 	var effectiveProjectName string
 	err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		projectHasImages, err := dbCluster.ProjectHasImages(ctx, tx.Tx(), projectName)
-		if err != nil {
-			return err
-		}
-
-		if !projectHasImages {
-			effectiveProjectName = api.ProjectDefaultName
-		}
-
-		return nil
+		var err error
+		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
+		return err
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -3623,10 +3680,16 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
+	var effectiveProjectName string
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
+		return err
+	})
 
 	// Set `userCanViewImageAlias` to true only when the caller is authenticated and can view the alias.
 	// We don't abort the request if this is false because the image alias may be for a public image.
 	var userCanViewImageAlias bool
+	request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
 	err = s.Authorizer.CheckPermission(r.Context(), entity.ImageAliasURL(projectName, name), auth.EntitlementCanView)
 	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
@@ -3635,7 +3698,7 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	var alias api.ImageAliasesEntry
-	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// If `userCanViewImageAlias` is false, the query will be restricted to public images only.
 		_, alias, err = tx.GetImageAlias(ctx, projectName, name, userCanViewImageAlias)
 
@@ -4054,7 +4117,13 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	// Get the image. We need to do this before the permission check because the URL in the permission check will not
 	// work with partial fingerprints.
 	var imgInfo *api.Image
+	effectiveProjectName := projectName
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
+		if err != nil {
+			return err
+		}
+
 		filter := dbCluster.ImageFilter{Project: &projectName}
 		if publicOnly {
 			filter.Public = &publicOnly
@@ -4107,6 +4176,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 			userCanViewImage = true
 		} else {
 			// Otherwise perform an access check with the full image fingerprint.
+			request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
 			err = s.Authorizer.CheckPermission(r.Context(), entity.ImageURL(projectName, imgInfo.Fingerprint), auth.EntitlementCanView)
 			if err != nil && !auth.IsDeniedError(err) {
 				return response.SmartError(err)
@@ -4227,17 +4297,7 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		// Check if the image exists
-		_, _, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
-
-		return err
-	})
+	details, err := request.GetCtxValue[imageDetails](r.Context(), ctxImageDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -4268,8 +4328,8 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 
 	run := func(op *operations.Operation) error {
 		createArgs := &lxd.ImageCreateArgs{}
-		imageMetaPath := shared.VarPath("images", fingerprint)
-		imageRootfsPath := shared.VarPath("images", fingerprint+".rootfs")
+		imageMetaPath := shared.VarPath("images", details.imageFingerprintPrefix)
+		imageRootfsPath := shared.VarPath("images", details.imageFingerprintPrefix+".rootfs")
 
 		metaFile, err := os.Open(imageMetaPath)
 		if err != nil {
@@ -4296,7 +4356,7 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 		image := api.ImagesPost{
 			Filename: createArgs.MetaName,
 			Source: &api.ImagesPostSource{
-				Fingerprint: fingerprint,
+				Fingerprint: details.imageFingerprintPrefix,
 				Secret:      req.Secret,
 				Mode:        "push",
 			},
@@ -4335,7 +4395,7 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed operation %q: %q", opWaitAPI.Status, opWaitAPI.Err)
 		}
 
-		s.Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(fingerprint, projectName, op.Requestor(), logger.Ctx{"target": req.Target}))
+		s.Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(details.imageFingerprintPrefix, projectName, op.Requestor(), logger.Ctx{"target": req.Target}))
 
 		return nil
 	}
@@ -4376,23 +4436,12 @@ func imageSecret(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
+	details, err := request.GetCtxValue[imageDetails](r.Context(), ctxImageDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	var imgInfo *api.Image
-
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		_, imgInfo, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
-
-		return err
-	})
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	return createTokenResponse(s, r, projectName, imgInfo.Fingerprint, nil)
+	return createTokenResponse(s, r, projectName, details.image.Fingerprint, nil)
 }
 
 func imageImportFromNode(imagesDir string, client lxd.InstanceServer, fingerprint string) error {
@@ -4495,19 +4544,7 @@ func imageRefresh(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	projectName := request.ProjectParam(r)
-	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	var imageID int
-	var imageInfo *api.Image
-
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		imageID, imageInfo, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
-
-		return err
-	})
+	details, err := request.GetCtxValue[imageDetails](r.Context(), ctxImageDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -4517,22 +4554,22 @@ func imageRefresh(d *Daemon, r *http.Request) response.Response {
 		var nodes []string
 
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			nodes, err = tx.GetNodesWithImageAndAutoUpdate(ctx, fingerprint, true)
+			nodes, err = tx.GetNodesWithImageAndAutoUpdate(ctx, details.imageFingerprintPrefix, true)
 
 			return err
 		})
 		if err != nil {
-			return fmt.Errorf("Error getting cluster members for refreshing image %q in project %q: %w", fingerprint, projectName, err)
+			return fmt.Errorf("Error getting cluster members for refreshing image %q in project %q: %w", details.imageFingerprintPrefix, projectName, err)
 		}
 
-		newImage, err := autoUpdateImage(s.ShutdownCtx, s, op, imageID, imageInfo, projectName, true)
+		newImage, err := autoUpdateImage(s.ShutdownCtx, s, op, details.imageID, &details.image, projectName, true)
 		if err != nil {
-			return fmt.Errorf("Failed to update image %q in project %q: %w", fingerprint, projectName, err)
+			return fmt.Errorf("Failed to update image %q in project %q: %w", details.imageFingerprintPrefix, projectName, err)
 		}
 
 		if newImage != nil {
 			if len(nodes) > 1 {
-				err := distributeImage(s.ShutdownCtx, s, nodes, fingerprint, newImage)
+				err := distributeImage(s.ShutdownCtx, s, nodes, details.imageFingerprintPrefix, newImage)
 				if err != nil {
 					return fmt.Errorf("Failed to distribute new image %q: %w", newImage.Fingerprint, err)
 				}
@@ -4540,10 +4577,10 @@ func imageRefresh(d *Daemon, r *http.Request) response.Response {
 
 			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				// Remove the database entry for the image after distributing to cluster members.
-				return tx.DeleteImage(ctx, imageID)
+				return tx.DeleteImage(ctx, details.imageID)
 			})
 			if err != nil {
-				logger.Error("Error deleting old image from database", logger.Ctx{"err": err, "fingerprint": fingerprint, "ID": imageID})
+				logger.Error("Error deleting old image from database", logger.Ctx{"err": err, "fingerprint": details.imageFingerprintPrefix, "ID": details.imageID})
 			}
 		}
 

--- a/lxd/network_allocations.go
+++ b/lxd/network_allocations.go
@@ -176,7 +176,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 			}
 
 			leases, err := n.Leases(projectName, clusterRequest.ClientTypeNormal)
-			if err != nil && !errors.Is(network.ErrNotImplemented, err) {
+			if err != nil && !errors.Is(err, network.ErrNotImplemented) {
 				return response.SmartError(fmt.Errorf("Failed getting leases for network %q in project %q: %w", networkName, projectName, err))
 			}
 

--- a/lxd/network_allocations.go
+++ b/lxd/network_allocations.go
@@ -76,18 +76,20 @@ var networkAllocationsCmd = APIEndpoint{
 func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, request.ProjectParam(r))
+	requestProjectName := request.ProjectParam(r)
+	effectiveProjectName, _, err := project.NetworkProject(d.State().DB.Cluster, requestProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
+	request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
 	allProjects := shared.IsTrue(request.QueryParam(r, "all-projects"))
 
 	var projectNames []string
 	err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Figure out the projects to retrieve.
 		if !allProjects {
-			projectNames = []string{projectName}
+			projectNames = []string{effectiveProjectName}
 		} else {
 			// Get all project names if no specific project requested.
 			projectNames, err = dbCluster.GetProjectNames(ctx, tx.Tx())
@@ -126,6 +128,13 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 
 	// Then, get all the networks, their network forwards and their network load balancers.
 	for _, projectName := range projectNames {
+		// The auth.PermissionChecker expects the url to contain the request project (not the effective project).
+		// So when getting networks in a single project, ensure we use the request project name.
+		authCheckProjectName := projectName
+		if !allProjects {
+			authCheckProjectName = requestProjectName
+		}
+
 		var networkNames []string
 
 		err := d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -141,7 +150,7 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 
 		// Get all the networks, their attached instances, their network forwards and their network load balancers.
 		for _, networkName := range networkNames {
-			if !userHasPermission(entity.NetworkURL(projectName, networkName)) {
+			if !userHasPermission(entity.NetworkURL(authCheckProjectName, networkName)) {
 				continue
 			}
 

--- a/lxd/network_forwards.go
+++ b/lxd/network_forwards.go
@@ -33,7 +33,7 @@ var networkForwardsCmd = APIEndpoint{
 var networkForwardCmd = APIEndpoint{
 	Path: "networks/{networkName}/forwards/{listenAddress}",
 
-	Delete: APIEndpointAction{Handler: networkForwardDelete, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanDelete, "networkName")},
+	Delete: APIEndpointAction{Handler: networkForwardDelete, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanEdit, "networkName")},
 	Get:    APIEndpointAction{Handler: networkForwardGet, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanView, "networkName")},
 	Put:    APIEndpointAction{Handler: networkForwardPut, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanEdit, "networkName")},
 	Patch:  APIEndpointAction{Handler: networkForwardPut, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanEdit, "networkName")},

--- a/lxd/network_forwards.go
+++ b/lxd/network_forwards.go
@@ -19,24 +19,23 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/version"
 )
 
 var networkForwardsCmd = APIEndpoint{
 	Path: "networks/{networkName}/forwards",
 
-	Get:  APIEndpointAction{Handler: networkForwardsGet, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanView, "networkName")},
-	Post: APIEndpointAction{Handler: networkForwardsPost, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanEdit, "networkName")},
+	Get:  APIEndpointAction{Handler: networkForwardsGet, AccessHandler: networkAccessHandler(auth.EntitlementCanView)},
+	Post: APIEndpointAction{Handler: networkForwardsPost, AccessHandler: networkAccessHandler(auth.EntitlementCanEdit)},
 }
 
 var networkForwardCmd = APIEndpoint{
 	Path: "networks/{networkName}/forwards/{listenAddress}",
 
-	Delete: APIEndpointAction{Handler: networkForwardDelete, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanEdit, "networkName")},
-	Get:    APIEndpointAction{Handler: networkForwardGet, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanView, "networkName")},
-	Put:    APIEndpointAction{Handler: networkForwardPut, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanEdit, "networkName")},
-	Patch:  APIEndpointAction{Handler: networkForwardPut, AccessHandler: allowPermission(entity.TypeNetwork, auth.EntitlementCanEdit, "networkName")},
+	Delete: APIEndpointAction{Handler: networkForwardDelete, AccessHandler: networkAccessHandler(auth.EntitlementCanEdit)},
+	Get:    APIEndpointAction{Handler: networkForwardGet, AccessHandler: networkAccessHandler(auth.EntitlementCanView)},
+	Put:    APIEndpointAction{Handler: networkForwardPut, AccessHandler: networkAccessHandler(auth.EntitlementCanEdit)},
+	Patch:  APIEndpointAction{Handler: networkForwardPut, AccessHandler: networkAccessHandler(auth.EntitlementCanEdit)},
 }
 
 // API endpoints
@@ -136,23 +135,23 @@ var networkForwardCmd = APIEndpoint{
 func networkForwardsGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, request.ProjectParam(r))
+	effectiveProjectName, err := request.GetCtxValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])
+	details, err := request.GetCtxValue[networkDetails](r.Context(), ctxNetworkDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(s, projectName, networkName)
+	n, err := network.LoadByName(s, effectiveProjectName, details.networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
 
 	// Check if project allows access to network.
-	if !project.NetworkAllowed(reqProject.Config, networkName, n.IsManaged()) {
+	if !project.NetworkAllowed(details.requestProject.Config, details.networkName, n.IsManaged()) {
 		return response.SmartError(api.StatusErrorf(http.StatusNotFound, "Network not found"))
 	}
 
@@ -241,7 +240,12 @@ func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, request.ProjectParam(r))
+	effectiveProjectName, err := request.GetCtxValue[string](r.Context(), request.CtxEffectiveProjectName)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	details, err := request.GetCtxValue[networkDetails](r.Context(), ctxNetworkDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -255,18 +259,13 @@ func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
 
 	req.Normalise() // So we handle the request in normalised/canonical form.
 
-	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	n, err := network.LoadByName(s, projectName, networkName)
+	n, err := network.LoadByName(s, effectiveProjectName, details.networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
 
 	// Check if project allows access to network.
-	if !project.NetworkAllowed(reqProject.Config, networkName, n.IsManaged()) {
+	if !project.NetworkAllowed(details.requestProject.Config, details.networkName, n.IsManaged()) {
 		return response.SmartError(api.StatusErrorf(http.StatusNotFound, "Network not found"))
 	}
 
@@ -282,7 +281,7 @@ func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	lc := lifecycle.NetworkForwardCreated.Event(n, listenAddress.String(), request.CreateRequestor(r), nil)
-	s.Events.SendLifecycle(projectName, lc)
+	s.Events.SendLifecycle(effectiveProjectName, lc)
 
 	return response.SyncResponseLocation(true, nil, lc.Source)
 }
@@ -319,23 +318,23 @@ func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, request.ProjectParam(r))
+	effectiveProjectName, err := request.GetCtxValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])
+	details, err := request.GetCtxValue[networkDetails](r.Context(), ctxNetworkDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(s, projectName, networkName)
+	n, err := network.LoadByName(s, effectiveProjectName, details.networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
 
 	// Check if project allows access to network.
-	if !project.NetworkAllowed(reqProject.Config, networkName, n.IsManaged()) {
+	if !project.NetworkAllowed(details.requestProject.Config, details.networkName, n.IsManaged()) {
 		return response.SmartError(api.StatusErrorf(http.StatusNotFound, "Network not found"))
 	}
 
@@ -355,7 +354,7 @@ func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed deleting forward: %w", err))
 	}
 
-	s.Events.SendLifecycle(projectName, lifecycle.NetworkForwardDeleted.Event(n, listenAddress, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkForwardDeleted.Event(n, listenAddress, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }
@@ -408,23 +407,23 @@ func networkForwardGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, request.ProjectParam(r))
+	effectiveProjectName, err := request.GetCtxValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])
+	details, err := request.GetCtxValue[networkDetails](r.Context(), ctxNetworkDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(s, projectName, networkName)
+	n, err := network.LoadByName(s, effectiveProjectName, details.networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
 
 	// Check if project allows access to network.
-	if !project.NetworkAllowed(reqProject.Config, networkName, n.IsManaged()) {
+	if !project.NetworkAllowed(details.requestProject.Config, details.networkName, n.IsManaged()) {
 		return response.SmartError(api.StatusErrorf(http.StatusNotFound, "Network not found"))
 	}
 
@@ -531,23 +530,23 @@ func networkForwardPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, reqProject, err := project.NetworkProject(s.DB.Cluster, request.ProjectParam(r))
+	effectiveProjectName, err := request.GetCtxValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	networkName, err := url.PathUnescape(mux.Vars(r)["networkName"])
+	details, err := request.GetCtxValue[networkDetails](r.Context(), ctxNetworkDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	n, err := network.LoadByName(s, projectName, networkName)
+	n, err := network.LoadByName(s, effectiveProjectName, details.networkName)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
 	}
 
 	// Check if project allows access to network.
-	if !project.NetworkAllowed(reqProject.Config, networkName, n.IsManaged()) {
+	if !project.NetworkAllowed(details.requestProject.Config, details.networkName, n.IsManaged()) {
 		return response.SmartError(api.StatusErrorf(http.StatusNotFound, "Network not found"))
 	}
 
@@ -607,7 +606,7 @@ func networkForwardPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed updating forward: %w", err))
 	}
 
-	s.Events.SendLifecycle(projectName, lifecycle.NetworkForwardUpdated.Event(n, listenAddress, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkForwardUpdated.Event(n, listenAddress, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -17,6 +17,7 @@ import (
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
@@ -33,10 +34,67 @@ var networkZonesCmd = APIEndpoint{
 var networkZoneCmd = APIEndpoint{
 	Path: "network-zones/{zone}",
 
-	Delete: APIEndpointAction{Handler: networkZoneDelete, AccessHandler: allowPermission(entity.TypeNetworkZone, auth.EntitlementCanDelete, "zone")},
-	Get:    APIEndpointAction{Handler: networkZoneGet, AccessHandler: allowPermission(entity.TypeNetworkZone, auth.EntitlementCanView, "zone")},
-	Put:    APIEndpointAction{Handler: networkZonePut, AccessHandler: allowPermission(entity.TypeNetworkZone, auth.EntitlementCanEdit, "zone")},
-	Patch:  APIEndpointAction{Handler: networkZonePut, AccessHandler: allowPermission(entity.TypeNetworkZone, auth.EntitlementCanEdit, "zone")},
+	Delete: APIEndpointAction{Handler: networkZoneDelete, AccessHandler: networkZoneAccessHandler(auth.EntitlementCanDelete)},
+	Get:    APIEndpointAction{Handler: networkZoneGet, AccessHandler: networkZoneAccessHandler(auth.EntitlementCanView)},
+	Put:    APIEndpointAction{Handler: networkZonePut, AccessHandler: networkZoneAccessHandler(auth.EntitlementCanEdit)},
+	Patch:  APIEndpointAction{Handler: networkZonePut, AccessHandler: networkZoneAccessHandler(auth.EntitlementCanEdit)},
+}
+
+// ctxNetworkZoneDetails should be used only for getting/setting networkZoneDetails in the request context.
+const ctxNetworkZoneDetails request.CtxKey = "network-zone-details"
+
+// networkZoneDetails contains fields that are determined prior to the access check. This is set in the request context when
+// addNetworkZoneDetailsToRequestContext is called.
+type networkZoneDetails struct {
+	zoneName       string
+	requestProject api.Project
+}
+
+// addNetworkZoneDetailsToRequestContext sets request.CtxEffectiveProjectName (string) and ctxNetworkZoneDetails (networkZoneDetails)
+// in the request context.
+func addNetworkZoneDetailsToRequestContext(s *state.State, r *http.Request) error {
+	zoneName, err := url.PathUnescape(mux.Vars(r)["zone"])
+	if err != nil {
+		return err
+	}
+
+	requestProjectName := request.ProjectParam(r)
+	effectiveProjectName, requestProject, err := project.NetworkZoneProject(s.DB.Cluster, requestProjectName)
+	if err != nil {
+		return fmt.Errorf("Failed to check project %q network feature: %w", requestProjectName, err)
+	}
+
+	request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
+	request.SetCtxValue(r, ctxNetworkZoneDetails, networkZoneDetails{
+		zoneName:       zoneName,
+		requestProject: *requestProject,
+	})
+
+	return nil
+}
+
+// profileAccessHandler calls addNetworkZoneDetailsToRequestContext, then uses the details to perform an access check with
+// the given auth.Entitlement.
+func networkZoneAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
+	return func(d *Daemon, r *http.Request) response.Response {
+		s := d.State()
+		err := addNetworkZoneDetailsToRequestContext(s, r)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		details, err := request.GetCtxValue[networkZoneDetails](r.Context(), ctxNetworkZoneDetails)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		err = s.Authorizer.CheckPermission(r.Context(), entity.NetworkZoneURL(details.requestProject.Name, details.zoneName), entitlement)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		return response.EmptySyncResponse
+	}
 }
 
 // API endpoints.
@@ -288,17 +346,17 @@ func networkZonesPost(d *Daemon, r *http.Request) response.Response {
 func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	projectName, _, err := project.NetworkZoneProject(s.DB.Cluster, request.ProjectParam(r))
+	effectiveProjectName, err := request.GetCtxValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	zoneName, err := url.PathUnescape(mux.Vars(r)["zone"])
+	details, err := request.GetCtxValue[networkZoneDetails](r.Context(), ctxNetworkZoneDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	netzone, err := zone.LoadByNameAndProject(s, projectName, zoneName)
+	netzone, err := zone.LoadByNameAndProject(s, effectiveProjectName, details.zoneName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -308,7 +366,7 @@ func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	s.Events.SendLifecycle(projectName, lifecycle.NetworkZoneDeleted.Event(netzone, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkZoneDeleted.Event(netzone, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }
@@ -356,17 +414,17 @@ func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
 func networkZoneGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	projectName, _, err := project.NetworkZoneProject(s.DB.Cluster, request.ProjectParam(r))
+	effectiveProjectName, err := request.GetCtxValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	zoneName, err := url.PathUnescape(mux.Vars(r)["zone"])
+	details, err := request.GetCtxValue[networkZoneDetails](r.Context(), ctxNetworkZoneDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	netzone, err := zone.LoadByNameAndProject(s, projectName, zoneName)
+	netzone, err := zone.LoadByNameAndProject(s, effectiveProjectName, details.zoneName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -454,18 +512,18 @@ func networkZoneGet(d *Daemon, r *http.Request) response.Response {
 func networkZonePut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	projectName, _, err := project.NetworkZoneProject(s.DB.Cluster, request.ProjectParam(r))
+	effectiveProjectName, err := request.GetCtxValue[string](r.Context(), request.CtxEffectiveProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	zoneName, err := url.PathUnescape(mux.Vars(r)["zone"])
+	details, err := request.GetCtxValue[networkZoneDetails](r.Context(), ctxNetworkZoneDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	// Get the existing Network zone.
-	netzone, err := zone.LoadByNameAndProject(s, projectName, zoneName)
+	netzone, err := zone.LoadByNameAndProject(s, effectiveProjectName, details.zoneName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -502,7 +560,7 @@ func networkZonePut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	s.Events.SendLifecycle(projectName, lifecycle.NetworkZoneUpdated.Event(netzone, request.CreateRequestor(r), nil))
+	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkZoneUpdated.Event(netzone, request.CreateRequestor(r), nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -203,7 +203,8 @@ func profileAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.
 func profilesGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	p, err := project.ProfileProject(s.DB.Cluster, request.ProjectParam(r))
+	requestProjectName := request.ProjectParam(r)
+	p, err := project.ProfileProject(s.DB.Cluster, requestProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -231,7 +232,7 @@ func profilesGet(d *Daemon, r *http.Request) response.Response {
 		if recursion {
 			apiProfiles = make([]*api.Profile, 0, len(profiles))
 			for _, profile := range profiles {
-				if !userHasPermission(entity.ProfileURL(p.Name, profile.Name)) {
+				if !userHasPermission(entity.ProfileURL(requestProjectName, profile.Name)) {
 					continue
 				}
 
@@ -250,7 +251,7 @@ func profilesGet(d *Daemon, r *http.Request) response.Response {
 		} else {
 			profileURLs = make([]string, 0, len(profiles))
 			for _, profile := range profiles {
-				profileURL := entity.ProfileURL(p.Name, profile.Name)
+				profileURL := entity.ProfileURL(requestProjectName, profile.Name)
 				if userHasPermission(profileURL) {
 					profileURLs = append(profileURLs, profileURL.String())
 				}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -25,6 +25,7 @@ import (
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -43,11 +44,68 @@ var profilesCmd = APIEndpoint{
 var profileCmd = APIEndpoint{
 	Path: "profiles/{name}",
 
-	Delete: APIEndpointAction{Handler: profileDelete, AccessHandler: allowPermission(entity.TypeProfile, auth.EntitlementCanDelete, "name")},
-	Get:    APIEndpointAction{Handler: profileGet, AccessHandler: allowPermission(entity.TypeProfile, auth.EntitlementCanView, "name")},
-	Patch:  APIEndpointAction{Handler: profilePatch, AccessHandler: allowPermission(entity.TypeProfile, auth.EntitlementCanEdit, "name")},
-	Post:   APIEndpointAction{Handler: profilePost, AccessHandler: allowPermission(entity.TypeProfile, auth.EntitlementCanEdit, "name")},
-	Put:    APIEndpointAction{Handler: profilePut, AccessHandler: allowPermission(entity.TypeProfile, auth.EntitlementCanEdit, "name")},
+	Delete: APIEndpointAction{Handler: profileDelete, AccessHandler: profileAccessHandler(auth.EntitlementCanDelete)},
+	Get:    APIEndpointAction{Handler: profileGet, AccessHandler: profileAccessHandler(auth.EntitlementCanView)},
+	Patch:  APIEndpointAction{Handler: profilePatch, AccessHandler: profileAccessHandler(auth.EntitlementCanEdit)},
+	Post:   APIEndpointAction{Handler: profilePost, AccessHandler: profileAccessHandler(auth.EntitlementCanEdit)},
+	Put:    APIEndpointAction{Handler: profilePut, AccessHandler: profileAccessHandler(auth.EntitlementCanEdit)},
+}
+
+// ctxProfileDetails should be used only for getting/setting profileDetails in the request context.
+const ctxProfileDetails request.CtxKey = "profile-details"
+
+// profileDetails contains fields that are determined prior to the access check. This is set in the request context when
+// addProfileDetailsToRequestContext is called.
+type profileDetails struct {
+	profileName      string
+	effectiveProject api.Project
+}
+
+// addProfileDetailsToRequestContext sets request.CtxEffectiveProjectName (string) and ctxProfileDetails (profileDetails)
+// in the request context.
+func addProfileDetailsToRequestContext(s *state.State, r *http.Request) error {
+	profileName, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return err
+	}
+
+	requestProjectName := request.ProjectParam(r)
+	effectiveProject, err := project.ProfileProject(s.DB.Cluster, requestProjectName)
+	if err != nil {
+		return fmt.Errorf("Failed to check project %q profile feature: %w", requestProjectName, err)
+	}
+
+	request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProject.Name)
+	request.SetCtxValue(r, ctxProfileDetails, profileDetails{
+		profileName:      profileName,
+		effectiveProject: *effectiveProject,
+	})
+
+	return nil
+}
+
+// profileAccessHandler calls addProfileDetailsToRequestContext, then uses the details to perform an access check with
+// the given auth.Entitlement.
+func profileAccessHandler(entitlement auth.Entitlement) func(d *Daemon, r *http.Request) response.Response {
+	return func(d *Daemon, r *http.Request) response.Response {
+		s := d.State()
+		err := addProfileDetailsToRequestContext(s, r)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		details, err := request.GetCtxValue[profileDetails](r.Context(), ctxProfileDetails)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		err = s.Authorizer.CheckPermission(r.Context(), entity.ProfileURL(request.ProjectParam(r), details.profileName), entitlement)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		return response.EmptySyncResponse
+	}
 }
 
 // swagger:operation GET /1.0/profiles profiles profiles_get
@@ -391,12 +449,7 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 func profileGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	p, err := project.ProfileProject(s.DB.Cluster, request.ProjectParam(r))
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
+	details, err := request.GetCtxValue[profileDetails](r.Context(), ctxProfileDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -404,7 +457,7 @@ func profileGet(d *Daemon, r *http.Request) response.Response {
 	var resp *api.Profile
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		profile, err := dbCluster.GetProfile(ctx, tx.Tx(), p.Name, name)
+		profile, err := dbCluster.GetProfile(ctx, tx.Tx(), details.effectiveProject.Name, details.profileName)
 		if err != nil {
 			return fmt.Errorf("Fetch profile: %w", err)
 		}
@@ -468,12 +521,7 @@ func profileGet(d *Daemon, r *http.Request) response.Response {
 func profilePut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	p, err := project.ProfileProject(s.DB.Cluster, request.ProjectParam(r))
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
+	details, err := request.GetCtxValue[profileDetails](r.Context(), ctxProfileDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -487,7 +535,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 			return response.BadRequest(err)
 		}
 
-		err = doProfileUpdateCluster(s, p.Name, name, old)
+		err = doProfileUpdateCluster(s, details.effectiveProject.Name, details.profileName, old)
 		return response.SmartError(err)
 	}
 
@@ -495,9 +543,9 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 	var profile *api.Profile
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		current, err := dbCluster.GetProfile(ctx, tx.Tx(), p.Name, name)
+		current, err := dbCluster.GetProfile(ctx, tx.Tx(), details.effectiveProject.Name, details.profileName)
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve profile %q: %w", name, err)
+			return fmt.Errorf("Failed to retrieve profile %q: %w", details.profileName, err)
 		}
 
 		profile, err = current.ToAPI(ctx, tx.Tx())
@@ -526,7 +574,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	err = doProfileUpdate(s, *p, name, id, profile, req)
+	err = doProfileUpdate(s, details.effectiveProject, details.profileName, id, profile, req)
 
 	if err == nil && !isClusterNotification(r) {
 		// Notify all other nodes. If a node is down, it will be ignored.
@@ -536,7 +584,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 		}
 
 		err = notifier(func(client lxd.InstanceServer) error {
-			return client.UseProject(p.Name).UpdateProfile(name, profile.Writable(), "")
+			return client.UseProject(details.effectiveProject.Name).UpdateProfile(details.profileName, profile.Writable(), "")
 		})
 		if err != nil {
 			return response.SmartError(err)
@@ -544,7 +592,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	s.Events.SendLifecycle(p.Name, lifecycle.ProfileUpdated.Event(name, p.Name, requestor, nil))
+	s.Events.SendLifecycle(details.effectiveProject.Name, lifecycle.ProfileUpdated.Event(details.profileName, details.effectiveProject.Name, requestor, nil))
 
 	return response.SmartError(err)
 }
@@ -586,12 +634,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 func profilePatch(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	p, err := project.ProfileProject(s.DB.Cluster, request.ProjectParam(r))
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
+	details, err := request.GetCtxValue[profileDetails](r.Context(), ctxProfileDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -600,9 +643,9 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 	var profile *api.Profile
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		current, err := dbCluster.GetProfile(ctx, tx.Tx(), p.Name, name)
+		current, err := dbCluster.GetProfile(ctx, tx.Tx(), details.effectiveProject.Name, details.profileName)
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve profile=%q: %w", name, err)
+			return fmt.Errorf("Failed to retrieve profile=%q: %w", details.profileName, err)
 		}
 
 		profile, err = current.ToAPI(ctx, tx.Tx())
@@ -676,9 +719,9 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	requestor := request.CreateRequestor(r)
-	s.Events.SendLifecycle(p.Name, lifecycle.ProfileUpdated.Event(name, p.Name, requestor, nil))
+	s.Events.SendLifecycle(details.effectiveProject.Name, lifecycle.ProfileUpdated.Event(details.profileName, details.effectiveProject.Name, requestor, nil))
 
-	return response.SmartError(doProfileUpdate(s, *p, name, id, profile, req))
+	return response.SmartError(doProfileUpdate(s, details.effectiveProject, details.profileName, id, profile, req))
 }
 
 // swagger:operation POST /1.0/profiles/{name} profiles profile_post
@@ -716,17 +759,12 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 func profilePost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	p, err := project.ProfileProject(s.DB.Cluster, request.ProjectParam(r))
+	details, err := request.GetCtxValue[profileDetails](r.Context(), ctxProfileDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	if name == "default" {
+	if details.profileName == "default" {
 		return response.Forbidden(errors.New(`The "default" profile cannot be renamed`))
 	}
 
@@ -751,20 +789,20 @@ func profilePost(d *Daemon, r *http.Request) response.Response {
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Check that the name isn't already in use.
-		_, err = dbCluster.GetProfile(ctx, tx.Tx(), p.Name, req.Name)
+		_, err = dbCluster.GetProfile(ctx, tx.Tx(), details.effectiveProject.Name, req.Name)
 		if err == nil {
 			return fmt.Errorf("Name %q already in use", req.Name)
 		}
 
-		return dbCluster.RenameProfile(ctx, tx.Tx(), p.Name, name, req.Name)
+		return dbCluster.RenameProfile(ctx, tx.Tx(), details.effectiveProject.Name, details.profileName, req.Name)
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	requestor := request.CreateRequestor(r)
-	lc := lifecycle.ProfileRenamed.Event(req.Name, p.Name, requestor, logger.Ctx{"old_name": name})
-	s.Events.SendLifecycle(p.Name, lc)
+	lc := lifecycle.ProfileRenamed.Event(req.Name, details.effectiveProject.Name, requestor, logger.Ctx{"old_name": details.profileName})
+	s.Events.SendLifecycle(details.effectiveProject.Name, lc)
 
 	return response.SyncResponseLocation(true, nil, lc.Source)
 }
@@ -796,22 +834,17 @@ func profilePost(d *Daemon, r *http.Request) response.Response {
 func profileDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
-	p, err := project.ProfileProject(s.DB.Cluster, request.ProjectParam(r))
+	details, err := request.GetCtxValue[profileDetails](r.Context(), ctxProfileDetails)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	name, err := url.PathUnescape(mux.Vars(r)["name"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	if name == "default" {
+	if details.profileName == "default" {
 		return response.Forbidden(errors.New(`The "default" profile cannot be deleted`))
 	}
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		profile, err := dbCluster.GetProfile(ctx, tx.Tx(), p.Name, name)
+		profile, err := dbCluster.GetProfile(ctx, tx.Tx(), details.effectiveProject.Name, details.profileName)
 		if err != nil {
 			return err
 		}
@@ -825,14 +858,14 @@ func profileDelete(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Profile is currently in use")
 		}
 
-		return dbCluster.DeleteProfile(ctx, tx.Tx(), p.Name, name)
+		return dbCluster.DeleteProfile(ctx, tx.Tx(), details.effectiveProject.Name, details.profileName)
 	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	requestor := request.CreateRequestor(r)
-	s.Events.SendLifecycle(p.Name, lifecycle.ProfileDeleted.Event(name, p.Name, requestor, nil))
+	s.Events.SendLifecycle(details.effectiveProject.Name, lifecycle.ProfileDeleted.Event(details.profileName, details.effectiveProject.Name, requestor, nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -38,7 +38,7 @@ func DNS(projectName string, instanceName string) string {
 // name is returned unmodified in the 2nd return value. This is suitable for passing back into Instance().
 // Note: This should only be used with Instance names (because they cannot contain the project separator) and this
 // function relies on this rule as project names can contain the project separator.
-func InstanceParts(projectInstanceName string) (string, string) {
+func InstanceParts(projectInstanceName string) (projectName string, instanceName string) {
 	i := strings.LastIndex(projectInstanceName, separator)
 	if i < 0 {
 		// This string is not project prefixed or is part of default project.
@@ -57,7 +57,7 @@ func StorageVolume(projectName string, storageVolumeName string) string {
 
 // StorageVolumeParts takes a project prefixed storage volume name and returns the project and storage volume
 // name as separate variables.
-func StorageVolumeParts(projectStorageVolumeName string) (string, string) {
+func StorageVolumeParts(projectStorageVolumeName string) (projectName string, storageVolumeName string) {
 	parts := strings.SplitN(projectStorageVolumeName, "_", 2)
 
 	// If the given name doesn't contain any project, only return the volume name.

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -310,4 +311,18 @@ func NetworkZoneProjectFromRecord(p *api.Project) string {
 	}
 
 	return api.ProjectDefaultName
+}
+
+// ImageProject returns the effective project for images based on the value of `features.images` in the given project.
+func ImageProject(ctx context.Context, tx *sql.Tx, requestProjectName string) (string, error) {
+	projectHasImages, err := cluster.ProjectHasImages(ctx, tx, requestProjectName)
+	if err != nil {
+		return "", err
+	}
+
+	if !projectHasImages {
+		return api.ProjectDefaultName, nil
+	}
+
+	return requestProjectName, nil
 }

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -2701,7 +2701,7 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 	// Convert the volume type name to our internal integer representation.
 	volumeType, err := storagePools.VolumeTypeNameToDBType(volumeTypeName)
 	if err != nil {
-		return api.StatusErrorf(http.StatusBadRequest, err.Error())
+		return api.StatusErrorf(http.StatusBadRequest, "Failed to get storage volume type: %w", err)
 	}
 
 	details.volumeType = volumeType

--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -42,33 +42,16 @@ test_storage_buckets() {
     return
   fi
 
-  poolName=$(lxc profile device get default root pool)
+  poolName="s3"
   bucketPrefix="lxd$$"
+
+  create_object_storage_pool "${poolName}"
 
   # Check cephobject.radosgw.endpoint is required for cephobject pools.
   if [ "$lxd_backend" = "ceph" ]; then
-    ! lxc storage create s3 cephobject || false
-    lxc storage create s3 cephobject cephobject.radosgw.endpoint="${LXD_CEPH_CEPHOBJECT_RADOSGW}"
-    lxc storage show s3
-    poolName="s3"
     s3Endpoint="${LXD_CEPH_CEPHOBJECT_RADOSGW}"
   else
-    # Create a loop device for dir pools as MinIO doesn't support running on tmpfs (which the test suite can do).
-    if [ "$lxd_backend" = "dir" ]; then
-      configure_loop_device loop_file_1 loop_device_1
-      # shellcheck disable=SC2154
-      mkfs.ext4 "${loop_device_1}"
-      mkdir "${TEST_DIR}/${bucketPrefix}"
-      mount "${loop_device_1}" "${TEST_DIR}/${bucketPrefix}"
-      losetup -d "${loop_device_1}"
-      mkdir "${TEST_DIR}/${bucketPrefix}/s3"
-      lxc storage create s3 dir source="${TEST_DIR}/${bucketPrefix}/s3"
-      poolName="s3"
-    fi
-
-    buckets_addr="127.0.0.1:$(local_tcp_port)"
-    lxc config set core.storage_buckets_address "${buckets_addr}"
-    s3Endpoint="https://${buckets_addr}"
+    s3Endpoint="https://$(lxc config get core.storage_buckets_address)"
   fi
 
   # Check bucket name validation.
@@ -183,15 +166,5 @@ test_storage_buckets() {
   ! lxc storage bucket list "${poolName}" | grep -F "${bucketPrefix}.foo" || false
   ! lxc storage bucket show "${poolName}" "${bucketPrefix}.foo" || false
 
-  if [ "$lxd_backend" = "ceph" ] || [ "$lxd_backend" = "dir" ]; then
-    lxc storage delete "${poolName}"
-  fi
-
-  if [ "$lxd_backend" = "dir" ]; then
-    umount "${TEST_DIR}/${bucketPrefix}"
-    rmdir "${TEST_DIR}/${bucketPrefix}"
-
-    # shellcheck disable=SC2154
-    deconfigure_loop_device "${loop_file_1}" "${loop_device_1}"
-  fi
+  delete_object_storage_pool "${poolName}"
 }


### PR DESCRIPTION
Implements the following:
1. Always sets the effective project when querying entities that have associated `features.*` project config. This includes:
    i. Adding network, network zone, image, and profile specific access handlers.
    ii. For each entity type above, setting details in the request context to avoid repeated calculation (same pattern as for storage buckets and volumes).
2. Always uses the request project in calls to `(Authorizer).CheckPermission` and in calls to the `auth.PermissionChecker` returned by `(Authorizer).GetPermissionChecker`.
3. In the TLS driver, we remove effective project handling (we always expect calls to use the request project, this is what we check in their allowed project list).
4. In the OpenFGA driver, overwrite the request project with the effective project in calls to the embedded OpenFGA server. But do not "punch through" to the default project like with the TLS driver, as these permissions can be managed by an administrator.
5. Increased test coverage for project features with TLS authorization.
6. Adds tests for handling of project features with fine-grained authorization.

Closes #13863