### PR TITLE
lxd: Refresh the state on cluster put/join (from Incus)

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -370,6 +370,10 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 		d.globalConfigMu.Unlock()
 
 		d.events.SetLocalLocation(d.serverName)
+
+		// Refresh the state.
+		s = d.State()
+
 		// Start clustering tasks
 		d.startClusterTasks()
 
@@ -796,6 +800,9 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		if err != nil {
 			return err
 		}
+
+		// Refresh the state.
+		s = d.State()
 
 		// Start up networks so any post-join changes can be applied now that we have a Node ID.
 		logger.Debug("Starting networks after cluster join")


### PR DESCRIPTION
This small PR ensures we update state upon cluster put/join.

Cherry picked from https://github.com/lxc/incus/pull/366.