### PR TITLE
lxd/firewall/drivers: Make sure to always use locking (from Incus)

### DIFF
--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -568,7 +568,7 @@ func (d Xtables) NetworkApplyACLRules(networkName string, rules []ACLRule) error
 
 		// Add rules to chain in table.
 		for _, iptRule := range iptRules {
-			_, err := shared.RunCommand(cmd, append([]string{"-t", "filter", "-A", chain}, iptRule...)...)
+			_, err := shared.RunCommand(cmd, append([]string{"-w", "-t", "filter", "-A", chain}, iptRule...)...)
 			if err != nil {
 				return fmt.Errorf("Failed adding rule to %q chain %q in table %q: %w", cmd, chain, "filter", err)
 			}
@@ -1449,7 +1449,7 @@ func (d Xtables) iptablesChainExists(ipVersion uint, table string, chain string)
 	}
 
 	// Attempt to dump the rules of the chain, if this fails then chain doesn't exist.
-	rules, err := shared.RunCommand(cmd, "-t", table, "-S", chain)
+	rules, err := shared.RunCommand(cmd, "-w", "-t", table, "-S", chain)
 	if err != nil {
 		return false, false, nil
 	}
@@ -1475,7 +1475,7 @@ func (d Xtables) iptablesChainCreate(ipVersion uint, table string, chain string)
 	}
 
 	// Attempt to create chain in table.
-	_, err := shared.RunCommand(cmd, "-t", table, "-N", chain)
+	_, err := shared.RunCommand(cmd, "-w", "-t", table, "-N", chain)
 	if err != nil {
 		return fmt.Errorf("Failed creating %q chain %q in table %q: %w", cmd, chain, table, err)
 	}
@@ -1496,14 +1496,14 @@ func (d Xtables) iptablesChainDelete(ipVersion uint, table string, chain string,
 
 	// Attempt to flush rules from chain in table.
 	if flushFirst {
-		_, err := shared.RunCommand(cmd, "-t", table, "-F", chain)
+		_, err := shared.RunCommand(cmd, "-w", "-t", table, "-F", chain)
 		if err != nil {
 			return fmt.Errorf("Failed flushing %q chain %q in table %q: %w", cmd, chain, table, err)
 		}
 	}
 
 	// Attempt to delete chain in table.
-	_, err := shared.RunCommand(cmd, "-t", table, "-X", chain)
+	_, err := shared.RunCommand(cmd, "-w", "-t", table, "-X", chain)
 	if err != nil {
 		return fmt.Errorf("Failed deleting %q chain %q in table %q: %w", cmd, chain, table, err)
 	}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -1107,7 +1107,7 @@ func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv
 func (d Xtables) generateFilterIptablesRules(parentName string, hostName string, hwAddr string, IPv6Nets []*net.IPNet, parentManaged bool) (rules [][]string, err error) {
 	mac, err := net.ParseMAC(hwAddr)
 	if err != nil {
-		return [][]string{}, err
+		return rules, err
 	}
 
 	macHex := hex.EncodeToString(mac)
@@ -1162,7 +1162,7 @@ func (d Xtables) generateFilterIptablesRules(parentName string, hostName string,
 		}
 	}
 
-	return [][]string{}, err
+	return rules, err
 }
 
 // matchEbtablesRule compares an active rule to a supplied match rule to see if they match.


### PR DESCRIPTION
Based on https://github.com/lxc/incus/pull/310.

This also fixes a bug where the Iptables rules were not being set correctly on xtables, it was included here because the linter was failing because of it.