### PR TITLE
storage: Conserve LV state (From Incus)

### DIFF
--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -449,16 +449,6 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 
 	l := d.logger.AddContext(logger.Ctx{"dev": volDevPath, "size": fmt.Sprintf("%db", sizeBytes)})
 
-	// Activate volume if needed.
-	activated, err := d.activateVolume(vol)
-	if err != nil {
-		return err
-	}
-
-	if activated {
-		defer func() { _, _ = d.deactivateVolume(vol) }()
-	}
-
 	inUse := vol.MountInUse()
 
 	// Resize filesystem if needed.
@@ -474,6 +464,12 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 				return ErrInUse // We don't allow online shrinking of filesytem volumes.
 			}
 
+			// Activate volume if needed.
+			_, err := d.activateVolume(vol)
+			if err != nil {
+				return err
+			}
+
 			// Shrink filesystem first.
 			// Pass allowUnsafeResize to allow disabling of filesystem resize safety checks.
 			// We do this as a separate step rather than passing -r to lvresize in resizeLogicalVolume
@@ -481,6 +477,13 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			// otherwise by passing -f to lvresize (required for other reasons) this would then pass
 			// -f onto resize2fs as well.
 			err = shrinkFileSystem(fsType, volDevPath, vol, sizeBytes, allowUnsafeResize)
+			if err != nil {
+				_, _ = d.deactivateVolume(vol)
+				return err
+			}
+
+			// Deactivate the volume if needed.
+			_, err = d.deactivateVolume(vol)
 			if err != nil {
 				return err
 			}
@@ -498,6 +501,16 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			if err != nil {
 				return err
 			}
+
+			// Activate the volume if needed.
+			_, err := d.activateVolume(vol)
+			if err != nil {
+				return err
+			}
+
+			defer func() {
+				_, _ = d.deactivateVolume(vol)
+			}()
 
 			// Grow the filesystem to fill block device.
 			err = growFileSystem(fsType, volDevPath, vol)
@@ -524,6 +537,16 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 		if err != nil {
 			return err
 		}
+
+		// Activate the volume if needed.
+		_, err := d.activateVolume(vol)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			_, _ = d.deactivateVolume(vol)
+		}()
 
 		// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as it is
 		// expected the caller will do all necessary post resize actions themselves).

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -465,9 +465,15 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			}
 
 			// Activate volume if needed.
-			_, err := d.activateVolume(vol)
+			activated, err := d.activateVolume(vol)
 			if err != nil {
 				return err
+			}
+
+			if !activated {
+				defer func() {
+					_, _ = d.activateVolume(vol)
+				}()
 			}
 
 			// Shrink filesystem first.
@@ -482,7 +488,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 				return err
 			}
 
-			// Deactivate the volume if needed.
+			// Deactivate the volume for resizing.
 			_, err = d.deactivateVolume(vol)
 			if err != nil {
 				return err
@@ -502,15 +508,17 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 				return err
 			}
 
-			// Activate the volume if needed.
-			_, err := d.activateVolume(vol)
+			// Activate the volume for resizing.
+			activated, err := d.activateVolume(vol)
 			if err != nil {
 				return err
 			}
 
-			defer func() {
-				_, _ = d.deactivateVolume(vol)
-			}()
+			if activated {
+				defer func() {
+					_, _ = d.deactivateVolume(vol)
+				}()
+			}
 
 			// Grow the filesystem to fill block device.
 			err = growFileSystem(fsType, volDevPath, vol)
@@ -538,19 +546,21 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			return err
 		}
 
-		// Activate the volume if needed.
-		_, err := d.activateVolume(vol)
-		if err != nil {
-			return err
-		}
-
-		defer func() {
-			_, _ = d.deactivateVolume(vol)
-		}()
-
 		// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as it is
 		// expected the caller will do all necessary post resize actions themselves).
 		if vol.IsVMBlock() && !allowUnsafeResize {
+			// Activate the volume for resizing.
+			activated, err := d.activateVolume(vol)
+			if err != nil {
+				return err
+			}
+
+			if activated {
+				defer func() {
+					_, _ = d.deactivateVolume(vol)
+				}()
+			}
+
 			err = d.moveGPTAltHeader(volDevPath)
 			if err != nil {
 				return err


### PR DESCRIPTION
Reactivates an already-active volume after its size has been increased. If a volume was active before being grown, it would be deactivated by `SetVolumeQuota`; this retains the state of the LV after a size adjustment.

Contains cherry-picks from https://github.com/lxc/incus/pull/1021 and https://github.com/lxc/incus/pull/1136

incus#1021 is only partially applied as its other commit depends on https://github.com/lxc/incus/pull/512; I've made a note of this in the tracking sheet.