### PR TITLE
Ubuntu Pro auto-attachment of guests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,7 +147,7 @@ jobs:
 
           # bin/max (sizes are in MiB)
           SIZES="lxc 15
-                 lxd-agent 12"
+                 lxd-agent 13"
           MIB="$((1024 * 1024))"
 
           while read -r bin max; do

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2470,3 +2470,8 @@ Adds the following internal metrics:
 This introduces per-pool project disk limits, introducing a `limits.disk.pool.NAME`
 configuration option to the project limits. When `limits.disk.pool.POOLNAME: 0`
 for a project, the pool is excluded from `lxc storage list` in that project.
+
+## `ubuntu_pro_guest_attach`
+
+Adds a new {config:option}`instance-miscellaneous:ubuntu_pro.guest_attach` configuration option for instances.
+When set to `on`, if the host has guest attachment enabled, the guest can request a guest token for Ubuntu Pro via `devlxd`.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1840,6 +1840,19 @@ Possible values are `boot` (load the modules when booting the container) and `on
 
 ```
 
+```{config:option} ubuntu_pro.guest_attach instance-miscellaneous
+:liveupdate: "no"
+:shortdesc: "Whether to auto-attach Ubuntu Pro."
+:type: "string"
+Indicate whether the guest should auto-attach Ubuntu Pro at start up.
+The allowed values are `off`, `on`, and `available`.
+If set to `off`, it will not be possible for the Ubuntu Pro client in the guest to obtain guest token via `devlxd`.
+If set to `available`, attachment via guest token is possible but will not be performed automatically by the Ubuntu Pro client in the guest at startup.
+If set to `on`, attachment will be performed automatically by the Ubuntu Pro client in the guest at startup.
+To allow guest attachment, the host must be an Ubuntu machine that is Pro attached, and guest attachment must be enabled via the Pro client.
+To do this, run `pro config set lxd_guest_attach=on`.
+```
+
 ```{config:option} user.* instance-miscellaneous
 :liveupdate: "no"
 :shortdesc: "Free-form user key/value storage"

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -69,6 +69,7 @@ import (
 	"github.com/canonical/lxd/lxd/storage/s3/miniod"
 	"github.com/canonical/lxd/lxd/sys"
 	"github.com/canonical/lxd/lxd/task"
+	"github.com/canonical/lxd/lxd/ubuntupro"
 	"github.com/canonical/lxd/lxd/ucred"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/lxd/warnings"
@@ -164,6 +165,9 @@ type Daemon struct {
 
 	// Syslog listener cancel function.
 	syslogSocketCancel context.CancelFunc
+
+	// Ubuntu Pro settings
+	ubuntuPro *ubuntupro.Client
 }
 
 // DaemonConfig holds configuration values for Daemon.
@@ -599,6 +603,7 @@ func (d *Daemon) State() *state.State {
 		ServerUUID:          d.serverUUID,
 		StartTime:           d.startTime,
 		Authorizer:          d.authorizer,
+		UbuntuPro:           d.ubuntuPro,
 	}
 }
 
@@ -1830,6 +1835,9 @@ func (d *Daemon) init() error {
 
 	// Start all background tasks
 	d.tasks.Start(d.shutdownCtx)
+
+	// Load Ubuntu Pro configuration before starting any instances.
+	d.ubuntuPro = ubuntupro.New(d.os.ReleaseInfo["NAME"], d.shutdownCtx)
 
 	// Restore instances
 	instancesStart(d.State(), instances)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -293,6 +293,50 @@ func devlxdDevicesGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrit
 	return response.DevLxdResponse(http.StatusOK, c.ExpandedDevices(), "json", c.Type() == instancetype.VM)
 }
 
+var devlxdUbuntuProGet = devLxdHandler{
+	path:        "/1.0/ubuntu-pro",
+	handlerFunc: devlxdUbuntuProGetHandler,
+}
+
+func devlxdUbuntuProGetHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
+	}
+
+	if r.Method != http.MethodGet {
+		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
+	}
+
+	settings := d.State().UbuntuPro.GuestAttachSettings(c.ExpandedConfig()["ubuntu_pro.guest_attach"])
+
+	// Otherwise, return the value from the instance configuration.
+	return response.DevLxdResponse(http.StatusOK, settings, "json", c.Type() == instancetype.VM)
+}
+
+var devlxdUbuntuProTokenPost = devLxdHandler{
+	path:        "/1.0/ubuntu-pro/token",
+	handlerFunc: devlxdUbuntuProTokenPostHandler,
+}
+
+func devlxdUbuntuProTokenPostHandler(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response {
+	if shared.IsFalse(c.ExpandedConfig()["security.devlxd"]) {
+		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusForbidden), c.Type() == instancetype.VM)
+	}
+
+	if r.Method != http.MethodPost {
+		return response.DevLxdErrorResponse(api.NewGenericStatusError(http.StatusMethodNotAllowed), c.Type() == instancetype.VM)
+	}
+
+	// Return http.StatusForbidden if the host does not have guest attachment enabled.
+	tokenJSON, err := d.State().UbuntuPro.GetGuestToken(r.Context(), c.ExpandedConfig()["ubuntu_pro.guest_attach"])
+	if err != nil {
+		return response.DevLxdErrorResponse(fmt.Errorf("Failed to get an Ubuntu Pro guest token: %w", err), c.Type() == instancetype.VM)
+	}
+
+	// Pass it back to the guest.
+	return response.DevLxdResponse(http.StatusOK, tokenJSON, "json", c.Type() == instancetype.VM)
+}
+
 var handlers = []devLxdHandler{
 	{
 		path: "/",
@@ -307,6 +351,8 @@ var handlers = []devLxdHandler{
 	devlxdEventsGet,
 	devlxdImageExport,
 	devlxdDevicesGet,
+	devlxdUbuntuProGet,
+	devlxdUbuntuProTokenPost,
 }
 
 func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -405,6 +405,20 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 		return err
 	},
 
+	// lxdmeta:generate(entities=instance; group=miscellaneous; key=ubuntu_pro.guest_attach)
+	// Indicate whether the guest should auto-attach Ubuntu Pro at start up.
+	// The allowed values are `off`, `on`, and `available`.
+	// If set to `off`, it will not be possible for the Ubuntu Pro client in the guest to obtain guest token via `devlxd`.
+	// If set to `available`, attachment via guest token is possible but will not be performed automatically by the Ubuntu Pro client in the guest at startup.
+	// If set to `on`, attachment will be performed automatically by the Ubuntu Pro client in the guest at startup.
+	// To allow guest attachment, the host must be an Ubuntu machine that is Pro attached, and guest attachment must be enabled via the Pro client.
+	// To do this, run `pro config set lxd_guest_attach=on`.
+	// ---
+	// type: string
+	// liveupdate: no
+	// shortdesc: Whether to auto-attach Ubuntu Pro.
+	"ubuntu_pro.guest_attach": validate.Optional(validate.IsOneOf("off", "on", "available")),
+
 	// Volatile keys.
 
 	// lxdmeta:generate(entities=instance; group=volatile; key=volatile.apply_template)

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2106,6 +2106,14 @@
 						}
 					},
 					{
+						"ubuntu_pro.guest_attach": {
+							"liveupdate": "no",
+							"longdesc": "Indicate whether the guest should auto-attach Ubuntu Pro at start up.\nThe allowed values are `off`, `on`, and `available`.\nIf set to `off`, it will not be possible for the Ubuntu Pro client in the guest to obtain guest token via `devlxd`.\nIf set to `available`, attachment via guest token is possible but will not be performed automatically by the Ubuntu Pro client in the guest at startup.\nIf set to `on`, attachment will be performed automatically by the Ubuntu Pro client in the guest at startup.\nTo allow guest attachment, the host must be an Ubuntu machine that is Pro attached, and guest attachment must be enabled via the Pro client.\nTo do this, run `pro config set lxd_guest_attach=on`.",
+							"shortdesc": "Whether to auto-attach Ubuntu Pro.",
+							"type": "string"
+						}
+					},
+					{
 						"user.*": {
 							"liveupdate": "no",
 							"longdesc": "User keys can be used in search.",

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canonical/lxd/lxd/maas"
 	"github.com/canonical/lxd/lxd/node"
 	"github.com/canonical/lxd/lxd/sys"
+	"github.com/canonical/lxd/lxd/ubuntupro"
 	"github.com/canonical/lxd/shared"
 )
 
@@ -91,4 +92,7 @@ type State struct {
 
 	// Authorizer.
 	Authorizer auth.Authorizer
+
+	// Ubuntu pro settings.
+	UbuntuPro *ubuntupro.Client
 }

--- a/lxd/ubuntupro/client.go
+++ b/lxd/ubuntupro/client.go
@@ -1,0 +1,247 @@
+package ubuntupro
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/canonical/lxd/lxd/fsmonitor"
+	"github.com/canonical/lxd/lxd/fsmonitor/drivers"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+)
+
+const (
+	// guestAttachSettingOff indicates that guest attachment is turned off.
+	// - When the host has this setting turned off, devlxd requests to `GET /1.0/ubuntu-pro` should return "off" and
+	//   `POST /1.0/ubuntu-pro/token` should return a 403 Forbidden (regardless of the guest setting).
+	// - When the guest has this setting turned off (`ubuntu_pro.guest_attach`), devlxd requests to `GET /1.0/ubuntu-pro`
+	//   should return "off" and `POST /1.0/ubuntu-pro/token` should return a 403 Forbidden (regardless of the host setting).
+	guestAttachSettingOff = "off"
+
+	// guestAttachSettingAvailable indicates that guest attachment is available.
+	// - When the host has this setting, devlxd requests to `GET /1.0/ubuntu-pro` should return the setting from the guest
+	//   (`ubuntu_pro.guest_attach) and `POST /1.0/ubuntu-pro/token` should retrieve a guest token via the Ubuntu Pro client.
+	// - When the guest has this setting, the pro client inside the guest will not try to retrieve a guest token at startup
+	//   (though attachment with a guest token can still be performed with `pro auto-attach`.
+	guestAttachSettingAvailable = "available"
+
+	// guestAttachSettingOn indicates that guest attachment is on.
+	// - When the host has this setting, devlxd requests to `GET /1.0/ubuntu-pro` should return the setting from the guest
+	//   (`ubuntu_pro.guest_attach) and `POST /1.0/ubuntu-pro/token` should retrieve a guest token via the Ubuntu Pro client.
+	// - When the guest has this setting, the pro client inside the guest will attempt to retrieve a guest token at startup.
+	guestAttachSettingOn = "on"
+)
+
+// isValid returns an error if the GuestAttachSetting is not one of the pre-defined values.
+func validateGuestAttachSetting(guestAttachSetting string) error {
+	if !shared.ValueInSlice(guestAttachSetting, []string{guestAttachSettingOff, guestAttachSettingAvailable, guestAttachSettingOn}) {
+		return fmt.Errorf("Invalid guest auto-attach setting %q", guestAttachSetting)
+	}
+
+	return nil
+}
+
+// ubuntuAdvantageDirectory is the base directory for Ubuntu Pro related configuration.
+const ubuntuAdvantageDirectory = "/var/lib/ubuntu-advantage"
+
+// Client is our wrapper for Ubuntu Pro configuration and the Ubuntu Pro CLI.
+type Client struct {
+	guestAttachSetting string
+	monitor            fsmonitor.FSMonitor
+	pro                pro
+}
+
+// pro is an internal interface that is used for mocking calls to the pro CLI.
+type pro interface {
+	getGuestToken(ctx context.Context) (*api.UbuntuProGuestTokenResponse, error)
+}
+
+// proCLI calls the actual Ubuntu Pro CLI to implement the interface.
+type proCLI struct{}
+
+// proAPIGetGuestTokenV1 represents the expected format of calls to `pro api u.pro.attach.guest.get_guest_token.v1`.
+// Not all fields are modelled as they are not required for guest attachment functionality.
+type proAPIGetGuestTokenV1 struct {
+	Result string `json:"result"`
+	Data   struct {
+		Attributes api.UbuntuProGuestTokenResponse `json:"attributes"`
+	} `json:"data"`
+	Errors []struct {
+		Title string
+	} `json:"errors"`
+}
+
+// getTokenJSON runs `pro api u.pro.attach.guest.get_guest_token.v1` and returns the result.
+func (proCLI) getGuestToken(ctx context.Context) (*api.UbuntuProGuestTokenResponse, error) {
+	// Run pro guest attach command.
+	response, err := shared.RunCommandContext(ctx, "pro", "api", "u.pro.attach.guest.get_guest_token.v1")
+	if err != nil {
+		return nil, api.StatusErrorf(http.StatusServiceUnavailable, "Ubuntu Pro client command unsuccessful: %w", err)
+	}
+
+	var getGuestTokenResponse proAPIGetGuestTokenV1
+	err = json.Unmarshal([]byte(response), &getGuestTokenResponse)
+	if err != nil {
+		return nil, api.StatusErrorf(http.StatusInternalServerError, "Received unexpected response from Ubuntu Pro contracts server: %w", err)
+	}
+
+	if getGuestTokenResponse.Result != "success" {
+		if len(getGuestTokenResponse.Errors) > 0 && getGuestTokenResponse.Errors[0].Title != "" {
+			return nil, api.StatusErrorf(http.StatusServiceUnavailable, "Ubuntu Pro contracts server returned %q when getting a guest token with error %q", getGuestTokenResponse.Result, getGuestTokenResponse.Errors[0].Title)
+		}
+
+		return nil, api.StatusErrorf(http.StatusServiceUnavailable, "Ubuntu Pro contracts server returned %q when getting a guest token", getGuestTokenResponse.Result)
+	}
+
+	return &getGuestTokenResponse.Data.Attributes, nil
+}
+
+// New returns a new Client that watches /var/lib/ubuntu-advantage for changes to LXD configuration and contains a shim
+// for the actual Ubuntu Pro CLI. If the host is not Ubuntu, it returns a static Client that always returns
+// guestAttachSettingOff.
+func New(osName string, ctx context.Context) *Client {
+	if osName != "Ubuntu" {
+		// If we're not on Ubuntu, return a static Client.
+		return &Client{guestAttachSetting: guestAttachSettingOff}
+	}
+
+	s := &Client{}
+	s.init(ctx, shared.HostPath(ubuntuAdvantageDirectory), proCLI{})
+	return s
+}
+
+// getGuestAttachSetting returns the correct attachment setting for an instance based the on the instance configuration
+// and the current GuestAttachSetting of the host.
+func (s *Client) getGuestAttachSetting(instanceSetting string) string {
+	// If the setting is "off" on the host then no guest attachment should take place.
+	if s.guestAttachSetting == guestAttachSettingOff {
+		return guestAttachSettingOff
+	}
+
+	// The `ubuntu_pro.guest_attach` setting is optional.
+	if instanceSetting == "" {
+		return guestAttachSettingOff
+	}
+
+	// If the setting is not empty, check it is valid. This should have been validated already when setting the value so
+	// log a warning if it is invalid.
+	err := validateGuestAttachSetting(instanceSetting)
+	if err != nil {
+		logger.Warn("Received invalid Ubuntu Pro guest attachment setting", logger.Ctx{"setting": instanceSetting})
+		return guestAttachSettingOff
+	}
+
+	return instanceSetting
+}
+
+// GuestAttachSettings returns UbuntuProSettings based on the instance configuration and the GuestAttachSetting of the host.
+func (s *Client) GuestAttachSettings(instanceSetting string) api.UbuntuProSettings {
+	return api.UbuntuProSettings{GuestAttach: s.getGuestAttachSetting(instanceSetting)}
+}
+
+// GetGuestToken returns a 403 Forbidden error if the host or the instance has guestAttachSettingOff, otherwise
+// it calls the pro shim to get a token.
+func (s *Client) GetGuestToken(ctx context.Context, instanceSetting string) (*api.UbuntuProGuestTokenResponse, error) {
+	if s.getGuestAttachSetting(instanceSetting) == guestAttachSettingOff {
+		return nil, api.NewStatusError(http.StatusForbidden, "Guest attachment not allowed")
+	}
+
+	return s.pro.getGuestToken(ctx)
+}
+
+// init configures the Client to watch the ubuntu advantage directory for file changes.
+func (s *Client) init(ctx context.Context, ubuntuAdvantageDir string, proShim pro) {
+	// Initial setting should be "off".
+	s.guestAttachSetting = guestAttachSettingOff
+	s.pro = proShim
+
+	// Set up a watcher on the ubuntu advantage directory.
+	err := s.watch(ctx, ubuntuAdvantageDir)
+	if err != nil {
+		logger.Warn("Failed to configure Ubuntu configuration watcher", logger.Ctx{"err": err})
+	}
+}
+
+func (s *Client) watch(ctx context.Context, ubuntuAdvantageDir string) error {
+	// On first call, attempt to read the contents of the config file.
+	configFilePath := path.Join(ubuntuAdvantageDir, "interfaces", "lxd-config.json")
+	err := s.parseConfigFile(configFilePath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		logger.Warn("Failed to read Ubunto Pro LXD configuration file", logger.Ctx{"err": err})
+	}
+
+	// Watch /var/lib/ubuntu-advantage for write, remove, and rename events.
+	monitor, err := drivers.Load(ctx, ubuntuAdvantageDir, fsmonitor.EventWrite, fsmonitor.EventRemove, fsmonitor.EventRename)
+	if err != nil {
+		return fmt.Errorf("Failed to create a file monitor: %w", err)
+	}
+
+	go func() {
+		// Wait for the context to be cancelled.
+		<-ctx.Done()
+
+		// On cancel, set the guestAttachSetting back to "off" and unwatch the file.
+		s.guestAttachSetting = guestAttachSettingOff
+		err := monitor.Unwatch(path.Join(ubuntuAdvantageDir, "interfaces", "lxd-config.json"), "")
+		if err != nil {
+			logger.Warn("Failed to remove Ubuntu Pro configuration file watcher", logger.Ctx{"err": err})
+		}
+	}()
+
+	// Add a hook for the config file.
+	err = monitor.Watch(configFilePath, "", func(path string, event fsmonitor.Event) bool {
+		if event == fsmonitor.EventRemove {
+			// On remove, set guest attach to "off".
+			s.guestAttachSetting = guestAttachSettingOff
+			return true
+		}
+
+		// Otherwise, parse the config file and update the client accordingly.
+		err := s.parseConfigFile(path)
+		if err != nil {
+			logger.Warn("Failed to read Ubunto Pro LXD configuration file", logger.Ctx{"err": err})
+		}
+
+		return true
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to configure file monitor: %w", err)
+	}
+
+	s.monitor = monitor
+	return nil
+}
+
+// parseConfigFile reads the Ubuntu Pro `lxd-config.json` file, validates it, and sets appropriate values in the Client.
+func (s *Client) parseConfigFile(lxdConfigFile string) error {
+	// Default to "off" if any error occurs.
+	s.guestAttachSetting = guestAttachSettingOff
+
+	f, err := os.Open(lxdConfigFile)
+	if err != nil {
+		return fmt.Errorf("Failed to open Ubuntu Pro configuration file: %w", err)
+	}
+
+	defer f.Close()
+
+	var settings api.UbuntuProSettings
+	err = json.NewDecoder(f).Decode(&settings)
+	if err != nil {
+		return fmt.Errorf("Failed to read Ubuntu Pro configuration file: %w", err)
+	}
+
+	err = validateGuestAttachSetting(settings.GuestAttach)
+	if err != nil {
+		return fmt.Errorf("Failed to read Ubuntu Pro configuration file: %w", err)
+	}
+
+	s.guestAttachSetting = settings.GuestAttach
+	return nil
+}

--- a/lxd/ubuntupro/client_test.go
+++ b/lxd/ubuntupro/client_test.go
@@ -1,0 +1,233 @@
+package ubuntupro
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+type proCLIMock struct {
+	mockResponse *api.UbuntuProGuestTokenResponse
+	mockErr      error
+}
+
+func (p proCLIMock) getGuestToken(_ context.Context) (*api.UbuntuProGuestTokenResponse, error) {
+	return p.mockResponse, p.mockErr
+}
+
+func TestClient(t *testing.T) {
+	sleep := func() {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	writeSettingsFile := func(filepath string, raw string, setting string) {
+		var d []byte
+		var err error
+		if raw != "" {
+			d = []byte(raw)
+		} else {
+			d, err = json.Marshal(api.UbuntuProSettings{GuestAttach: setting})
+			require.NoError(t, err)
+		}
+
+		err = os.WriteFile(filepath, d, 0666)
+		require.NoError(t, err)
+		sleep()
+	}
+
+	mockTokenResponse := api.UbuntuProGuestTokenResponse{
+		Expires:    time.Now().String(),
+		GuestToken: "token",
+		ID:         uuid.New().String(),
+	}
+
+	mockProCLI := proCLIMock{
+		mockResponse: &mockTokenResponse,
+		mockErr:      nil,
+	}
+
+	type assertion struct {
+		instanceSetting   string
+		expectedSetting   string
+		expectErr         bool
+		expectedToken     *api.UbuntuProGuestTokenResponse
+		expectedErrorCode int
+	}
+
+	assertionsWhenHostHasGuestAttachmentOff := []assertion{
+		{
+			instanceSetting:   "",
+			expectedSetting:   guestAttachSettingOff,
+			expectErr:         true,
+			expectedErrorCode: http.StatusForbidden,
+		},
+		{
+			instanceSetting:   guestAttachSettingOff,
+			expectedSetting:   guestAttachSettingOff,
+			expectErr:         true,
+			expectedErrorCode: http.StatusForbidden,
+		},
+		{
+			instanceSetting:   guestAttachSettingAvailable,
+			expectedSetting:   guestAttachSettingOff,
+			expectErr:         true,
+			expectedErrorCode: http.StatusForbidden,
+		},
+		{
+			instanceSetting:   guestAttachSettingOn,
+			expectedSetting:   guestAttachSettingOff,
+			expectErr:         true,
+			expectedErrorCode: http.StatusForbidden,
+		},
+	}
+
+	assertionsWhenHostHasGuestAttachmentOnOrAvailable := []assertion{
+		{
+			instanceSetting:   "",
+			expectedSetting:   guestAttachSettingOff,
+			expectErr:         true,
+			expectedErrorCode: http.StatusForbidden,
+		},
+		{
+			instanceSetting:   guestAttachSettingOff,
+			expectedSetting:   guestAttachSettingOff,
+			expectErr:         true,
+			expectedErrorCode: http.StatusForbidden,
+		},
+		{
+			instanceSetting: guestAttachSettingAvailable,
+			expectedSetting: guestAttachSettingAvailable,
+			expectedToken:   &mockTokenResponse,
+		},
+		{
+			instanceSetting: guestAttachSettingOn,
+			expectedSetting: guestAttachSettingOn,
+			expectedToken:   &mockTokenResponse,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Make a temporary directory to test file watcher behaviour.
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	// Create and initialise the Client. Don't call New(), as this will create a real client watching the actual
+	// /var/lib/ubuntu-advantage directory.
+	s := &Client{}
+	s.init(ctx, tmpDir, mockProCLI)
+
+	runAssertions := func(assertions []assertion) {
+		for _, a := range assertions {
+			assert.Equal(t, api.UbuntuProSettings{GuestAttach: a.expectedSetting}, s.GuestAttachSettings(a.instanceSetting))
+			token, err := s.GetGuestToken(ctx, a.instanceSetting)
+			assert.Equal(t, a.expectedToken, token)
+			if a.expectErr {
+				assert.True(t, api.StatusErrorCheck(err, a.expectedErrorCode))
+			} else {
+				assert.NoError(t, err)
+			}
+		}
+	}
+
+	// There is no "interfaces" directory, so the guest attach setting should be off.
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	// Create the interfaces directory and sleep to wait for the filewatcher to catch up.
+	interfacesDir := filepath.Join(tmpDir, "interfaces")
+	err = os.Mkdir(interfacesDir, 0755)
+	require.NoError(t, err)
+	sleep()
+
+	// There is no "lxd-config.json" file, so the guest attach setting should be off.
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	// Create the lxd-config.json file and sleep to wait for the filewatcher.
+	lxdConfigFilepath := filepath.Join(interfacesDir, "lxd-config.json")
+	f, err := os.Create(lxdConfigFilepath)
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+	sleep()
+
+	// The guest attach setting should still be false as we've not written anything to the file.
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	// Write '{"guest_attach":"available"}' to the settings file.
+	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingAvailable)
+	assert.Equal(t, guestAttachSettingAvailable, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+
+	// Write '{"guest_attach":"off"}' to the settings file.
+	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingOff)
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	// Write '{"guest_attach":"on"}' to the settings file.
+	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingOn)
+	assert.Equal(t, guestAttachSettingOn, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+
+	// Write invalid JSON to the settings file.
+	writeSettingsFile(lxdConfigFilepath, "{{}\\foo", "")
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	// Write '{"guest_attach":"on"}' to the settings file.
+	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingOn)
+	assert.Equal(t, guestAttachSettingOn, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+
+	// Write an invalid setting to the settings file.
+	writeSettingsFile(lxdConfigFilepath, "", "foo")
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	// Write '{"guest_attach":"on"}' to the settings file.
+	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingOn)
+	assert.Equal(t, guestAttachSettingOn, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+
+	// Remove the config file.
+	err = os.Remove(lxdConfigFilepath)
+	require.NoError(t, err)
+	sleep()
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	// Create a temporary config file and move it to the right location.
+	tmpSettingsFilePath := filepath.Join(interfacesDir, "lxd-config.json.tmp")
+	_, err = os.Create(tmpSettingsFilePath)
+	require.NoError(t, err)
+	writeSettingsFile(tmpSettingsFilePath, "", guestAttachSettingOn)
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	err = os.Rename(tmpSettingsFilePath, lxdConfigFilepath)
+	require.NoError(t, err)
+	sleep()
+	assert.Equal(t, guestAttachSettingOn, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+
+	// Cancel the context.
+	cancel()
+	sleep()
+	assert.Equal(t, guestAttachSettingOff, s.guestAttachSetting)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOff)
+
+	err = os.RemoveAll(tmpDir)
+	require.NoError(t, err)
+}

--- a/shared/api/devlxd.go
+++ b/shared/api/devlxd.go
@@ -23,3 +23,34 @@ type DevLXDGet struct {
 	// Example: lxd01
 	Location string `json:"location" yaml:"location"`
 }
+
+// UbuntuProGuestTokenResponse contains the expected fields of proAPIGetGuestTokenV1 that must be passed back to
+// the guest for pro attachment to succeed.
+//
+// API extension: ubuntu_pro_guest_attach.
+type UbuntuProGuestTokenResponse struct {
+	// Expires denotes the time at which the token will expire.
+	//
+	// Example: 2025-03-23T20:00:00-04:00
+	Expires string `json:"expires"`
+
+	// GuestToken contains the guest Pro attach token.
+	//
+	// Example: RANDOM-STRING
+	GuestToken string `json:"guest_token"`
+
+	// ID is an identifier for the token.
+	//
+	// Example: 9f65c3d0-c326-491e-927f-9b062b6649a0
+	ID string `json:"id"`
+}
+
+// UbuntuProSettings contains Ubuntu Pro settings relevant to LXD.
+//
+// API extension: ubuntu_pro_guest_attach.
+type UbuntuProSettings struct {
+	// GuestAttach indicates the availability of ubuntu pro guest attachment.
+	//
+	// Example: on
+	GuestAttach string `json:"guest_attach"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -416,6 +416,7 @@ var APIExtensions = []string{
 	"disk_io_bus_virtio_blk",
 	"metrics_api_requests",
 	"projects_limits_disk_pool",
+	"ubuntu_pro_guest_attach",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR implements the LXD side of things for auto-attachment of ubuntu guests:
- Adds a `lxd/ubuntupro` package containing a `Client` which contains an fsmonitor for LXD related configuration.
- Adds the `ubuntupro.Client` to Daemon and State.
- Adds a new config option `ubuntu_pro.guest_attach` with allowed values `on`, `off`, or `available`.
- Adds two `devlxd` endpoints: `GET /1.0/ubuntu-pro` and `POST /1.0/ubuntu-pro/token`. The first returns the value of `ubuntu_pro.guest_attach` (if enabled on the host, otherwise it returns "off"). The second executes a `pro` command on the host to request a guest token, which is returned to the guest.
- Adds the `devlxd` endpoints to the LXD agent.

To use the `fsmonitor` package for this, I needed to refactor it somewhat. This makes the fsmonitor package much more flexible, but we do need to watch for regressions in unix devices, as I'm not sure if our tests cover all the edge cases here.

See https://docs.google.com/document/d/1MJA1LcTcd1OGHweyiahxAJ-UjrjXKzGtslrNqHnc9uc/edit for more details.

Opening as draft while I conduct more testing.