### PR TITLE
lxd/instance: Allow importing snapshots with non-alphanumeric names

### DIFF
--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -652,12 +652,14 @@ func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx
 // so it takes an argument indicating whether the name is to be used for a snapshot or not.
 func ValidName(instanceName string, isSnapshot bool) error {
 	if isSnapshot {
-		parentName, snapshotName, _ := api.GetParentAndSnapshotName(instanceName)
-		err := validate.IsHostname(parentName)
-		if err != nil {
-			return fmt.Errorf("Invalid instance name %q: %w", parentName, err)
+		parentName, snapshotName, isSnap := api.GetParentAndSnapshotName(instanceName)
+		if isSnap {
+			err := validate.IsHostname(parentName)
+			if err != nil {
+				return fmt.Errorf("Invalid instance name %q: %w", parentName, err)
+			}
 		}
-
+		
 		// Snapshot part is more flexible, but doesn't allow space or / character.
 		if strings.ContainsAny(snapshotName, " /") {
 			return fmt.Errorf("Invalid instance snapshot name %q: Cannot contain spaces or slashes", snapshotName)

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -659,7 +659,7 @@ func ValidName(instanceName string, isSnapshot bool) error {
 				return fmt.Errorf("Invalid instance name %q: %w", parentName, err)
 			}
 		}
-		
+
 		// Snapshot part is more flexible, but doesn't allow space or / character.
 		if strings.ContainsAny(snapshotName, " /") {
 			return fmt.Errorf("Invalid instance snapshot name %q: Cannot contain spaces or slashes", snapshotName)

--- a/test/main.sh
+++ b/test/main.sh
@@ -367,6 +367,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_backup_rename "backup rename"
     run_test test_backup_volume_export "backup volume export"
     run_test test_backup_export_import_instance_only "backup export and import instance only"
+    run_test test_backup_export_import_named_snapshot "backup export and import named snapshot"
     run_test test_backup_volume_rename_delete "backup volume rename and delete"
     run_test test_backup_different_instance_uuid "backup instance and check instance UUIDs"
     run_test test_backup_volume_expiry "backup volume expiry"

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1067,8 +1067,8 @@ test_backup_export_import_named_snapshot() {
     lxc delete -f c1 
 
     # Import the instance from tarball.
-    lxc import "${LXD_DIR}/c1.tar.gz
+    lxc import "${LXD_DIR}/c1.tar.gz"
 
-    rm "${LXD_DIR}"/c1.tar.gz"
+    rm "${LXD_DIR}/c1.tar.gz"
     lxc delete -f c1
 }

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1051,3 +1051,24 @@ test_backup_export_import_instance_only() {
   rm "${LXD_DIR}/c1.tar.gz"
   lxc delete -f c1
 }
+
+test_backup_export_import_named_snapshot() {
+    poolName=$(lxc profile device get default root pool)
+
+    ensure_import_testimage
+    ensure_has_localhost_remote "${LXD_ADDR}"
+
+    # Create an instance with named snapshot (includes non-alphanumeric characters).
+    lxc init testimage c1
+    lxc snapshot c1 snap_test.01
+
+    # Export the instance and remove it.
+    lxc export c1 "${LXD_DIR}/c1.tar.gz"
+    lxc delete -f c1 
+
+    # Import the instance from tarball.
+    lxc import "${LXD_DIR}/c1.tar.gz
+
+    rm "${LXD_DIR}"/c1.tar.gz"
+    lxc delete -f c1
+}

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1064,7 +1064,7 @@ test_backup_export_import_named_snapshot() {
 
     # Export the instance and remove it.
     lxc export c1 "${LXD_DIR}/c1.tar.gz"
-    lxc delete -f c1 
+    lxc delete -f c1
 
     # Import the instance from tarball.
     lxc import "${LXD_DIR}/c1.tar.gz"


### PR DESCRIPTION
Bug fix for issue #13879: "lxc import" fails if a snapshot name contains non-alphanumeric characters.