### PR TITLE
VM: Improve QEMU passthrough device ID generation

### DIFF
--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -936,7 +936,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				pciSlotName: "host-slot",
 			},
 			`# PCI card ("physical-pci-name" device)
-			[device "dev-lxd_physical-pci-name"]
+			[device "dev-lxd_physical--pci--name"]
 			driver = "vfio-pci"
 			bus = "qemu_pcie1"
 			addr = "00.0"
@@ -948,7 +948,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				pciSlotName: "host-slot-ccw",
 			},
 			`# PCI card ("physical-ccw-name" device)
-			[device "dev-lxd_physical-ccw-name"]
+			[device "dev-lxd_physical--ccw--name"]
 			driver = "vfio-ccw"
 			multifunction = "on"
 			host = "host-slot-ccw"`,
@@ -969,7 +969,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				pciSlotName: "gpu-slot",
 			},
 			`# GPU card ("gpu-name" device)
-			[device "dev-lxd_gpu-name"]
+			[device "dev-lxd_gpu--name"]
 			driver = "vfio-pci"
 			bus = "qemu_pcie1"
 			addr = "00.0"
@@ -982,7 +982,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				vga:         true,
 			},
 			`# GPU card ("gpu-name" device)
-			[device "dev-lxd_gpu-name"]
+			[device "dev-lxd_gpu--name"]
 			driver = "vfio-ccw"
 			multifunction = "on"
 			host = "gpu-slot"
@@ -994,7 +994,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				vgpu:    "vgpu-dev",
 			},
 			`# GPU card ("vgpu-name" device)
-			[device "dev-lxd_vgpu-name"]
+			[device "dev-lxd_vgpu--name"]
 			driver = "vfio-pci"
 			bus = "qemu_pcie1"
 			addr = "00.0"

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -797,7 +797,7 @@ func qemuPCIPhysical(opts *qemuPCIPhysicalOpts) []cfgSection {
 
 	return []cfgSection{{
 		// Devices use "lxd_" prefix indicating that this is a user named device.
-		name:    fmt.Sprintf(`device "dev-lxd_%s"`, opts.devName),
+		name:    fmt.Sprintf(`device "%s"`, qemuDeviceNameOrID(qemuDeviceIDPrefix, opts.devName, "", qemuDeviceIDMaxLength)),
 		comment: fmt.Sprintf(`PCI card ("%s" device)`, opts.devName),
 		entries: entries,
 	}}
@@ -833,7 +833,7 @@ func qemuGPUDevPhysical(opts *qemuGPUDevPhysicalOpts) []cfgSection {
 
 	return []cfgSection{{
 		// Devices use "lxd_" prefix indicating that this is a user named device.
-		name:    fmt.Sprintf(`device "dev-lxd_%s"`, opts.devName),
+		name:    fmt.Sprintf(`device "%s"`, qemuDeviceNameOrID(qemuDeviceIDPrefix, opts.devName, "", qemuDeviceIDMaxLength)),
 		comment: fmt.Sprintf(`GPU card ("%s" device)`, opts.devName),
 		entries: entries,
 	}}


### PR DESCRIPTION
Although this changes qemu device IDs for physical PCI and GPU under some specific circumstances, it is safe to merge since the device ID is only a reference inside QEMU and does not affect how the device is shown inside the instance (`lspci`  information is the same regardless of these changes). Applying this changes was tested and it does not affect previously created devices, they will may have a different device ID iin QEMU the next reboot.

Since `lxd-ci` does not include tests with these types of devices, no tests related to these changes will be added.

Fixes #13597