### PR TITLE
Migration: Show source errors first (from Incus)

### DIFF
--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -780,14 +780,14 @@ func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool stor
 			return err
 		}
 
-		err = destOp.Wait()
-		if err != nil {
-			return fmt.Errorf("Instance move to destination failed: %w", err)
-		}
-
 		err = srcOp.Wait(context.Background())
 		if err != nil {
 			return fmt.Errorf("Instance move to destination failed on source: %w", err)
+		}
+
+		err = destOp.Wait()
+		if err != nil {
+			return fmt.Errorf("Instance move to destination failed: %w", err)
 		}
 
 		err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {


### PR DESCRIPTION
When migrating an instance between clustered servers, beginning the source operation before the destination operation allows us to return more helpful error messages.

Cherry pick from https://github.com/lxc/incus/pull/1039.

Relevant to https://github.com/canonical/lxd/issues/11948.