### PR TITLE
lxd/firewall: Fix iptablesClear on nft shim (from Incus)

### DIFF
--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -1283,17 +1283,19 @@ func (d Xtables) iptablesClear(ipVersion uint, comments []string, fromTables ...
 
 	// Check which tables exist.
 	var tables []string // Uninitialised slice indicates we haven't opened the table file yet.
-	file, err := os.Open(tablesFile)
-	if err != nil {
-		logger.Warnf("Failed getting list of tables from %q, assuming all requested tables exist", tablesFile)
-	} else {
-		tables = []string{} // Initialise the tables slice indcating we were able to open the tables file.
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			tables = append(tables, scanner.Text())
-		}
+	if !d.xtablesIsNftables(cmd) {
+		file, err := os.Open(tablesFile)
+		if err != nil {
+			logger.Warnf("Failed getting list of tables from %q, assuming all requested tables exist", tablesFile)
+		} else {
+			tables = []string{} // Initialise the tables slice indcating we were able to open the tables file.
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				tables = append(tables, scanner.Text())
+			}
 
-		_ = file.Close()
+			_ = file.Close()
+		}
 	}
 
 	for _, fromTable := range fromTables {


### PR DESCRIPTION
cherry-picked from lxc/incus#376

When xtables uses the nft shim, the actual xtables kernel modules never get loaded, therefore the files containing the list of valid tables never get populated.

This then leads to iptablesClear always skipping all tables despite rules having been added previously.


(cherry picked from commit 3c6a60d844a7fccfb207f53e01fbb111958d42be)

License: Apache-2.0