### PR TITLE
Migration: Forward migration errors (from Incus)

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -978,7 +978,12 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 
 		targetSecrets := map[string]string{}
 		for k, v := range opAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			vStr, ok := v.(string)
+			if !ok {
+				continue
+			}
+
+			targetSecrets[k] = vStr
 		}
 
 		// Prepare the source request
@@ -1006,7 +1011,12 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 
 	sourceSecrets := map[string]string{}
 	for k, v := range opAPI.Metadata {
-		sourceSecrets[k] = v.(string)
+		vStr, ok := v.(string)
+		if !ok {
+			continue
+		}
+
+		sourceSecrets[k] = vStr
 	}
 
 	// Relay mode migration
@@ -1026,7 +1036,12 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 		// Extract the websockets
 		targetSecrets := map[string]string{}
 		for k, v := range targetOpAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			vStr, ok := v.(string)
+			if !ok {
+				continue
+			}
+
+			targetSecrets[k] = vStr
 		}
 
 		// Launch the relay
@@ -1268,9 +1283,16 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 
 	value, ok := opAPI.Metadata["fds"]
 	if ok {
-		values := value.(map[string]any)
-		for k, v := range values {
-			fds[k] = v.(string)
+		values, ok := value.(map[string]any)
+		if ok {
+			for k, v := range values {
+				vStr, ok := v.(string)
+				if !ok {
+					continue
+				}
+
+				fds[k] = vStr
+			}
 		}
 	}
 
@@ -1285,7 +1307,12 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 		outputs, ok := opAPI.Metadata["output"].(map[string]any)
 		if ok {
 			for k, v := range outputs {
-				outputFiles[k] = v.(string)
+				vStr, ok := v.(string)
+				if !ok {
+					continue
+				}
+
+				outputFiles[k] = vStr
 			}
 		}
 
@@ -2017,7 +2044,12 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 
 		targetSecrets := map[string]string{}
 		for k, v := range opAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			vStr, ok := v.(string)
+			if !ok {
+				continue
+			}
+
+			targetSecrets[k] = vStr
 		}
 
 		// Prepare the source request
@@ -2045,7 +2077,12 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 
 	sourceSecrets := map[string]string{}
 	for k, v := range opAPI.Metadata {
-		sourceSecrets[k] = v.(string)
+		vStr, ok := v.(string)
+		if !ok {
+			continue
+		}
+
+		sourceSecrets[k] = vStr
 	}
 
 	// Relay mode migration
@@ -2065,7 +2102,12 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 		// Extract the websockets
 		targetSecrets := map[string]string{}
 		for k, v := range targetOpAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			vStr, ok := v.(string)
+			if !ok {
+				continue
+			}
+
+			targetSecrets[k] = vStr
 		}
 
 		// Launch the relay
@@ -2621,9 +2663,16 @@ func (r *ProtocolLXD) ConsoleInstance(instanceName string, console api.InstanceC
 
 	value, ok := opAPI.Metadata["fds"]
 	if ok {
-		values := value.(map[string]any)
-		for k, v := range values {
-			fds[k] = v.(string)
+		values, ok := value.(map[string]any)
+		if ok {
+			for k, v := range values {
+				vStr, ok := v.(string)
+				if !ok {
+					continue
+				}
+
+				fds[k] = vStr
+			}
 		}
 	}
 
@@ -2713,9 +2762,16 @@ func (r *ProtocolLXD) ConsoleInstanceDynamic(instanceName string, console api.In
 
 	value, ok := opAPI.Metadata["fds"]
 	if ok {
-		values := value.(map[string]any)
-		for k, v := range values {
-			fds[k] = v.(string)
+		values, ok := value.(map[string]any)
+		if ok {
+			for k, v := range values {
+				vStr, ok := v.(string)
+				if !ok {
+					continue
+				}
+
+				fds[k] = vStr
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds functionality to report source errors during copy. This helps to solve the issue of the incorrect error being reported when a live migration is attempted while `migration.stateful` is missing or set to false.

(Also rectifies a few unchecked type assertions in `client/lxd_instances.go` since the linter complained)

Closes https://github.com/canonical/lxd/issues/11948.