### PR TITLE
Storage: Allow rename of all remote storage vols if cluster member is offline

### DIFF
--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1485,7 +1485,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 				return resp
 			}
 
-			if details.pool.Driver().Info().Name == "ceph" {
+			if details.pool.Driver().Info().Remote {
 				var dbVolume *db.StorageVolume
 				var volumeNotFound bool
 				var targetIsSet bool


### PR DESCRIPTION
This check was hardcoded to work only with the Ceph RBD storage driver as it was the only remote storage driver before we have added support for Dell PowerFlex.

Fixes https://github.com/canonical/lxd/issues/13542
The other part of the issue is already addressed in https://github.com/canonical/lxd/pull/13934.