### PR TITLE
Network: Switch to long-lived OVN ports

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -2432,12 +2432,6 @@ Possible values are `true` or `false`.
 The original MAC that was used when moving a physical device into an instance.
 ```
 
-```{config:option} volatile.<name>.last_state.ip_addresses instance-volatile
-:shortdesc: "Last used IP addresses"
-:type: "string"
-Comma-separated list of the last used IP addresses of the network device.
-```
-
 ```{config:option} volatile.<name>.last_state.mtu instance-volatile
 :shortdesc: "Network device original MTU"
 :type: "string"

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -554,44 +554,17 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
 
-	v := d.volatileGet()
-
-	// Retrieve any last state IPs from volatile and pass them to OVN driver for potential use with sticky
-	// DHCPv4 allocations.
-	var lastStateIPs []net.IP
-	for _, ipStr := range shared.SplitNTrimSpace(v["last_state.ip_addresses"], ",", -1, true) {
-		lastStateIP := net.ParseIP(ipStr)
-		if lastStateIP != nil {
-			lastStateIPs = append(lastStateIPs, lastStateIP)
-		}
-	}
-
 	// Add new OVN logical switch port for instance.
-	logicalPortName, dnsIPs, err := d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+	logicalPortName, _, err := d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
 		InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 		DNSName:      d.inst.Name(),
 		DeviceName:   d.name,
 		DeviceConfig: d.config,
 		UplinkConfig: uplink.Config,
-		LastStateIPs: lastStateIPs, // Pass in volatile last state IPs for use with sticky DHCPv4 hint.
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed setting up OVN port: %w", err)
 	}
-
-	// Record switch port DNS IPs to volatile so they can be used as sticky DHCPv4 hint in the future in order
-	// to allocate the same IPs on next start if they are still available/appropriate.
-	// This volatile key will not be removed when instance stops.
-	var dnsIPsStr strings.Builder
-	for i, dnsIP := range dnsIPs {
-		if i > 0 {
-			dnsIPsStr.WriteString(",")
-		}
-
-		dnsIPsStr.WriteString(dnsIP.String())
-	}
-
-	saveData["last_state.ip_addresses"] = dnsIPsStr.String()
 
 	// Associated host side interface to OVN logical switch port (if not nested).
 	if integrationBridgeNICName != "" {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -861,20 +861,6 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 		}
 	}
 
-	// If the devices config is invalid validateConfig() won't populate this field.
-	if d.network != nil {
-		instanceUUID := d.inst.LocalConfig()["volatile.uuid"]
-		err = d.network.InstanceDevicePortStop(ovsExternalOVNPort, &network.OVNInstanceNICStopOpts{
-			InstanceUUID: instanceUUID,
-			DeviceName:   d.name,
-			DeviceConfig: d.config,
-		})
-		if err != nil {
-			// Don't fail here as we still want the postStop hook to run to clean up the local veth pair.
-			d.logger.Error("Failed to remove OVN device port", logger.Ctx{"err": err})
-		}
-	}
-
 	// Remove BGP announcements.
 	err = bgpRemovePrefix(&d.deviceCommon, d.config)
 	if err != nil {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -37,7 +37,7 @@ type ovnNet interface {
 
 	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
 	InstanceDevicePortAdd(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
-	InstanceDevicePortStart(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, []net.IP, error)
+	InstanceDevicePortStart(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error)
 	InstanceDevicePortRemove(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
 	InstanceDevicePortIPs(instanceUUID string, deviceName string) ([]net.IP, error)
 }
@@ -555,7 +555,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	networkVethFillFromVolatile(d.config, saveData)
 
 	// Add new OVN logical switch port for instance.
-	logicalPortName, _, err := d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+	logicalPortName, err := d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
 		InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 		DNSName:      d.inst.Name(),
 		DeviceName:   d.name,
@@ -724,7 +724,7 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			}
 
 			// Update OVN logical switch port for instance.
-			_, _, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+			_, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
 				InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 				DNSName:      d.inst.Name(),
 				DeviceName:   d.name,

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -38,7 +38,6 @@ type ovnNet interface {
 	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
 	InstanceDevicePortAdd(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
 	InstanceDevicePortStart(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, []net.IP, error)
-	InstanceDevicePortStop(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *network.OVNInstanceNICStopOpts) error
 	InstanceDevicePortRemove(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
 	InstanceDevicePortIPs(instanceUUID string, deviceName string) ([]net.IP, error)
 }
@@ -593,14 +592,6 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	saveData["last_state.ip_addresses"] = dnsIPsStr.String()
-
-	revert.Add(func() {
-		_ = d.network.InstanceDevicePortStop("", &network.OVNInstanceNICStopOpts{
-			InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
-			DeviceName:   d.name,
-			DeviceConfig: d.config,
-		})
-	})
 
 	// Associated host side interface to OVN logical switch port (if not nested).
 	if integrationBridgeNICName != "" {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -835,19 +835,8 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 
 	var err error
 
-	// Try and retrieve the last associated OVN switch port for the instance interface in the local OVS DB.
-	// If we cannot get this, don't fail, as InstanceDevicePortStop will then try and generate the likely
-	// port name using the same regime it does for new ports. This part is only here in order to allow
-	// instance ports generated under an older regime to be cleaned up properly.
 	networkVethFillFromVolatile(d.config, v)
 	ovs := openvswitch.NewOVS()
-	var ovsExternalOVNPort openvswitch.OVNSwitchPort
-	if d.config["nested"] == "" {
-		ovsExternalOVNPort, err = ovs.InterfaceAssociatedOVNSwitchPort(d.config["host_name"])
-		if err != nil {
-			d.logger.Warn("Could not find OVN Switch port associated to OVS interface", logger.Ctx{"interface": d.config["host_name"]})
-		}
-	}
 
 	integrationBridgeNICName := d.config["host_name"]
 	if d.config["acceleration"] == "sriov" || d.config["acceleration"] == "vdpa" {

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -1179,15 +1179,6 @@ func ConfigKeyChecker(key string, instanceType Type) (func(value string) error, 
 			return validate.IsAny, nil
 		}
 
-		// lxdmeta:generate(entities=instance; group=volatile; key=volatile.<name>.last_state.ip_addresses)
-		// Comma-separated list of the last used IP addresses of the network device.
-		// ---
-		//  type: string
-		//  shortdesc: Last used IP addresses
-		if strings.HasSuffix(key, ".last_state.ip_addresses") {
-			return validate.IsListOf(validate.IsNetworkAddress), nil
-		}
-
 		// lxdmeta:generate(entities=instance; group=volatile; key=volatile.<name>.apply_quota)
 		// The disk quota is applied the next time the instance starts.
 		// ---

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2747,13 +2747,6 @@
 						}
 					},
 					{
-						"volatile.\u003cname\u003e.last_state.ip_addresses": {
-							"longdesc": "Comma-separated list of the last used IP addresses of the network device.",
-							"shortdesc": "Last used IP addresses",
-							"type": "string"
-						}
-					},
-					{
 						"volatile.\u003cname\u003e.last_state.mtu": {
 							"longdesc": "The original MTU that was used when moving a physical device into an instance.",
 							"shortdesc": "Network device original MTU",

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3661,15 +3661,15 @@ func (n *ovn) hasDHCPv4Reservation(dhcpReservations []shared.IPRange, ip net.IP)
 
 // InstanceDevicePortStart sets up an instance device port to the internal logical switch.
 // Accepts a list of ACLs being removed from the NIC device (if called as part of a NIC update).
-// Returns the logical switch port name and a list of IPs that were allocated to the port for DNS.
-func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, []net.IP, error) {
+// Returns the logical switch port name.
+func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error) {
 	if opts.InstanceUUID == "" {
-		return "", nil, fmt.Errorf("Instance UUID is required")
+		return "", fmt.Errorf("Instance UUID is required")
 	}
 
 	mac, err := net.ParseMAC(opts.DeviceConfig["hwaddr"])
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 
 	staticIPs := []net.IP{}
@@ -3680,7 +3680,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 		ip := net.ParseIP(opts.DeviceConfig[key])
 		if ip == nil {
-			return "", nil, fmt.Errorf("Invalid %s value %q", key, opts.DeviceConfig[key])
+			return "", fmt.Errorf("Invalid %s value %q", key, opts.DeviceConfig[key])
 		}
 
 		staticIPs = append(staticIPs, ip)
@@ -3688,7 +3688,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 	internalRoutes, externalRoutes, err := n.instanceDevicePortRoutesParse(opts.DeviceConfig)
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed parsing NIC device routes: %w", err)
+		return "", fmt.Errorf("Failed parsing NIC device routes: %w", err)
 	}
 
 	revert := revert.New()
@@ -3696,7 +3696,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 	client, err := openvswitch.NewOVN(n.state)
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed to get OVN client: %w", err)
+		return "", fmt.Errorf("Failed to get OVN client: %w", err)
 	}
 
 	// Get existing DHCPv4 static reservations.
@@ -3704,7 +3704,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 	// reservations exist.
 	dhcpReservations, err := client.LogicalSwitchDHCPv4RevervationsGet(n.getIntSwitchName())
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed getting DHCPv4 reservations: %w", err)
+		return "", fmt.Errorf("Failed getting DHCPv4 reservations: %w", err)
 	}
 
 	dhcpv4Subnet := n.DHCPv4Subnet()
@@ -3715,14 +3715,14 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		// Find existing DHCP options set for IPv4 and IPv6 and update them instead of adding sets.
 		existingOpts, err := client.LogicalSwitchDHCPOptionsGet(n.getIntSwitchName())
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed getting existing DHCP settings for internal switch: %w", err)
+			return "", fmt.Errorf("Failed getting existing DHCP settings for internal switch: %w", err)
 		}
 
 		if dhcpv4Subnet != nil {
 			for _, existingOpt := range existingOpts {
 				if existingOpt.CIDR.String() == dhcpv4Subnet.String() {
 					if dhcpV4ID != "" {
-						return "", nil, fmt.Errorf("Multiple matching DHCP option sets found for switch %q and subnet %q", n.getIntSwitchName(), dhcpv4Subnet.String())
+						return "", fmt.Errorf("Multiple matching DHCP option sets found for switch %q and subnet %q", n.getIntSwitchName(), dhcpv4Subnet.String())
 					}
 
 					dhcpV4ID = existingOpt.UUID
@@ -3730,7 +3730,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			}
 
 			if dhcpV4ID == "" {
-				return "", nil, fmt.Errorf("Could not find DHCPv4 options for instance port for subnet %q", dhcpv4Subnet.String())
+				return "", fmt.Errorf("Could not find DHCPv4 options for instance port for subnet %q", dhcpv4Subnet.String())
 			}
 		}
 
@@ -3738,7 +3738,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			for _, existingOpt := range existingOpts {
 				if existingOpt.CIDR.String() == dhcpv6Subnet.String() {
 					if dhcpv6ID != "" {
-						return "", nil, fmt.Errorf("Multiple matching DHCP option sets found for switch %q and subnet %q", n.getIntSwitchName(), dhcpv6Subnet.String())
+						return "", fmt.Errorf("Multiple matching DHCP option sets found for switch %q and subnet %q", n.getIntSwitchName(), dhcpv6Subnet.String())
 					}
 
 					dhcpv6ID = existingOpt.UUID
@@ -3746,7 +3746,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			}
 
 			if dhcpv6ID == "" {
-				return "", nil, fmt.Errorf("Could not find DHCPv6 options for instance port for subnet %q", dhcpv6Subnet.String())
+				return "", fmt.Errorf("Could not find DHCPv6 options for instance port for subnet %q", dhcpv6Subnet.String())
 			}
 
 			// If port isn't going to have fully dynamic IPs allocated by OVN, and instead only static
@@ -3766,7 +3766,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 				if !hasIPv6 {
 					eui64IP, err := eui64.ParseMAC(dhcpv6Subnet.IP, mac)
 					if err != nil {
-						return "", nil, fmt.Errorf("Failed generating EUI64 for instance port %q: %w", mac.String(), err)
+						return "", fmt.Errorf("Failed generating EUI64 for instance port %q: %w", mac.String(), err)
 					}
 
 					// Add EUI64 to list of static IPs for instance port.
@@ -3784,7 +3784,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		nestedPortParentName = n.getInstanceDevicePortName(opts.InstanceUUID, opts.DeviceConfig["nested"])
 		nestedPortVLANInt64, err := strconv.ParseUint(opts.DeviceConfig["vlan"], 10, 16)
 		if err != nil {
-			return "", nil, fmt.Errorf("Invalid VLAN ID %q: %w", opts.DeviceConfig["vlan"], err)
+			return "", fmt.Errorf("Invalid VLAN ID %q: %w", opts.DeviceConfig["vlan"], err)
 		}
 
 		nestedPortVLAN = uint16(nestedPortVLANInt64)
@@ -3804,7 +3804,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		Location:     n.state.ServerName,
 	}, true)
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 
 	revert.Add(func() { _ = client.LogicalSwitchPortDelete(instancePortName) })
@@ -3841,7 +3841,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		for i := 0; i < 5; i++ {
 			dynamicIPs, err = client.LogicalSwitchPortDynamicIPs(instancePortName)
 			if err != nil {
-				return "", nil, err
+				return "", err
 			}
 
 			if len(dynamicIPs) > 0 {
@@ -3858,14 +3858,14 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 		// Check, after considering all dynamic IPs, whether we have got the required ones.
 		if (dnsIPv4 == nil && dhcpv4Subnet != nil) || (dnsIPv6 == nil && dhcpv6Subnet != nil) {
-			return "", nil, fmt.Errorf("Insufficient dynamic addresses allocated")
+			return "", fmt.Errorf("Insufficient dynamic addresses allocated")
 		}
 	}
 
 	dnsName := fmt.Sprintf("%s.%s", opts.DNSName, n.getDomainName())
 	dnsUUID, err := client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, dnsName, dnsIPs)
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed setting DNS for %q: %w", dnsName, err)
+		return "", fmt.Errorf("Failed setting DNS for %q: %w", dnsName, err)
 	}
 
 	revert.Add(func() { _ = client.LogicalSwitchPortDeleteDNS(n.getIntSwitchName(), dnsUUID, false) })
@@ -3879,7 +3879,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			dhcpReservations = append(dhcpReservations, shared.IPRange{Start: dnsIPv4})
 			err = client.LogicalSwitchDHCPv4RevervationsSet(n.getIntSwitchName(), dhcpReservations)
 			if err != nil {
-				return "", nil, fmt.Errorf("Failed adding DHCPv4 reservation for %q: %w", dnsIPv4.String(), err)
+				return "", fmt.Errorf("Failed adding DHCPv4 reservation for %q: %w", dnsIPv4.String(), err)
 			}
 		}
 	}
@@ -3905,7 +3905,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 			err = client.LogicalRouterDNATSNATAdd(n.getRouterName(), ip, ip, true, true)
 			if err != nil {
-				return "", nil, err
+				return "", err
 			}
 
 			revert.Add(func() { _ = client.LogicalRouterDNATSNATDelete(n.getRouterName(), ip) })
@@ -3933,7 +3933,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		}
 
 		if targetIP == nil {
-			return "", nil, fmt.Errorf("Cannot add static route for %q as target IP is not set", internalRoute.String())
+			return "", fmt.Errorf("Cannot add static route for %q as target IP is not set", internalRoute.String())
 		}
 
 		routes = append(routes, openvswitch.OVNRouterRoute{
@@ -3951,7 +3951,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		}
 
 		if targetIP == nil {
-			return "", nil, fmt.Errorf("Cannot add static route for %q as target IP is not set", externalRoute.String())
+			return "", fmt.Errorf("Cannot add static route for %q as target IP is not set", externalRoute.String())
 		}
 
 		routes = append(routes, openvswitch.OVNRouterRoute{
@@ -3977,7 +3977,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 				return nil
 			})
 			if err != nil {
-				return "", nil, err
+				return "", err
 			}
 		}
 	}
@@ -3986,7 +3986,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		// Add routes to local router.
 		err = client.LogicalRouterRouteAdd(n.getRouterName(), true, routes...)
 		if err != nil {
-			return "", nil, err
+			return "", err
 		}
 
 		routePrefixes := make([]net.IPNet, 0, len(routes))
@@ -3999,7 +3999,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		// Add routes to internal switch's address set for ACL usage.
 		err = client.AddressSetAdd(acl.OVNIntSwitchPortGroupAddressSetPrefix(n.ID()), routePrefixes...)
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed adding switch address set entries: %w", err)
+			return "", fmt.Errorf("Failed adding switch address set entries: %w", err)
 		}
 
 		revert.Add(func() {
@@ -4008,12 +4008,12 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 		routerIntPortIPv4, _, err := n.parseRouterIntPortIPv4Net()
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed parsing local router's peering port IPv4 Net: %w", err)
+			return "", fmt.Errorf("Failed parsing local router's peering port IPv4 Net: %w", err)
 		}
 
 		routerIntPortIPv6, _, err := n.parseRouterIntPortIPv6Net()
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed parsing local router's peering port IPv6 Net: %w", err)
+			return "", fmt.Errorf("Failed parsing local router's peering port IPv6 Net: %w", err)
 		}
 
 		// Add routes to peer routers, and security policies for each peer port on local router.
@@ -4048,7 +4048,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			return nil
 		})
 		if err != nil {
-			return "", nil, err
+			return "", err
 		}
 	}
 
@@ -4069,7 +4069,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 	// Get logical port UUID.
 	portUUID, err := client.LogicalSwitchPortUUID(instancePortName)
 	if err != nil || portUUID == "" {
-		return "", nil, fmt.Errorf("Failed getting logical port UUID for security ACL removal: %w", err)
+		return "", fmt.Errorf("Failed getting logical port UUID for security ACL removal: %w", err)
 	}
 
 	// Add NIC port to network port group (this includes the port in the @internal subject for ACL rules).
@@ -4086,7 +4086,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			return err
 		})
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed getting network ACL IDs for security ACL setup: %w", err)
+			return "", fmt.Errorf("Failed getting network ACL IDs for security ACL setup: %w", err)
 		}
 
 		// Add port to ACLs requested.
@@ -4098,7 +4098,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 			cleanup, err := acl.OVNEnsureACLs(n.state, n.logger, client, n.Project(), aclNameIDs, aclNets, nicACLNames, false)
 			if err != nil {
-				return "", nil, fmt.Errorf("Failed ensuring security ACLs are configured in OVN for instance: %w", err)
+				return "", fmt.Errorf("Failed ensuring security ACLs are configured in OVN for instance: %w", err)
 			}
 
 			revert.Add(cleanup)
@@ -4106,7 +4106,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			for _, aclName := range nicACLNames {
 				aclID, found := aclNameIDs[aclName]
 				if !found {
-					return "", nil, fmt.Errorf("Cannot find security ACL ID for %q", aclName)
+					return "", fmt.Errorf("Cannot find security ACL ID for %q", aclName)
 				}
 
 				// Add NIC port to ACL port group.
@@ -4126,7 +4126,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 			aclID, found := aclNameIDs[aclName]
 			if !found {
-				return "", nil, fmt.Errorf("Cannot find security ACL ID for %q", aclName)
+				return "", fmt.Errorf("Cannot find security ACL ID for %q", aclName)
 			}
 
 			// Remove NIC port from ACL port group.
@@ -4142,7 +4142,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 	n.logger.Debug("Applying instance NIC port group member change sets")
 	err = client.PortGroupMemberChange(addChangeSet, removeChangeSet)
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed applying OVN port group member change sets for instance NIC: %w", err)
+		return "", fmt.Errorf("Failed applying OVN port group member change sets for instance NIC: %w", err)
 	}
 
 	// Set the automatic default ACL rule for the port.
@@ -4153,21 +4153,21 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		logPrefix := fmt.Sprintf("%s-%s", opts.InstanceUUID, opts.DeviceName)
 		err = acl.OVNApplyInstanceNICDefaultRules(client, acl.OVNIntSwitchPortGroupName(n.ID()), logPrefix, instancePortName, ingressAction, ingressLogged, egressAction, egressLogged)
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed applying OVN default ACL rules for instance NIC: %w", err)
+			return "", fmt.Errorf("Failed applying OVN default ACL rules for instance NIC: %w", err)
 		}
 
 		n.logger.Debug("Set NIC default rule", logger.Ctx{"port": instancePortName, "ingressAction": ingressAction, "ingressLogged": ingressLogged, "egressAction": egressAction, "egressLogged": egressLogged})
 	} else {
 		err = client.PortGroupPortClearACLRules(acl.OVNIntSwitchPortGroupName(n.ID()), instancePortName)
 		if err != nil {
-			return "", nil, fmt.Errorf("Failed clearing OVN default ACL rules for instance NIC: %w", err)
+			return "", fmt.Errorf("Failed clearing OVN default ACL rules for instance NIC: %w", err)
 		}
 
 		n.logger.Debug("Cleared NIC default rule", logger.Ctx{"port": instancePortName})
 	}
 
 	revert.Success()
-	return instancePortName, dnsIPs, nil
+	return instancePortName, nil
 }
 
 // instanceDeviceACLDefaults returns the action and logging mode to use for the specified direction's default rule.
@@ -4633,7 +4633,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 
 						// Re-add logical switch port to apply the l2proxy DNAT_AND_SNAT rules.
 						n.logger.Debug("Re-adding instance OVN NIC port to apply ingress mode changes", logger.Ctx{"project": inst.Project, "instance": inst.Name, "device": devName})
-						_, _, err = n.InstanceDevicePortStart(&OVNInstanceNICSetupOpts{
+						_, err = n.InstanceDevicePortStart(&OVNInstanceNICSetupOpts{
 							InstanceUUID: instanceUUID,
 							DNSName:      inst.Name,
 							DeviceName:   devName,

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3791,9 +3791,8 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 	}
 
 	// Add port with mayExist set to true, so that if instance port exists, we don't fail and continue below
-	// to configure the port as needed. This is required in case the OVN northbound database was unavailable
-	// when the instance NIC was stopped and was unable to remove the port on last stop, which would otherwise
-	// prevent future NIC starts.
+	// to configure the port as needed. This is required because the port is created when the NIC is added, but
+	// we need to ensure it is present at start up as well in case it was deleted since the NIC was added.
 	err = client.LogicalSwitchPortAdd(n.getIntSwitchName(), instancePortName, &openvswitch.OVNSwitchPortOpts{
 		DHCPv4OptsID: dhcpV4ID,
 		DHCPv6OptsID: dhcpv6ID,

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4250,12 +4250,6 @@ func (n *ovn) InstanceDevicePortIPs(instanceUUID string, deviceName string) ([]n
 	return devIPs, nil
 }
 
-// InstanceDevicePortStop deletes an instance device port from the internal logical switch.
-func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *OVNInstanceNICStopOpts) error {
-
-	return nil
-}
-
 // InstanceDevicePortRemove unregisters the NIC device in the OVN database by removing the DNS entry that should
 // have been created during InstanceDevicePortAdd(). If the DNS record exists at remove time then this indicates
 // the NIC device was successfully added and this function also clears any DHCP reservations for the NIC's IPs.


### PR DESCRIPTION
- [x] Convert OVN logical switch ports and associated config to be created at NIC create time and deleted at NIC delete time (rather than start and stop time respectively).
- [x] Update tests to reflect this. See https://github.com/canonical/lxd-ci/pull/261
- [x] Add DB patch to clear out `volatile.*last_state.ip_addresses` instance config entries as no longer needed.
- [x] Explore if we can have a network level option to allow the OVN dynamic IPs to be refreshed on start and cleared on stop to allow the old dynamic behaviour as well, otherwise it won't be possible to create more instances than available IPs, even if not all of them are running at the same time.
- [x] Test live VM migration works - tested using both ceph and zfs migrations.

Confirmed that creating an OVN NIC when there is insufficient space causes an error:

```
Error: Failed instance creation: Failed creating instance record: Failed initialising instance: Failed to add device "eth0": Failed setting up OVN port: Insufficient dynamic addresses allocated
```

WRT to exploring if we can later add a network option to allow dynamic allocation at start time rather than create time, this should be possible to do by not setting the `dynamic` option when we create the port, but instead setting it at start time and removing it at stop time. **But will not add this functionality in this PR.**

E.g.

```
sudo ovn-nbctl find logical_switch_port
addresses           : ["00:16:3e:24:9c:4c"]
dhcpv4_options      : 592a6788-4c73-4773-a8fa-12808377eccf
dhcpv6_options      : 52436e24-f9d1-4436-9de4-96a264739aed
dynamic_addresses   : []
enabled             : []
external_ids        : {lxd_location=none, lxd_switch=lxd-net14-ls-int}
ha_chassis_group    : []
name                : lxd-net14-instance-3dd0d44c-f72f-4981-b04c-bdf6414e0bba-eth0
options             : {}
parent_name         : []
port_security       : []
tag                 : []
tag_request         : []
type                : ""
up                  : false
```

And then:

```
sudo ovn-nbctl lsp-set-addresses lxd-net14-instance-3dd0d44c-f72f-4981-b04c-bdf6414e0bba-eth0 00:16:3e:24:9c:4c dynamic
```

Will result in dynamic IPs being allocated:

```
addresses           : ["00:16:3e:24:9c:4c", dynamic]
dynamic_addresses   : "be:af:33:b8:e5:03 10.184.229.2 fd42:843c:cb92:3d28:bcaf:33ff:feb8:e503"
```

Then removing `dynamic`:

```
sudo ovn-nbctl lsp-set-addresses lxd-net14-instance-3dd0d44c-f72f-4981-b04c-bdf6414e0bba-eth0 00:16:3e:24:9c:4c
```

Causes the dynamic IPs to be removed too:

```
addresses           : ["00:16:3e:24:9c:4c"]
dynamic_addresses   : []
```

It would also need the DNS setup to be delayed until NIC start time and have it torn down at NIC stop time as otherwise we won't have IPs to associate to the DNS name.