### PR TITLE
Shared: Add HMAC and cert utils

### DIFF
--- a/shared/cert.go
+++ b/shared/cert.go
@@ -430,6 +430,16 @@ func GenerateMemCert(client bool, options CertOptions) ([]byte, []byte, error) {
 	return cert, key, nil
 }
 
+// ParseCert parse a X.509 certificate from the given byte slice and return its parsed content.
+func ParseCert(cert []byte) (*x509.Certificate, error) {
+	certBlock, _ := pem.Decode(cert)
+	if certBlock == nil {
+		return nil, fmt.Errorf("Invalid certificate file")
+	}
+
+	return x509.ParseCertificate(certBlock.Bytes)
+}
+
 // ReadCert reads a X.509 certificate from the filesystem, do PEM decoding and return its parsed content.
 func ReadCert(fpath string) (*x509.Certificate, error) {
 	cf, err := os.ReadFile(fpath)
@@ -437,12 +447,7 @@ func ReadCert(fpath string) (*x509.Certificate, error) {
 		return nil, err
 	}
 
-	certBlock, _ := pem.Decode(cf)
-	if certBlock == nil {
-		return nil, fmt.Errorf("Invalid certificate file")
-	}
-
-	return x509.ParseCertificate(certBlock.Bytes)
+	return ParseCert(cf)
 }
 
 // CertFingerprint returns the SHA256 fingerprint of a X.509 certificate.

--- a/shared/trust/hmac.go
+++ b/shared/trust/hmac.go
@@ -1,0 +1,202 @@
+package trust
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+// HMACFormatter represents arbitrary formats to diplay and parse the actual HMAC.
+// For example implementations like argon2 extend the format with an additional salt.
+// Example using argon2: `Authorization: <version> <salt>:<HMAC>`.
+type HMACFormatter interface {
+	// The Write* methods allow the creation of an HMAC based on various inputs.
+	WriteBytes(b []byte) ([]byte, error)
+	WriteJSON(v any) ([]byte, error)
+	WriteRequest(r *http.Request) ([]byte, error)
+
+	// Version returns the current HMAC version set for the format.
+	Version() HMACVersion
+	// HTTPHeader expects the HMAC computed over the payload and returns the final Authorization header.
+	HTTPHeader(hmac []byte) string
+	// ParseHTTPHeader expects an Authorization header and returns the used version and HMAC.
+	ParseHTTPHeader(header string) (HMACVersion, []byte, error)
+	// Equal compares two HMACs and returns true in case of a match.
+	Equal(hmac1 []byte, hmac2 []byte) bool
+}
+
+// HMAC represents the the tooling for creating and validating HMACs.
+type HMAC struct {
+	conf HMACConf
+	key  []byte
+}
+
+// HMACVersion indicates the version used for the authorization header format.
+// This allows to define a format used by the header so that the scheme can be modified
+// in future implementations without breaking already existing versions.
+// An example version can be `LXD1.0` which indicates that this is version 1.0 of the
+// LXD HMAC authentication scheme.
+// The format used after the version is dependant on the actual implementation:
+// Example: `Authorization: <version> <format including the HMAC>`.
+type HMACVersion string
+
+// HMACConf represents the HMAC configuration.
+type HMACConf struct {
+	HashFunc func() hash.Hash
+	Version  HMACVersion
+}
+
+// NewDefaultHMACConf returns the default configuration for HMAC.
+func NewDefaultHMACConf(version HMACVersion) HMACConf {
+	return HMACConf{
+		HashFunc: sha256.New,
+		Version:  version,
+	}
+}
+
+// NewHMAC returns a new instance of HMAC.
+func NewHMAC(key []byte, conf HMACConf) HMACFormatter {
+	return &HMAC{
+		conf: conf,
+		key:  key,
+	}
+}
+
+func (h *HMAC) splitVersionFromHMAC(header string) (HMACVersion, string, error) {
+	authHeaderSplit := strings.Split(header, " ")
+	if len(authHeaderSplit) != 2 {
+		return "", "", errors.New("Version or HMAC is missing")
+	}
+
+	if authHeaderSplit[0] == "" {
+		return "", "", errors.New("Version cannot be empty")
+	}
+
+	if authHeaderSplit[1] == "" {
+		return "", "", errors.New("HMAC cannot be empty")
+	}
+
+	return HMACVersion(authHeaderSplit[0]), authHeaderSplit[1], nil
+}
+
+// HTTPHeader returns the actual HMAC together with the used version.
+func (h *HMAC) HTTPHeader(hmac []byte) string {
+	return fmt.Sprintf("%s %s", h.conf.Version, hex.EncodeToString(hmac))
+}
+
+// Version returns the used HMAC version.
+func (h *HMAC) Version() HMACVersion {
+	return h.conf.Version
+}
+
+// ParseHTTPHeader extracts the actual version and HMAC from the Authorization header.
+func (h *HMAC) ParseHTTPHeader(header string) (HMACVersion, []byte, error) {
+	version, hmacStr, err := h.splitVersionFromHMAC(header)
+	if err != nil {
+		return "", nil, err
+	}
+
+	hmac, err := hex.DecodeString(hmacStr)
+	if err != nil {
+		return "", nil, fmt.Errorf("Failed to decode the HMAC: %w", err)
+	}
+
+	return version, hmac, nil
+}
+
+// WriteBytes creates a new HMAC hash using the given bytes.
+func (h *HMAC) WriteBytes(b []byte) ([]byte, error) {
+	mac := hmac.New(h.conf.HashFunc, h.key)
+	_, err := mac.Write(b)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create HMAC: %w", err)
+	}
+
+	return mac.Sum(nil), nil
+}
+
+// WriteJSON creates a new HMAC hash using the given struct.
+func (h *HMAC) WriteJSON(v any) ([]byte, error) {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal payload: %w", err)
+	}
+
+	return h.WriteBytes(payload)
+}
+
+// WriteRequest creates a new HMAC hash using the given request.
+// It will extract the requests body.
+func (h *HMAC) WriteRequest(r *http.Request) ([]byte, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read request body: %w", err)
+	}
+
+	defer func() {
+		// Reset the request body for the actual handler.
+		r.Body = io.NopCloser(bytes.NewBuffer(body))
+	}()
+
+	err = r.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to close the request body: %w", err)
+	}
+
+	return h.WriteBytes(body)
+}
+
+// Equal returns true in case hmac1 is identical to hmac2.
+func (h *HMAC) Equal(hmac1 []byte, hmac2 []byte) bool {
+	return hmac.Equal(hmac1, hmac2)
+}
+
+// HMACEqual extracts the HMAC from the Authorization header and
+// validates if it is equal to the HMAC created from the request's body using the given formatter.
+func HMACEqual(h HMACFormatter, r *http.Request) error {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return api.StatusErrorf(http.StatusBadRequest, "Authorization header is missing")
+	}
+
+	version, hmacFromHeader, err := h.ParseHTTPHeader(authHeader)
+	if err != nil {
+		return api.StatusErrorf(http.StatusBadRequest, "Failed to parse Authorization header: %w", err)
+	}
+
+	hmacVersion := h.Version()
+	if version != hmacVersion {
+		return api.StatusErrorf(http.StatusBadRequest, "Authorization header uses version %q but expected %q", version, hmacVersion)
+	}
+
+	hmacFromBody, err := h.WriteRequest(r)
+	if err != nil {
+		return api.StatusErrorf(http.StatusInternalServerError, "Failed to calculate HMAC from request body: %w", err)
+	}
+
+	if !hmac.Equal(hmacFromHeader, hmacFromBody) {
+		return api.StatusErrorf(http.StatusForbidden, "Invalid HMAC")
+	}
+
+	return nil
+}
+
+// HMACAuthorizationHeader returns the HMAC as an Authorization header using the given formatter.
+func HMACAuthorizationHeader(h HMACFormatter, v any) (string, error) {
+	hmacBytes, err := h.WriteJSON(v)
+	if err != nil {
+		return "", err
+	}
+
+	return h.HTTPHeader(hmacBytes), nil
+}

--- a/shared/trust/hmac_argon2.go
+++ b/shared/trust/hmac_argon2.go
@@ -1,0 +1,95 @@
+package trust
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// HMACArgon2 represents the tooling for creating and validating HMACs
+// bundled with the key derivation function argon2.
+type HMACArgon2 struct {
+	HMAC
+	salt []byte
+}
+
+// NewHMACArgon2 returns a new HMAC implementation using argon2.
+// If the salt is nil a random one is generated.
+// Recommended defaults according to https://www.rfc-editor.org/rfc/rfc9106#section-4-6.2.
+// We use the second recommended option to not require a system having 2 GiB of memory.
+func NewHMACArgon2(password []byte, salt []byte, conf HMACConf) (HMACFormatter, error) {
+	if salt == nil {
+		// 128 bit salt.
+		salt = make([]byte, 16)
+		_, err := rand.Read(salt)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create salt: %w", err)
+		}
+	}
+
+	// 3 iterations.
+	var time uint32 = 3
+
+	// 64 MiB memory.
+	var memory uint32 = 64 * 1024
+
+	// 4 lanes.
+	var threads uint8 = 4
+
+	// 256 bit tag size.
+	var keyLen uint32 = 32
+
+	return &HMACArgon2{
+		HMAC: HMAC{
+			conf: conf,
+			key:  argon2.IDKey(password, salt, time, memory, threads, keyLen),
+		},
+
+		salt: salt,
+	}, nil
+}
+
+// HTTPHeader returns the actual HMAC alongside it's salt together with the used version.
+func (h *HMACArgon2) HTTPHeader(hmac []byte) string {
+	return fmt.Sprintf("%s %s:%s", h.conf.Version, hex.EncodeToString(h.salt), hex.EncodeToString(hmac))
+}
+
+// ParseHTTPHeader extracts the actual version, HMAC and it's salt from the Authorization header.
+func (h *HMACArgon2) ParseHTTPHeader(header string) (HMACVersion, []byte, error) {
+	version, hmacStr, err := h.splitVersionFromHMAC(header)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// In case of argon2 the HMAC has the salt as prefix.
+	authHeaderDetails := strings.Split(hmacStr, ":")
+	if len(authHeaderDetails) != 2 {
+		return "", nil, errors.New("Argon2 salt or HMAC is missing")
+	}
+
+	if authHeaderDetails[0] == "" {
+		return "", nil, fmt.Errorf("Argon2 salt cannot be empty")
+	}
+
+	if authHeaderDetails[1] == "" {
+		return "", nil, fmt.Errorf("Argon2 HMAC cannot be empty")
+	}
+
+	salt, err := hex.DecodeString(authHeaderDetails[0])
+	if err != nil {
+		return "", nil, fmt.Errorf("Failed to decode the argon2 salt: %w", err)
+	}
+
+	h.salt = salt
+
+	hmac, err := hex.DecodeString(authHeaderDetails[1])
+	if err != nil {
+		return "", nil, fmt.Errorf("Failed to decode the argon2 HMAC: %w", err)
+	}
+
+	return version, hmac, nil
+}

--- a/shared/trust/hmac_test.go
+++ b/shared/trust/hmac_test.go
@@ -1,0 +1,337 @@
+package trust
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errorCloser implements the Reader and Closer interfaces and allows to
+// simulate errors during read and close operations.
+type errorReaderCloser struct {
+	readErr  error
+	closeErr error
+}
+
+// Read simulates a read from errorReaderCloser.
+// Return io.EOF to exit out any read operations.
+func (e errorReaderCloser) Read(p []byte) (n int, err error) {
+	return 0, e.readErr
+}
+
+// Close simulates a close of errorReaderCloser.
+func (e errorReaderCloser) Close() error {
+	return e.closeErr
+}
+
+func TestCreateHMAC(t *testing.T) {
+	tests := []struct {
+		name           string
+		conf           HMACConf
+		key            []byte
+		password       []byte
+		hexSalt        string
+		payload        any
+		expectedHeader string
+		expectedErr    error
+	}{
+		{
+			name:           "Create HMAC from simple payload",
+			conf:           NewDefaultHMACConf("LXD1.0"),
+			key:            []byte("foo"),
+			payload:        map[string]string{"hello": "world"},
+			expectedHeader: "LXD1.0 4022ad4878aff5a3bbd815aec63cce26cb5e8abd4df69589312cd0dee25fd717",
+		},
+		{
+			name:           "Create HMAC from simple payload using argon2 as KDF",
+			conf:           NewDefaultHMACConf("LXD1.0"),
+			password:       []byte("foo"),
+			hexSalt:        "caffee",
+			payload:        map[string]string{"hello": "world"},
+			expectedHeader: "LXD1.0 caffee:b4b19532928620a1d54e7d1c58e4baaa916a8e0023ed8a08b2b05038d6da189a",
+		},
+		{
+			name:        "Reject creating HMAC from invalid payload",
+			conf:        NewDefaultHMACConf("LXD1.0"),
+			key:         []byte("foo"),
+			payload:     make(chan bool),
+			expectedErr: errors.New("Failed to marshal payload: json: unsupported type: chan bool"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			var hmac HMACFormatter
+			if tt.key != nil {
+				hmac = NewHMAC(tt.key, tt.conf)
+			}
+
+			if tt.password != nil {
+				salt, err := hex.DecodeString(tt.hexSalt)
+				require.NoError(t, err)
+
+				hmac, err = NewHMACArgon2(tt.password, salt, tt.conf)
+				require.NoError(t, err)
+			}
+
+			hmacStr, err := HMACAuthorizationHeader(hmac, tt.payload)
+			if tt.expectedErr != nil {
+				require.Equal(t, tt.expectedErr.Error(), err.Error())
+			} else {
+				require.Equal(t, tt.expectedHeader, hmacStr)
+			}
+		})
+	}
+}
+
+func TestValidateHMAC(t *testing.T) {
+	tests := []struct {
+		name        string
+		conf        HMACConf
+		key         []byte
+		password    []byte
+		hexSalt     string
+		request     *http.Request
+		expectedErr error
+	}{
+		{
+			name: "Validate HMAC from request header",
+			conf: NewDefaultHMACConf("LXD1.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 4022ad4878aff5a3bbd815aec63cce26cb5e8abd4df69589312cd0dee25fd717"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`{"hello":"world"}`)),
+			},
+		},
+		{
+			name: "Validate non-matching HMAC from request header",
+			conf: NewDefaultHMACConf("LXD1.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 4022ad4878aff5a3bbd815aec63cce26cb5e8abd4df69589312cd0dee25fd717"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`{"hello":"world","modified":"body"}`)),
+			},
+			expectedErr: errors.New("Invalid HMAC"),
+		},
+		{
+			name:     "Validate HMAC from request header using argon2 as KDF",
+			conf:     NewDefaultHMACConf("LXD1.0"),
+			password: []byte("foo"),
+			hexSalt:  "caffee",
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 caffee:b4b19532928620a1d54e7d1c58e4baaa916a8e0023ed8a08b2b05038d6da189a"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`{"hello":"world"}`)),
+			},
+		},
+		{
+			name:     "Validate non-matching HMAC from request header using argon2 as KDF",
+			conf:     NewDefaultHMACConf("LXD1.0"),
+			password: []byte("foo"),
+			hexSalt:  "caffee",
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 caffee:b4b19532928620a1d54e7d1c58e4baaa916a8e0023ed8a08b2b05038d6da189a"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`{"hello":"world","modified":"body"}`)),
+			},
+			expectedErr: errors.New("Invalid HMAC"),
+		},
+		{
+			name: "Reject header missing the version",
+			conf: NewDefaultHMACConf("LXD1.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"invalid"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Version or HMAC is missing"),
+		},
+		{
+			name:     "Reject header missing the version using argon2 as KDF",
+			conf:     NewDefaultHMACConf("LXD1.0"),
+			password: []byte("foo"),
+			hexSalt:  "caffee",
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"invalid"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Version or HMAC is missing"),
+		},
+		{
+			name:     "Reject header missing the HMAC and salt combination using argon2 as KDF",
+			conf:     NewDefaultHMACConf("LXD1.0"),
+			password: []byte("foo"),
+			hexSalt:  "caffee",
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 caffee"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Argon2 salt or HMAC is missing"),
+		},
+		{
+			name:     "Reject header with a non hex salt using argon2 as KDF",
+			conf:     NewDefaultHMACConf("LXD1.0"),
+			password: []byte("foo"),
+			hexSalt:  "caffee",
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 nonhex:abc"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Failed to decode the argon2 salt: encoding/hex: invalid byte: U+006E 'n'"),
+		},
+		{
+			name:     "Reject header with a non hex HMAC using argon2 as KDF",
+			conf:     NewDefaultHMACConf("LXD1.0"),
+			password: []byte("foo"),
+			hexSalt:  "caffee",
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 caffee:nonhex"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Failed to decode the argon2 HMAC: encoding/hex: invalid byte: U+006E 'n'"),
+		},
+		{
+			name:        "Reject request with missing Authorization header",
+			conf:        NewDefaultHMACConf("LXD1.0"),
+			request:     &http.Request{},
+			expectedErr: errors.New("Authorization header is missing"),
+		},
+		{
+			name: "Reject request with non-matching HMAC version",
+			conf: NewDefaultHMACConf("LXD2.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 4022ad4878aff5a3bbd815aec63cce26cb5e8abd4df69589312cd0dee25fd717"},
+				},
+			},
+			expectedErr: errors.New(`Authorization header uses version "LXD1.0" but expected "LXD2.0"`),
+		},
+		{
+			name: "Reject request with a non hex HMAC",
+			conf: NewDefaultHMACConf("LXD1.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 nonhexcharacters"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Failed to decode the HMAC: encoding/hex: invalid byte: U+006E 'n'"),
+		},
+		{
+			name: "Reject request whose body cannot be read",
+			conf: NewDefaultHMACConf("LXD1.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 4022ad4878aff5a3bbd815aec63cce26cb5e8abd4df69589312cd0dee25fd717"},
+				},
+				// Use reader that errors out immediately.
+				Body: errorReaderCloser{readErr: errors.New("Fail always")},
+			},
+			expectedErr: errors.New("Failed to calculate HMAC from request body: Failed to read request body: Fail always"),
+		},
+		{
+			name: "Reject request whose body cannot be closed",
+			conf: NewDefaultHMACConf("LXD1.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 4022ad4878aff5a3bbd815aec63cce26cb5e8abd4df69589312cd0dee25fd717"},
+				},
+				// Use reader that errors out immediately.
+				// Return EOF from the reader to trigger a Close.
+				Body: errorReaderCloser{readErr: io.EOF, closeErr: errors.New("Fail always")},
+			},
+			expectedErr: errors.New("Failed to calculate HMAC from request body: Failed to close the request body: Fail always"),
+		},
+		{
+			name: "Reject request with empty HMAC version",
+			conf: NewDefaultHMACConf("LXD1.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{" 4022ad4878aff5a3bbd815aec63cce26cb5e8abd4df69589312cd0dee25fd717"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Version cannot be empty"),
+		},
+		{
+			name: "Reject request with empty HMAC",
+			conf: NewDefaultHMACConf("LXD1.0"),
+			key:  []byte("foo"),
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 "},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: HMAC cannot be empty"),
+		},
+		{
+			name:     "Reject request with empty argon2 salt",
+			conf:     NewDefaultHMACConf("LXD1.0"),
+			password: []byte("foo"),
+			hexSalt:  "caffee",
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 :abc"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Argon2 salt cannot be empty"),
+		},
+		{
+			name:     "Reject request with empty argon2 HMAC",
+			conf:     NewDefaultHMACConf("LXD1.0"),
+			password: []byte("foo"),
+			hexSalt:  "caffee",
+			request: &http.Request{
+				Header: http.Header{
+					"Authorization": []string{"LXD1.0 caffee:"},
+				},
+			},
+			expectedErr: errors.New("Failed to parse Authorization header: Argon2 HMAC cannot be empty"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			var hmac HMACFormatter
+			if tt.key != nil {
+				hmac = NewHMAC(tt.key, tt.conf)
+			}
+
+			if tt.password != nil {
+				salt, err := hex.DecodeString(tt.hexSalt)
+				require.NoError(t, err)
+
+				hmac, err = NewHMACArgon2(tt.password, salt, tt.conf)
+				require.NoError(t, err)
+			}
+
+			err = HMACEqual(hmac, tt.request)
+			if tt.expectedErr != nil {
+				require.Equal(t, tt.expectedErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds additional HMAC and cert utils to the `shared` package.

The HMAC implementation follows the practices from the [explicit trust establishment spec](https://discourse.ubuntu.com/t/explicit-trust-establishment-mechanism-for-microcloud/44261).
It's imported as a general utility in LXD to be used by MicroCloud during trust establishment.

In order to make the use of a KDF (in this case argon2) optional, there is a second factory function that allows using some extended functionality added by argon2.

To create a HMAC header, the caller runs:

```go
// Specific HMAC version to allow indicating protocol changes in the future.
const HMACMicroCloud10 trust.HMACVersion = "MicroCloud-1.0"

// Basic format
hmac := trust.NewHMAC(<key>, NewDefaultHMACConf("LXD1.0"))
// Create the "Authorization" header in the format `Authorization: <version> <HMAC>`
header, err := trust.HMACAuthorizationHeader(hmac, <message body to be sent>)

// Or custom format that extends HMAC with a KDF (in this case argon2).
hmac, err := trust.NewHMACArgon2(<password>, <salt or nil>, NewDefaultHMACConf("LXD1.0"))
// Create the "Authorization" header in the format `Authorization: <version> <salt>:<HMAC>`
header, err := trust.HMACAuthorizationHeader(hmac, <message body to be sent>)
```

On the server side the validation happens as follows:

```go
// Initialize the expected HMAC format
hmac, err := trust.NewHMACArgon2(<password>, <salt or nil>, NewDefaultHMACConf("LXD1.0"))

// Validate the HMAC based on the given *http.Request r
err = trust.HMACEqual(hmac, r)
```

