### PR TITLE
doc: unpin Swagger version

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -280,7 +280,7 @@ html_extra_path = ['.sphinx/_extra']
 
 # Download and link swagger-ui files
 if not os.path.isdir('.sphinx/deps/swagger-ui'):
-    Repo.clone_from('https://github.com/swagger-api/swagger-ui', '.sphinx/deps/swagger-ui', depth=1, single_branch=True, b='v5.11.7')
+    Repo.clone_from('https://github.com/swagger-api/swagger-ui', '.sphinx/deps/swagger-ui', depth=1)
 
 os.makedirs('.sphinx/_static/swagger-ui/', exist_ok=True)
 


### PR DESCRIPTION
The latest version of Swagger works with our docs again.

Closes #12974