### PR TITLE
lxd: Disable networks during evacuation (from Incus)

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3269,6 +3269,9 @@ func evacuateClusterMember(s *state.State, gateway *cluster.Gateway, r *http.Req
 			return err
 		}
 
+		// Stop networks after evacuation.
+		networkShutdown(s)
+
 		revert.Success()
 		return nil
 	}
@@ -3438,6 +3441,12 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 		var sourceNode db.NodeInfo
 
 		metadata := make(map[string]any)
+
+		// Restart the networks.
+		err = networkStartup(d.State())
+		if err != nil {
+			return err
+		}
 
 		// Restart the local instances.
 		for _, inst := range localInstances {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1600,10 +1600,13 @@ func (d *Daemon) init() error {
 	})
 
 	// Setup the networks.
-	logger.Infof("Initializing networks")
-	err = networkStartup(d.State())
-	if err != nil {
-		return err
+	if !d.db.Cluster.LocalNodeIsEvacuated() {
+		logger.Infof("Initializing networks")
+
+		err = networkStartup(d.State())
+		if err != nil {
+			return err
+		}
 	}
 
 	// Setup tertiary listeners that may use managed network addresses and must be started after networks.


### PR DESCRIPTION
Stop networks when a cluster member has been evacuated.

Includes cherry-picks from https://github.com/lxc/incus/pull/747