### PR TITLE
Cluster: Enforce member name cannot be `none`

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1329,6 +1329,10 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("This server is not clustered"))
 	}
 
+	if req.ServerName == "none" {
+		return response.BadRequest(fmt.Errorf("Join token name cannot be %q", req.ServerName))
+	}
+
 	expiry, err := shared.GetExpiry(time.Now(), s.GlobalConfig.ClusterJoinTokenExpiry())
 	if err != nil {
 		return response.BadRequest(err)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -363,6 +363,10 @@ func clusterPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("ServerName may not start with %q", targetGroupPrefix))
 	}
 
+	if req.ServerName == "none" {
+		return response.BadRequest(fmt.Errorf("ServerName cannot be %q", req.ServerName))
+	}
+
 	// Disable clustering.
 	if !req.Enabled {
 		return clusterPutDisable(d, r, req)


### PR DESCRIPTION
In https://github.com/canonical/lxd/pull/13957#discussion_r1726718542 we found that currently `none` is a valid LXD cluster member name.

This collides with the internally used concept which identifies if LXD is clustered or not by setting it's internal `ServerName` to `none` or it's actual cluster name.

The PR ensures that a LXD cluster member's name cannot be `none` as well as blocking the creation of join tokens with name `none`.