### PR TITLE
Patches: Fix patch system so that it respects the patch stages

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1266,14 +1266,16 @@ func patchStorageRenameCustomISOBlockVolumesV2(name string, d *Daemon) error {
 			return fmt.Errorf("Failed loading pool %q: %w", poolName, err)
 		}
 
+		isRemotePool := p.Driver().Info().Remote
+
 		// Ensure the renaming is done only on the selected patch cluster member for remote storage pools.
-		if p.Driver().Info().Remote && !isSelectedPatchMember {
+		if isRemotePool && !isSelectedPatchMember {
 			continue
 		}
 
 		for _, vol := range volumes {
-			// In a non-clusted environment ServerName will be empty.
-			if s.ServerName != "" && vol.Location != s.ServerName {
+			// Skip volumes on local pools that are on other servers.
+			if !isRemotePool && s.ServerClustered && vol.Location != s.ServerName {
 				continue
 			}
 


### PR DESCRIPTION
It appears that ever since I introduced the concept of a [patch stage in LXD 3.23](https://github.com/canonical/lxd/pull/7012) the patch stage argument hasn't actually been taking effect.

This hasn't been noticed as each time we've introduced an earlier stage the existing patches were either compatible with the earlier stage or had already been run and so we weren't getting reports of issues.

However with the introduction of the [`patchPreLoadClusterConfig` stage in LXD 6.1](https://github.com/canonical/lxd/pull/13567) it has now become apparent because of a new patch I am working on to remove specific volatile instance config keys from instances on the local member, and I noticed that `state.ServerName` was empty even though it was being set after the `patchPreLoadClusterConfig` stage and my new patch was supposed to be running after that, but in fact, wasn't.

Fixes #13860