### PR TITLE
Add methods to instantiate a `StatusError` without formatting

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -156,7 +157,7 @@ func (c *cmdRemoteAdd) runToken(server string, token string, rawToken *api.Certi
 	conf := c.global.conf
 
 	if !conf.HasClientCertificate() {
-		fmt.Fprintf(os.Stderr, i18n.G("Generating a client certificate. This may take a minute...")+"\n")
+		fmt.Fprint(os.Stderr, i18n.G("Generating a client certificate. This may take a minute...")+"\n")
 		err := conf.GenerateClientCertificate()
 		if err != nil {
 			return err
@@ -179,7 +180,7 @@ func (c *cmdRemoteAdd) runToken(server string, token string, rawToken *api.Certi
 	}
 
 	fmt.Println(i18n.G("All server addresses are unavailable"))
-	fmt.Printf(i18n.G("Please provide an alternate server address (empty to abort):") + " ")
+	fmt.Print(i18n.G("Please provide an alternate server address (empty to abort):") + " ")
 
 	line, err := shared.ReadStdin()
 	if err != nil {
@@ -187,7 +188,7 @@ func (c *cmdRemoteAdd) runToken(server string, token string, rawToken *api.Certi
 	}
 
 	if len(line) == 0 {
-		return fmt.Errorf(i18n.G("Failed to add remote"))
+		return errors.New(i18n.G("Failed to add remote"))
 	}
 
 	err = c.addRemoteFromToken(string(line), server, token, rawToken.Fingerprint)
@@ -221,7 +222,7 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 		dnam := conf.ConfigPath("servercerts")
 		err := os.MkdirAll(dnam, 0750)
 		if err != nil {
-			return fmt.Errorf(i18n.G("Could not create server cert dir"))
+			return errors.New(i18n.G("Could not create server cert dir"))
 		}
 
 		certf := conf.ServerCertPath(server)
@@ -290,12 +291,12 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(addr) == 0 {
-		return fmt.Errorf(i18n.G("Remote address must not be empty"))
+		return errors.New(i18n.G("Remote address must not be empty"))
 	}
 
 	// Validate the server name.
 	if strings.Contains(server, ":") {
-		return fmt.Errorf(i18n.G("Remote names may not contain colons"))
+		return errors.New(i18n.G("Remote names may not contain colons"))
 	}
 
 	// Check for existing remote
@@ -332,7 +333,7 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 	// Fast track simplestreams
 	if c.flagProtocol == "simplestreams" {
 		if remoteURL.Scheme != "https" {
-			return fmt.Errorf(i18n.G("Only https URLs are supported for simplestreams"))
+			return errors.New(i18n.G("Only https URLs are supported for simplestreams"))
 		}
 
 		conf.Remotes[server] = config.Remote{Addr: addr, Public: true, Protocol: c.flagProtocol}
@@ -397,7 +398,7 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 	// adding the remote server.
 	if rScheme != "unix" && !c.flagPublic && (c.flagAuthType == api.AuthenticationMethodTLS || c.flagAuthType == "") {
 		if !conf.HasClientCertificate() {
-			fmt.Fprintf(os.Stderr, i18n.G("Generating a client certificate. This may take a minute...")+"\n")
+			fmt.Fprint(os.Stderr, i18n.G("Generating a client certificate. This may take a minute...")+"\n")
 			err = conf.GenerateClientCertificate()
 			if err != nil {
 				return err
@@ -451,8 +452,8 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 		if !c.flagAcceptCert {
 			digest := shared.CertFingerprint(certificate)
 
-			fmt.Printf(i18n.G("Certificate fingerprint: %s")+"\n", digest)
-			fmt.Printf(i18n.G("ok (y/n/[fingerprint])?") + " ")
+			fmt.Printf("%s: %s\n", i18n.G("Certificate fingerprint"), digest)
+			fmt.Print(i18n.G("ok (y/n/[fingerprint])?") + " ")
 			line, err := shared.ReadStdin()
 			if err != nil {
 				return err
@@ -460,9 +461,9 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 
 			if string(line) != digest {
 				if len(line) < 1 || strings.ToLower(string(line[0])) == i18n.G("n") {
-					return fmt.Errorf(i18n.G("Server certificate NACKed by user"))
+					return errors.New(i18n.G("Server certificate NACKed by user"))
 				} else if strings.ToLower(string(line[0])) != i18n.G("y") {
-					return fmt.Errorf(i18n.G("Please type 'y', 'n' or the fingerprint:"))
+					return errors.New(i18n.G("Please type 'y', 'n' or the fingerprint:"))
 				}
 			}
 		}
@@ -470,7 +471,7 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 		dnam := conf.ConfigPath("servercerts")
 		err := os.MkdirAll(dnam, 0750)
 		if err != nil {
-			return fmt.Errorf(i18n.G("Could not create server cert dir"))
+			return errors.New(i18n.G("Could not create server cert dir"))
 		}
 
 		certf := conf.ServerCertPath(server)
@@ -612,7 +613,7 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 		}
 
 		if srv.Auth != "trusted" {
-			return fmt.Errorf(i18n.G("Server doesn't trust us after authentication"))
+			return errors.New(i18n.G("Server doesn't trust us after authentication"))
 		}
 
 		if c.flagAuthType == api.AuthenticationMethodTLS {
@@ -874,7 +875,7 @@ func (c *cmdRemoteRemove) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if conf.DefaultRemote == args[0] {
-		return fmt.Errorf(i18n.G("Can't remove the default remote"))
+		return errors.New(i18n.G("Can't remove the default remote"))
 	}
 
 	delete(conf.Remotes, args[0])

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -210,7 +210,7 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 	if err != nil {
 		certificate, err = shared.GetRemoteCertificate(addr, c.global.conf.UserAgent)
 		if err != nil {
-			return api.StatusErrorf(http.StatusServiceUnavailable, i18n.G("Unavailable remote server")+": %w", err)
+			return api.StatusErrorf(http.StatusServiceUnavailable, "%s: %w", i18n.G("Unavailable remote server"), err)
 		}
 
 		certDigest := shared.CertFingerprint(certificate)
@@ -244,7 +244,7 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 
 	d, err := conf.GetInstanceServer(server)
 	if err != nil {
-		return api.StatusErrorf(http.StatusServiceUnavailable, i18n.G("Unavailable remote server")+": %w", err)
+		return api.StatusErrorf(http.StatusServiceUnavailable, "%s: %w", i18n.G("Unavailable remote server"), err)
 	}
 
 	req := api.CertificatesPost{}

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -133,7 +133,7 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 
 	// Untrusted requests are denied.
 	if !auth.IsTrusted(ctx) {
-		return api.StatusErrorf(http.StatusForbidden, "%s", http.StatusText(http.StatusForbidden))
+		return api.NewGenericStatusError(http.StatusForbidden)
 	}
 
 	isRoot, err := auth.IsServerAdmin(ctx, e.identityCache)
@@ -284,7 +284,7 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 			l.Info("Access denied", logger.Ctx{"http_code": responseCode})
 		}
 
-		return api.StatusErrorf(responseCode, "%s", http.StatusText(responseCode))
+		return api.NewGenericStatusError(responseCode)
 	}
 
 	return nil

--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -43,7 +43,7 @@ func (t *tls) load(ctx context.Context, identityCache *identity.Cache, opts Opts
 func (t *tls) CheckPermission(ctx context.Context, entityURL *api.URL, entitlement auth.Entitlement) error {
 	// Untrusted requests are denied.
 	if !auth.IsTrusted(ctx) {
-		return api.StatusErrorf(http.StatusForbidden, "%s", http.StatusText(http.StatusForbidden))
+		return api.NewGenericStatusError(http.StatusForbidden)
 	}
 
 	isRoot, err := auth.IsServerAdmin(ctx, t.identities)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -249,7 +249,7 @@ func devlxdAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter,
 
 		err := json.NewDecoder(r.Body).Decode(&req)
 		if err != nil {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusBadRequest, err.Error()), c.Type() == instancetype.VM)
+			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusBadRequest, "Invalid request body: %w", err), c.Type() == instancetype.VM)
 		}
 
 		state := api.StatusCodeFromString(req.State)
@@ -260,7 +260,7 @@ func devlxdAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter,
 
 		err = c.VolatileSet(map[string]string{"volatile.last_state.ready": strconv.FormatBool(state == api.Ready)})
 		if err != nil {
-			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, err.Error()), c.Type() == instancetype.VM)
+			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "Failed to set instance state: %w", err), c.Type() == instancetype.VM)
 		}
 
 		if state == api.Ready {
@@ -270,7 +270,7 @@ func devlxdAPIHandlerFunc(d *Daemon, c instance.Instance, w http.ResponseWriter,
 		return response.DevLxdResponse(http.StatusOK, "", "raw", c.Type() == instancetype.VM)
 	}
 
-	return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusMethodNotAllowed, fmt.Sprintf("method %q not allowed", r.Method)), c.Type() == instancetype.VM)
+	return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusMethodNotAllowed, "method %q not allowed", r.Method), c.Type() == instancetype.VM)
 }
 
 var devlxdDevicesGet = devLxdHandler{

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -505,7 +505,7 @@ func (m *Monitor) RemoveBlockDevice(blockDevName string) error {
 		err := m.run("blockdev-del", blockDevName, nil)
 		if err != nil {
 			if strings.Contains(err.Error(), "is in use") {
-				return api.StatusErrorf(http.StatusLocked, err.Error())
+				return api.StatusErrorf(http.StatusLocked, "%w", err)
 			}
 
 			if strings.Contains(err.Error(), "Failed to find") {

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -135,7 +135,7 @@ func (r *sftpServeResponse) Render(w http.ResponseWriter) error {
 
 	err = response.Upgrade(remoteConn, "sftp")
 	if err != nil {
-		return api.StatusErrorf(http.StatusInternalServerError, err.Error())
+		return api.StatusErrorf(http.StatusInternalServerError, "Failed to upgrade SFTP connection: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(r.req.Context())

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1632,7 +1632,7 @@ func CheckTargetMember(p *api.Project, targetMemberName string, allMembers []db.
 			// If restricted groups are specified then check member is in at least one of them.
 			err := AllowClusterMember(p, &potentialMember)
 			if err != nil {
-				return nil, api.StatusErrorf(http.StatusForbidden, err.Error())
+				return nil, api.StatusErrorf(http.StatusForbidden, "%w", err)
 			}
 
 			return &potentialMember, nil
@@ -1647,7 +1647,7 @@ func CheckTargetGroup(ctx context.Context, tx *db.ClusterTx, p *api.Project, gro
 	// If restricted groups are specified then check the requested group is in the list.
 	err := AllowClusterGroup(p, groupName)
 	if err != nil {
-		return api.StatusErrorf(http.StatusForbidden, err.Error())
+		return api.StatusErrorf(http.StatusForbidden, "%w", err)
 	}
 
 	// Check if the target group exists.

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -631,11 +631,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -739,7 +739,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1054,15 +1054,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1074,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1322,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1366,7 +1365,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1716,9 +1715,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2256,7 +2255,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2271,11 +2270,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2285,7 +2284,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2295,12 +2294,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2325,7 +2324,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2408,7 +2407,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2446,7 +2445,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2466,7 +2465,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2887,7 +2886,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3024,7 +3023,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3343,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3642,7 +3641,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3985,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4012,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4039,7 +4038,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4241,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4312,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4345,7 +4344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4357,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4488,7 +4487,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4586,7 +4585,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4677,45 +4676,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4797,7 +4796,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4854,7 +4853,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -4999,7 +4998,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5036,19 +5035,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5255,7 +5254,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5486,7 +5485,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5698,7 +5697,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5944,7 +5943,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6008,7 +6007,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6051,7 +6050,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6079,7 +6078,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6099,7 +6098,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6402,7 +6401,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7051,7 +7050,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7059,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7445,7 +7444,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7457,7 +7456,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7494,7 +7493,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -774,15 +774,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
@@ -905,11 +905,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -979,7 +979,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -1018,7 +1018,7 @@ msgstr "Aliasse:\n"
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1042,7 +1042,7 @@ msgstr "Architektur: %s\n"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1119,7 +1119,7 @@ msgstr "automatisches Update: %s"
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 #, fuzzy
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1357,16 +1357,16 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+#, fuzzy
+msgid "Certificate fingerprint"
+msgstr "Fingerabdruck des Zertifikats: % x\n"
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
-
-#: lxc/remote.go:454
-#, fuzzy, c-format
-msgid "Certificate fingerprint: %s"
-msgstr "Fingerabdruck des Zertifikats: % x\n"
 
 #: lxc/network.go:893
 msgid "Chassis"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1634,12 +1634,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1678,7 +1678,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -2060,9 +2060,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2645,7 +2645,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2660,11 +2660,11 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2674,7 +2674,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2684,12 +2684,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2714,7 +2714,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2801,7 +2801,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3393,7 +3393,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3454,7 +3454,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3804,7 +3804,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -4144,7 +4144,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4517,7 +4517,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4544,7 +4544,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4571,7 +4571,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4779,7 +4779,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4850,11 +4850,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4884,7 +4884,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
@@ -4898,7 +4898,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5034,7 +5034,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5133,7 +5133,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -5230,45 +5230,45 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -5363,7 +5363,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5427,7 +5427,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5582,7 +5582,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5619,21 +5619,21 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5854,7 +5854,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6113,7 +6113,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -6337,7 +6337,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6594,7 +6594,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6658,7 +6658,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6702,7 +6702,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6730,7 +6730,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
@@ -6751,7 +6751,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, fuzzy, c-format
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7091,7 +7091,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -8356,7 +8356,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8373,7 +8373,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -8763,7 +8763,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -8775,7 +8775,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8812,7 +8812,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -636,11 +636,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -745,7 +745,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1061,15 +1061,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1081,7 +1080,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1329,12 +1328,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1373,7 +1372,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1731,9 +1730,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2281,7 +2280,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2296,11 +2295,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2310,7 +2309,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2320,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2350,7 +2349,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2433,7 +2432,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2471,7 +2470,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2491,7 +2490,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2925,7 +2924,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3006,7 +3005,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3062,7 +3061,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3383,7 +3382,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3695,7 +3694,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4050,7 +4049,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4077,7 +4076,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4104,7 +4103,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4308,7 +4307,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4379,11 +4378,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4412,7 +4411,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4425,7 +4424,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4556,7 +4555,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4654,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4745,45 +4744,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4869,7 +4868,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4927,7 +4926,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5073,7 +5072,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5110,19 +5109,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5336,7 +5335,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5583,7 +5582,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5796,7 +5795,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6043,7 +6042,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6107,7 +6106,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6150,7 +6149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6178,7 +6177,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6198,7 +6197,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6518,7 +6517,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7167,7 +7166,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7175,7 +7174,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7561,7 +7560,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7573,7 +7572,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7610,7 +7609,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,15 +757,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -807,7 +807,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
@@ -880,11 +880,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -952,7 +952,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -989,7 +989,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1013,7 +1013,7 @@ msgstr "Arquitectura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1085,7 +1085,7 @@ msgstr "Auto actualización: %s"
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1311,16 +1311,16 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+#, fuzzy
+msgid "Certificate fingerprint"
+msgstr "Certificado de la huella digital: %s"
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
-msgstr "Certificado de la huella digital: %s"
 
 #: lxc/network.go:893
 msgid "Chassis"
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1584,12 +1584,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1628,7 +1628,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1992,9 +1992,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2546,7 +2546,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
@@ -2561,11 +2561,11 @@ msgstr "Acepta certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2575,7 +2575,7 @@ msgstr "Acepta certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2585,12 +2585,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2615,7 +2615,7 @@ msgstr "Acepta certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2699,7 +2699,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2737,7 +2737,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3199,7 +3199,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3281,7 +3281,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3338,7 +3338,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3670,7 +3670,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4376,7 +4376,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4403,7 +4403,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4605,7 +4605,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4676,11 +4676,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4709,7 +4709,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4857,7 +4857,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4955,7 +4955,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -5048,46 +5048,46 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -5174,7 +5174,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5233,7 +5233,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5384,7 +5384,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5421,19 +5421,19 @@ msgstr "Creado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5648,7 +5648,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5896,7 +5896,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -6110,7 +6110,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6360,7 +6360,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6424,7 +6424,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6469,7 +6469,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6497,7 +6497,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6517,7 +6517,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6839,7 +6839,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7630,7 +7630,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7640,7 +7640,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -8026,7 +8026,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -8038,7 +8038,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8075,7 +8075,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -764,17 +764,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -817,7 +817,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -826,7 +826,7 @@ msgstr "TYPE"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -901,11 +901,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -984,7 +984,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -1022,7 +1022,7 @@ msgstr "Alias :"
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr "Architecture : %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1122,7 +1122,7 @@ msgstr "Mise à jour auto. : %s"
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 #, fuzzy
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
@@ -1282,7 +1282,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1351,16 +1351,16 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+#, fuzzy
+msgid "Certificate fingerprint"
+msgstr "Empreinte du certificat : %s"
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
-msgstr "Empreinte du certificat : %s"
 
 #: lxc/network.go:893
 msgid "Chassis"
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1637,12 +1637,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1681,7 +1681,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -2084,9 +2084,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2676,7 +2676,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2691,12 +2691,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2706,7 +2706,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2716,12 +2716,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2746,7 +2746,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2834,7 +2834,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2892,7 +2892,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -3354,7 +3354,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3437,7 +3437,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3495,7 +3495,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3891,7 +3891,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -4225,7 +4225,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4604,7 +4604,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr "NOM"
@@ -4631,7 +4631,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr "NON"
 
@@ -4659,7 +4659,7 @@ msgstr ""
 msgid "Name"
 msgstr "Nom : %s"
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4873,7 +4873,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4949,11 +4949,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4984,7 +4984,7 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
@@ -4998,7 +4998,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr "Profil %s supprimé"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5233,7 +5233,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -5333,45 +5333,45 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Ajouter de nouveaux clients de confiance"
@@ -5467,7 +5467,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5531,7 +5531,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5703,7 +5703,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5743,21 +5743,21 @@ msgstr "Créé : %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -5980,7 +5980,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6244,7 +6244,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6471,7 +6471,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6732,7 +6732,7 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6798,7 +6798,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6843,7 +6843,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr "URL"
 
@@ -6871,7 +6871,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
@@ -6892,7 +6892,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -7233,7 +7233,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr "OUI"
 
@@ -8609,7 +8609,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8629,7 +8629,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -9038,7 +9038,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -9051,7 +9051,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9088,7 +9088,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr "o"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1058,15 +1058,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1078,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1326,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1369,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1720,9 +1719,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2260,7 +2259,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2275,11 +2274,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2289,7 +2288,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2299,12 +2298,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2329,7 +2328,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2412,7 +2411,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2449,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,7 +2469,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2891,7 +2890,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2971,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3028,7 +3027,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3347,7 +3346,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3646,7 +3645,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3989,7 +3988,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4016,7 +4015,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4043,7 +4042,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4245,7 +4244,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4316,11 +4315,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4349,7 +4348,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4361,7 +4360,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4492,7 +4491,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4590,7 +4589,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4681,45 +4680,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4801,7 +4800,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4858,7 +4857,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5003,7 +5002,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5040,19 +5039,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5259,7 +5258,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5490,7 +5489,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5702,7 +5701,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5948,7 +5947,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6012,7 +6011,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6055,7 +6054,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6083,7 +6082,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6103,7 +6102,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6406,7 +6405,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7055,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7063,7 +7062,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7449,7 +7448,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7461,7 +7460,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7498,7 +7497,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -759,15 +759,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -882,11 +882,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -991,7 +991,7 @@ msgstr "Alias:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr "Architettura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1064,7 +1064,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1087,7 +1087,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1309,15 +1309,15 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+#, fuzzy
+msgid "Certificate fingerprint"
+msgstr "Creazione del container in corso"
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1578,12 +1578,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1622,7 +1622,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1987,9 +1987,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2542,7 +2542,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
@@ -2557,11 +2557,11 @@ msgstr "Accetta certificato"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2571,7 +2571,7 @@ msgstr "Accetta certificato"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2581,12 +2581,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2611,7 +2611,7 @@ msgstr "Accetta certificato"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2696,7 +2696,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2754,7 +2754,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3191,7 +3191,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3274,7 +3274,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3331,7 +3331,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3664,7 +3664,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3984,7 +3984,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4347,7 +4347,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4374,7 +4374,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4604,7 +4604,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4675,11 +4675,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4709,7 +4709,7 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4855,7 +4855,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4953,7 +4953,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -5047,46 +5047,46 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -5174,7 +5174,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5233,7 +5233,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5384,7 +5384,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5421,19 +5421,19 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5646,7 +5646,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5892,7 +5892,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -6108,7 +6108,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6358,7 +6358,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6422,7 +6422,7 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6466,7 +6466,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6494,7 +6494,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
@@ -6515,7 +6515,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6833,7 +6833,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7627,7 +7627,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
@@ -7637,7 +7637,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -8023,7 +8023,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -8036,7 +8036,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8073,7 +8073,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 
@@ -8107,10 +8107,6 @@ msgstr "si"
 
 #, fuzzy
 #~ msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
-#~ msgstr "Creazione del container in corso"
-
-#, fuzzy
-#~ msgid "[<remote>:] <fingerprint>"
 #~ msgstr "Creazione del container in corso"
 
 #, fuzzy

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -749,15 +749,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -792,7 +792,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -800,7 +800,7 @@ msgstr "AUTH TYPE"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -872,11 +872,11 @@ msgstr "グループからメンバーを削除します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -962,7 +962,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -999,7 +999,7 @@ msgstr "エイリアス:"
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
@@ -1023,7 +1023,7 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "本当に %s しますか? （対象: クラスターメンバー %q） (yes/no) [default=no]: "
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
@@ -1075,7 +1075,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1098,7 +1098,7 @@ msgstr "自動更新: %s"
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1325,17 +1325,17 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+#, fuzzy
+msgid "Certificate fingerprint"
+msgstr "証明書のフィンガープリント: %s"
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
-msgstr "証明書のフィンガープリント: %s"
 
 #: lxc/network.go:893
 msgid "Chassis"
@@ -1346,7 +1346,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1613,12 +1613,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1657,7 +1657,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -2015,9 +2015,9 @@ msgstr "警告を削除します"
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2593,7 +2593,7 @@ msgstr "デバイス上書きのためのプロファイル %q のロードに�
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
@@ -2608,11 +2608,11 @@ msgstr "sshfs の起動に失敗しました: %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
@@ -2622,7 +2622,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2632,12 +2632,12 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2662,7 +2662,7 @@ msgstr "エイリアス %s の削除に失敗しました: %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
@@ -2761,7 +2761,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2799,7 +2799,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -3264,7 +3264,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3353,7 +3353,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3409,7 +3409,7 @@ msgstr "LOCATION"
 msgid "LXD - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
@@ -3856,7 +3856,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -4195,7 +4195,7 @@ msgstr ""
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
@@ -4561,7 +4561,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr "NAME"
@@ -4588,7 +4588,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr "NO"
 
@@ -4615,7 +4615,7 @@ msgstr "NVRM バージョン: %v"
 msgid "Name"
 msgstr "名前"
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
@@ -4820,7 +4820,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4891,11 +4891,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4924,7 +4924,7 @@ msgstr "インスタンスを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
@@ -4936,7 +4936,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -5069,7 +5069,7 @@ msgstr "プロジェクト %s を削除しました"
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
@@ -5170,7 +5170,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -5263,45 +5263,45 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 #, fuzzy
 msgid "Remote trust token"
 msgstr "信頼済みクライアントを削除します"
@@ -5387,7 +5387,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5446,7 +5446,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -5600,7 +5600,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5637,20 +5637,20 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 #, fuzzy
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -5915,7 +5915,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -6158,7 +6158,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -6370,7 +6370,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6637,7 +6637,7 @@ msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
@@ -6707,7 +6707,7 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -6752,7 +6752,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr "URL"
 
@@ -6780,7 +6780,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
@@ -6800,7 +6800,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
@@ -7122,7 +7122,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr "YES"
 
@@ -7803,7 +7803,7 @@ msgstr "[<remote>:][<instance>] <key>=<value>..."
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
@@ -7812,7 +7812,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr "現在値"
 
@@ -8365,7 +8365,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr "n"
 
@@ -8377,7 +8377,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -8416,7 +8416,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr "y"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -631,11 +631,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -739,7 +739,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1054,15 +1054,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1074,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1322,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1366,7 +1365,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1716,9 +1715,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2256,7 +2255,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2271,11 +2270,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2285,7 +2284,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2295,12 +2294,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2325,7 +2324,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2408,7 +2407,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2446,7 +2445,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2466,7 +2465,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2887,7 +2886,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3024,7 +3023,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3343,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3642,7 +3641,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3985,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4012,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4039,7 +4038,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4241,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4312,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4345,7 +4344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4357,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4488,7 +4487,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4586,7 +4585,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4677,45 +4676,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4797,7 +4796,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4854,7 +4853,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -4999,7 +4998,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5036,19 +5035,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5255,7 +5254,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5486,7 +5485,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5698,7 +5697,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5944,7 +5943,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6008,7 +6007,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6051,7 +6050,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6079,7 +6078,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6099,7 +6098,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6402,7 +6401,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7051,7 +7050,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7059,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7445,7 +7444,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7457,7 +7456,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7494,7 +7493,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-08-23 10:25-0500\n"
+        "POT-Creation-Date: 2024-08-27 13:17+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -482,15 +482,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -522,7 +522,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -530,7 +530,7 @@ msgstr  ""
 msgid   "AUTHENTICATION METHOD"
 msgstr  ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -600,11 +600,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -664,7 +664,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -701,7 +701,7 @@ msgstr  ""
 msgid   "All projects"
 msgstr  ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -724,7 +724,7 @@ msgstr  ""
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
@@ -771,7 +771,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -794,7 +794,7 @@ msgstr  ""
 msgid   "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr  ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid   "Available projects:"
 msgstr  ""
 
@@ -947,7 +947,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -1012,14 +1012,13 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:218
-#, c-format
-msgid   "Certificate fingerprint mismatch between certificate token and server %q"
+#: lxc/remote.go:455
+msgid   "Certificate fingerprint"
 msgstr  ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:219
 #, c-format
-msgid   "Certificate fingerprint: %s"
+msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
 #: lxc/network.go:893
@@ -1031,7 +1030,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1236,12 +1235,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1280,7 +1279,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1539,7 +1538,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930 lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172 lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354 lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:171 lxc/network_forward.go:236 lxc/network_forward.go:379 lxc/network_forward.go:448 lxc/network_forward.go:546 lxc/network_forward.go:576 lxc/network_forward.go:718 lxc/network_forward.go:780 lxc/network_forward.go:795 lxc/network_forward.go:860 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383 lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549 lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722 lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:394 lxc/profile.go:444 lxc/profile.go:572 lxc/profile.go:633 lxc/profile.go:694 lxc/profile.go:770 lxc/profile.go:822 lxc/profile.go:898 lxc/profile.go:954 lxc/project.go:29 lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372 lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682 lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90 lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844 lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1017 lxc/storage_bucket.go:1152 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:263 lxc/storage_volume.go:354 lxc/storage_volume.go:557 lxc/storage_volume.go:636 lxc/storage_volume.go:711 lxc/storage_volume.go:793 lxc/storage_volume.go:874 lxc/storage_volume.go:1083 lxc/storage_volume.go:1198 lxc/storage_volume.go:1345 lxc/storage_volume.go:1429 lxc/storage_volume.go:1674 lxc/storage_volume.go:1755 lxc/storage_volume.go:1870 lxc/storage_volume.go:2014 lxc/storage_volume.go:2123 lxc/storage_volume.go:2169 lxc/storage_volume.go:2266 lxc/storage_volume.go:2333 lxc/storage_volume.go:2487 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:731 lxc/config.go:855 lxc/config.go:890 lxc/config.go:930 lxc/config.go:985 lxc/config.go:1076 lxc/config.go:1107 lxc/config.go:1161 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172 lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:901 lxc/image.go:1035 lxc/image.go:1354 lxc/image.go:1441 lxc/image.go:1499 lxc/image.go:1550 lxc/image.go:1605 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:32 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:48 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:171 lxc/network_forward.go:236 lxc/network_forward.go:379 lxc/network_forward.go:448 lxc/network_forward.go:546 lxc/network_forward.go:576 lxc/network_forward.go:718 lxc/network_forward.go:780 lxc/network_forward.go:795 lxc/network_forward.go:860 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:238 lxc/network_load_balancer.go:383 lxc/network_load_balancer.go:451 lxc/network_load_balancer.go:549 lxc/network_load_balancer.go:579 lxc/network_load_balancer.go:722 lxc/network_load_balancer.go:783 lxc/network_load_balancer.go:798 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:948 lxc/network_load_balancer.go:963 lxc/network_load_balancer.go:1024 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:394 lxc/profile.go:444 lxc/profile.go:572 lxc/profile.go:633 lxc/profile.go:694 lxc/profile.go:770 lxc/profile.go:822 lxc/profile.go:898 lxc/profile.go:954 lxc/project.go:29 lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372 lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682 lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845 lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1017 lxc/storage_bucket.go:1152 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:263 lxc/storage_volume.go:354 lxc/storage_volume.go:557 lxc/storage_volume.go:636 lxc/storage_volume.go:711 lxc/storage_volume.go:793 lxc/storage_volume.go:874 lxc/storage_volume.go:1083 lxc/storage_volume.go:1198 lxc/storage_volume.go:1345 lxc/storage_volume.go:1429 lxc/storage_volume.go:1674 lxc/storage_volume.go:1755 lxc/storage_volume.go:1870 lxc/storage_volume.go:2014 lxc/storage_volume.go:2123 lxc/storage_volume.go:2169 lxc/storage_volume.go:2266 lxc/storage_volume.go:2333 lxc/storage_volume.go:2487 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -2028,7 +2027,7 @@ msgstr  ""
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid   "Failed starting command: %w"
 msgstr  ""
@@ -2043,11 +2042,11 @@ msgstr  ""
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -2057,7 +2056,7 @@ msgstr  ""
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -2067,12 +2066,12 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -2097,7 +2096,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -2166,7 +2165,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435 lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1446 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1061 lxc/image_alias.go:157 lxc/list.go:132 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435 lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2202,7 +2201,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2222,7 +2221,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2640,7 +2639,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2720,7 +2719,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -2772,7 +2771,7 @@ msgstr  ""
 msgid   "LXD - Command line client"
 msgstr  ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
@@ -3079,7 +3078,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3374,7 +3373,7 @@ msgid   "Manage storage volumes\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
@@ -3643,7 +3642,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521 lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521 lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid   "NAME"
 msgstr  ""
 
@@ -3667,7 +3666,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479 lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499 lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479 lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499 lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid   "NO"
 msgstr  ""
 
@@ -3693,7 +3692,7 @@ msgstr  ""
 msgid   "Name"
 msgstr  ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
@@ -3894,7 +3893,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3965,11 +3964,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -3998,7 +3997,7 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -4010,7 +4009,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -4132,7 +4131,7 @@ msgstr  ""
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid   "Project to use for the remote"
 msgstr  ""
 
@@ -4214,7 +4213,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Removes the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid   "Public image server"
 msgstr  ""
 
@@ -4305,44 +4304,44 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921 lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922 lxc/remote.go:962
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid   "Remote address must not be empty"
 msgstr  ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid   "Remote trust token"
 msgstr  ""
 
@@ -4424,7 +4423,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4480,7 +4479,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4622,7 +4621,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid   "STATIC"
 msgstr  ""
 
@@ -4659,19 +4658,19 @@ msgstr  ""
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -4850,7 +4849,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -5075,7 +5074,7 @@ msgid   "Show the current identity\n"
         "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -5287,7 +5286,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5522,7 +5521,7 @@ msgstr  ""
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
@@ -5584,7 +5583,7 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
@@ -5624,7 +5623,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid   "URL"
 msgstr  ""
 
@@ -5650,7 +5649,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -5669,7 +5668,7 @@ msgstr  ""
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid   "Unknown console type %q"
 msgstr  ""
@@ -5962,7 +5961,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481 lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501 lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481 lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501 lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid   "YES"
 msgstr  ""
 
@@ -6574,7 +6573,7 @@ msgstr  ""
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
@@ -6582,7 +6581,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid   "current"
 msgstr  ""
 
@@ -6901,7 +6900,7 @@ msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid   "n"
 msgstr  ""
 
@@ -6913,7 +6912,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6950,7 +6949,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -739,15 +739,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -780,7 +780,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -858,11 +858,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -966,7 +966,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -989,7 +989,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1037,7 +1037,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1281,15 +1281,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1301,7 +1300,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1549,12 +1548,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1593,7 +1592,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1943,9 +1942,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2483,7 +2482,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2498,11 +2497,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2512,7 +2511,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2522,12 +2521,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2552,7 +2551,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2635,7 +2634,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2673,7 +2672,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2693,7 +2692,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3114,7 +3113,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3195,7 +3194,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3251,7 +3250,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3570,7 +3569,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3869,7 +3868,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4212,7 +4211,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4239,7 +4238,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4266,7 +4265,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4468,7 +4467,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4539,11 +4538,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4572,7 +4571,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4584,7 +4583,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4715,7 +4714,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4813,7 +4812,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4904,45 +4903,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -5024,7 +5023,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5081,7 +5080,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5226,7 +5225,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5263,19 +5262,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5482,7 +5481,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5713,7 +5712,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5925,7 +5924,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6171,7 +6170,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6235,7 +6234,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6278,7 +6277,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6306,7 +6305,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6326,7 +6325,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6629,7 +6628,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7278,7 +7277,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7286,7 +7285,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7672,7 +7671,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7684,7 +7683,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7721,7 +7720,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -777,15 +777,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -826,7 +826,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -896,11 +896,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1075,7 +1075,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1319,15 +1319,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1339,7 +1338,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1587,12 +1586,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1631,7 +1630,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1981,9 +1980,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2521,7 +2520,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2536,11 +2535,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2550,7 +2549,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2560,12 +2559,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2590,7 +2589,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2673,7 +2672,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2711,7 +2710,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2731,7 +2730,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3152,7 +3151,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3233,7 +3232,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3289,7 +3288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3608,7 +3607,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3907,7 +3906,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4250,7 +4249,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4277,7 +4276,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4304,7 +4303,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4506,7 +4505,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4577,11 +4576,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4610,7 +4609,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4622,7 +4621,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4753,7 +4752,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4851,7 +4850,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4942,45 +4941,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -5062,7 +5061,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5119,7 +5118,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5264,7 +5263,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5301,19 +5300,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5520,7 +5519,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5751,7 +5750,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5963,7 +5962,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6209,7 +6208,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6273,7 +6272,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6316,7 +6315,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6344,7 +6343,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6364,7 +6363,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6667,7 +6666,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7316,7 +7315,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7324,7 +7323,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7710,7 +7709,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7722,7 +7721,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7759,7 +7758,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -631,11 +631,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -739,7 +739,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1054,15 +1054,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1074,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1322,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1366,7 +1365,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1716,9 +1715,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2256,7 +2255,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2271,11 +2270,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2285,7 +2284,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2295,12 +2294,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2325,7 +2324,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2408,7 +2407,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2446,7 +2445,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2466,7 +2465,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2887,7 +2886,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3024,7 +3023,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3343,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3642,7 +3641,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3985,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4012,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4039,7 +4038,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4241,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4312,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4345,7 +4344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4357,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4488,7 +4487,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4586,7 +4585,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4677,45 +4676,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4797,7 +4796,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4854,7 +4853,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -4999,7 +4998,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5036,19 +5035,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5255,7 +5254,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5486,7 +5485,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5698,7 +5697,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5944,7 +5943,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6008,7 +6007,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6051,7 +6050,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6079,7 +6078,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6099,7 +6098,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6402,7 +6401,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7051,7 +7050,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7059,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7445,7 +7444,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7457,7 +7456,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7494,7 +7493,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -823,7 +823,7 @@ msgstr "TIPO DE AUTENTICAÇÃO"
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
@@ -897,11 +897,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -1010,7 +1010,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgstr "Arquitetura: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1088,7 +1088,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1111,7 +1111,7 @@ msgstr "Atualização automática: %s"
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
@@ -1268,7 +1268,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1335,16 +1335,16 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+#, fuzzy
+msgid "Certificate fingerprint"
+msgstr "Certificado fingerprint: %s"
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
-msgstr "Certificado fingerprint: %s"
 
 #: lxc/network.go:893
 msgid "Chassis"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1615,12 +1615,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1659,7 +1659,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -2039,9 +2039,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2605,7 +2605,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
@@ -2620,11 +2620,11 @@ msgstr "Aceitar certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2634,7 +2634,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2644,12 +2644,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2674,7 +2674,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2758,7 +2758,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2796,7 +2796,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3259,7 +3259,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3341,7 +3341,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3726,7 +3726,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -4050,7 +4050,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4413,7 +4413,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4440,7 +4440,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4467,7 +4467,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4669,7 +4669,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4740,11 +4740,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4786,7 +4786,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5020,7 +5020,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -5114,46 +5114,46 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Adicionar novos clientes confiáveis"
@@ -5247,7 +5247,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5308,7 +5308,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5463,7 +5463,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5500,19 +5500,19 @@ msgstr "Criado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5732,7 +5732,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5989,7 +5989,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -6204,7 +6204,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6456,7 +6456,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6520,7 +6520,7 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6564,7 +6564,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6592,7 +6592,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
@@ -6613,7 +6613,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6942,7 +6942,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7662,7 +7662,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
@@ -7672,7 +7672,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -8058,7 +8058,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -8070,7 +8070,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8107,7 +8107,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -819,7 +819,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -827,7 +827,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -901,11 +901,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -1011,7 +1011,7 @@ msgstr "Псевдонимы:"
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr "Архитектура: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1108,7 +1108,7 @@ msgstr "Авто-обновление: %s"
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1332,15 +1332,18 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+#, fuzzy
+msgid "Certificate fingerprint"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1352,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1603,12 +1606,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1647,7 +1650,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -2025,9 +2028,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2589,7 +2592,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
@@ -2604,11 +2607,11 @@ msgstr "Принять сертификат"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2618,7 +2621,7 @@ msgstr "Принять сертификат"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2628,12 +2631,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2658,7 +2661,7 @@ msgstr "Принять сертификат"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2742,7 +2745,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2780,7 +2783,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2800,7 +2803,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3245,7 +3248,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3327,7 +3330,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3384,7 +3387,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3720,7 +3723,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -4047,7 +4050,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4414,7 +4417,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4441,7 +4444,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4468,7 +4471,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4674,7 +4677,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4745,11 +4748,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4778,7 +4781,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4791,7 +4794,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4922,7 +4925,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5020,7 +5023,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -5115,46 +5118,46 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 #, fuzzy
 msgid "Remote admin password"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -5242,7 +5245,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5303,7 +5306,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5457,7 +5460,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5494,19 +5497,19 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5721,7 +5724,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5975,7 +5978,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -6194,7 +6197,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6441,7 +6444,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6505,7 +6508,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6549,7 +6552,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6577,7 +6580,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6597,7 +6600,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6922,7 +6925,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -8143,7 +8146,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8159,7 +8162,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -8545,7 +8548,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -8557,7 +8560,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8594,7 +8597,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 
@@ -8640,13 +8643,6 @@ msgstr "да"
 
 #, fuzzy
 #~ msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
-#~ msgstr ""
-#~ "Изменение состояния одного или нескольких контейнеров %s.\n"
-#~ "\n"
-#~ "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#, fuzzy
-#~ msgid "[<remote>:] <fingerprint>"
 #~ msgstr ""
 #~ "Изменение состояния одного или нескольких контейнеров %s.\n"
 #~ "\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1058,15 +1058,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1078,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1326,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1369,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1720,9 +1719,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2260,7 +2259,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2275,11 +2274,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2289,7 +2288,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2299,12 +2298,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2329,7 +2328,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2412,7 +2411,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2449,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,7 +2469,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2891,7 +2890,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2971,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3028,7 +3027,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3347,7 +3346,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3646,7 +3645,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3989,7 +3988,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4016,7 +4015,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4043,7 +4042,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4245,7 +4244,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4316,11 +4315,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4349,7 +4348,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4361,7 +4360,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4492,7 +4491,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4590,7 +4589,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4681,45 +4680,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4801,7 +4800,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4858,7 +4857,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5003,7 +5002,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5040,19 +5039,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5259,7 +5258,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5490,7 +5489,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5702,7 +5701,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5948,7 +5947,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6012,7 +6011,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6055,7 +6054,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6083,7 +6082,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6103,7 +6102,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6406,7 +6405,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7055,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7063,7 +7062,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7449,7 +7448,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7461,7 +7460,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7498,7 +7497,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1058,15 +1058,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1078,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1326,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1369,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1720,9 +1719,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2260,7 +2259,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2275,11 +2274,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2289,7 +2288,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2299,12 +2298,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2329,7 +2328,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2412,7 +2411,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2449,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,7 +2469,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2891,7 +2890,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2971,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3028,7 +3027,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3347,7 +3346,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3646,7 +3645,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3989,7 +3988,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4016,7 +4015,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4043,7 +4042,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4245,7 +4244,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4316,11 +4315,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4349,7 +4348,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4361,7 +4360,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4492,7 +4491,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4590,7 +4589,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4681,45 +4680,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4801,7 +4800,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4858,7 +4857,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5003,7 +5002,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5040,19 +5039,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5259,7 +5258,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5490,7 +5489,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5702,7 +5701,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5948,7 +5947,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6012,7 +6011,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6055,7 +6054,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6083,7 +6082,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6103,7 +6102,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6406,7 +6405,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7055,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7063,7 +7062,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7449,7 +7448,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7461,7 +7460,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7498,7 +7497,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -631,11 +631,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -739,7 +739,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1054,15 +1054,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1074,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1322,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1366,7 +1365,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1716,9 +1715,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2256,7 +2255,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2271,11 +2270,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2285,7 +2284,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2295,12 +2294,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2325,7 +2324,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2408,7 +2407,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2446,7 +2445,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2466,7 +2465,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2887,7 +2886,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3024,7 +3023,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3343,7 +3342,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3642,7 +3641,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3985,7 +3984,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4012,7 +4011,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4039,7 +4038,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4241,7 +4240,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4312,11 +4311,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4345,7 +4344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4357,7 +4356,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4488,7 +4487,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4586,7 +4585,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4677,45 +4676,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4797,7 +4796,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4854,7 +4853,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -4999,7 +4998,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5036,19 +5035,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5255,7 +5254,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5486,7 +5485,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5698,7 +5697,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5944,7 +5943,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6008,7 +6007,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6051,7 +6050,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6079,7 +6078,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6099,7 +6098,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6402,7 +6401,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7051,7 +7050,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7059,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7445,7 +7444,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7457,7 +7456,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7494,7 +7493,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -565,7 +565,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1058,15 +1058,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1078,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1326,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1370,7 +1369,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1720,9 +1719,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2260,7 +2259,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2275,11 +2274,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2289,7 +2288,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2299,12 +2298,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2329,7 +2328,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2412,7 +2411,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2450,7 +2449,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2470,7 +2469,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2891,7 +2890,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2972,7 +2971,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3028,7 +3027,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3347,7 +3346,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3646,7 +3645,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3989,7 +3988,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4016,7 +4015,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4043,7 +4042,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4245,7 +4244,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4316,11 +4315,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4349,7 +4348,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4361,7 +4360,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4492,7 +4491,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4590,7 +4589,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4681,45 +4680,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4801,7 +4800,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4858,7 +4857,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5003,7 +5002,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5040,19 +5039,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5259,7 +5258,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5490,7 +5489,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5702,7 +5701,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5948,7 +5947,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6012,7 +6011,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6055,7 +6054,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6083,7 +6082,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6103,7 +6102,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6406,7 +6405,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7055,7 +7054,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7063,7 +7062,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7449,7 +7448,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7461,7 +7460,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7498,7 +7497,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -676,15 +676,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -795,11 +795,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -903,7 +903,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -997,7 +997,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1218,15 +1218,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1238,7 +1237,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1486,12 +1485,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1530,7 +1529,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1880,9 +1879,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2420,7 +2419,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2435,11 +2434,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2459,12 +2458,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2489,7 +2488,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2572,7 +2571,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2610,7 +2609,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2630,7 +2629,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3051,7 +3050,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3132,7 +3131,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3188,7 +3187,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3507,7 +3506,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3806,7 +3805,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4149,7 +4148,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4176,7 +4175,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4203,7 +4202,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4405,7 +4404,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4476,11 +4475,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4509,7 +4508,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4521,7 +4520,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4652,7 +4651,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4750,7 +4749,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4841,45 +4840,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4961,7 +4960,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -5018,7 +5017,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5163,7 +5162,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5200,19 +5199,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5419,7 +5418,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5650,7 +5649,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5862,7 +5861,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6108,7 +6107,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6172,7 +6171,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6215,7 +6214,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6243,7 +6242,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6263,7 +6262,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6566,7 +6565,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7215,7 +7214,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7223,7 +7222,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7609,7 +7608,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7621,7 +7620,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7658,7 +7657,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-08-23 10:25-0500\n"
+"POT-Creation-Date: 2024-08-27 13:17+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:841 lxc/remote.go:898
+#: lxc/remote.go:842 lxc/remote.go:899
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:938
+#: lxc/remote.go:939
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:768
+#: lxc/remote.go:769
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:751
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -564,7 +564,7 @@ msgstr ""
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:101
 msgid "Accept certificate"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:90
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:91
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:580
+#: lxc/remote.go:581
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:182
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:137
 msgid "Available projects:"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:878
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,15 +1057,14 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:455
+msgid "Certificate fingerprint"
+msgstr ""
+
+#: lxc/remote.go:219
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
-msgstr ""
-
-#: lxc/remote.go:454
-#, c-format
-msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/network.go:893
@@ -1077,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:620
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:489
+#: lxc/remote.go:490
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:473
+#: lxc/remote.go:225 lxc/remote.go:474
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:485
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1719,9 +1718,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:181 lxc/project.go:244 lxc/project.go:372
 #: lxc/project.go:433 lxc/project.go:546 lxc/project.go:603 lxc/project.go:682
 #: lxc/project.go:713 lxc/project.go:766 lxc/project.go:825 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:90
-#: lxc/remote.go:647 lxc/remote.go:685 lxc/remote.go:771 lxc/remote.go:844
-#: lxc/remote.go:900 lxc/remote.go:940 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:845
+#: lxc/remote.go:901 lxc/remote.go:941 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2259,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:365
+#: lxc/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2274,11 +2273,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:191
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:242
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2288,7 +2287,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:232
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2298,12 +2297,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2328,7 +2327,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:237
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2411,7 +2410,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:637 lxc/project.go:435
-#: lxc/project.go:827 lxc/remote.go:689 lxc/storage.go:588
+#: lxc/project.go:827 lxc/remote.go:690 lxc/storage.go:588
 #: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1446 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2449,7 +2448,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:754
 msgid "GLOBAL"
 msgstr ""
 
@@ -2469,7 +2468,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:400
+#: lxc/remote.go:160 lxc/remote.go:401
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2890,7 +2889,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:352
+#: lxc/remote.go:353
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2970,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:341
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3027,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:386
+#: lxc/console.go:387
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3346,7 +3345,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:684 lxc/remote.go:685
+#: lxc/remote.go:685 lxc/remote.go:686
 msgid "List the available remotes"
 msgstr ""
 
@@ -3645,7 +3644,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:34 lxc/remote.go:35
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:564 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
 #: lxc/network_zone.go:741 lxc/profile.go:677 lxc/project.go:521
-#: lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506
+#: lxc/remote.go:748 lxc/storage.go:638 lxc/storage_bucket.go:506
 #: lxc/storage_bucket.go:826 lxc/storage_volume.go:1561
 msgid "NAME"
 msgstr ""
@@ -4015,7 +4014,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:479
 #: lxc/project.go:484 lxc/project.go:489 lxc/project.go:494 lxc/project.go:499
-#: lxc/project.go:504 lxc/remote.go:707 lxc/remote.go:712 lxc/remote.go:717
+#: lxc/project.go:504 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4042,7 +4041,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:141
+#: lxc/remote.go:142
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4244,7 +4243,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:335
+#: lxc/remote.go:336
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4315,11 +4314,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:750
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1073 lxc/remote.go:751
+#: lxc/image.go:1073 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4348,7 +4347,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:183
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4360,7 +4359,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4491,7 +4490,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:106
+#: lxc/remote.go:107
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4589,7 +4588,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:105
+#: lxc/remote.go:106
 msgid "Public image server"
 msgstr ""
 
@@ -4680,45 +4679,45 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:801
+#: lxc/remote.go:802
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:792 lxc/remote.go:792 lxc/remote.go:865 lxc/remote.go:921
-#: lxc/remote.go:961
+#: lxc/project.go:792 lxc/remote.go:793 lxc/remote.go:866 lxc/remote.go:922
+#: lxc/remote.go:962
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:304
+#: lxc/remote.go:305
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:874
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:796 lxc/remote.go:869 lxc/remote.go:965
+#: lxc/remote.go:797 lxc/remote.go:870 lxc/remote.go:966
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:293
+#: lxc/remote.go:294
 msgid "Remote address must not be empty"
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:102
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:298
+#: lxc/remote.go:299
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:103
 msgid "Remote trust token"
 msgstr ""
 
@@ -4800,7 +4799,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:843 lxc/remote.go:844
+#: lxc/remote.go:844 lxc/remote.go:845
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,7 +4856,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:770 lxc/remote.go:771
+#: lxc/remote.go:771 lxc/remote.go:772
 msgid "Rename remotes"
 msgstr ""
 
@@ -5002,7 +5001,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:753
 msgid "STATIC"
 msgstr ""
 
@@ -5039,19 +5038,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:104
+#: lxc/remote.go:105
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:464
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:616
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:104
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5258,7 +5257,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:939 lxc/remote.go:940
+#: lxc/remote.go:940 lxc/remote.go:941
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5489,7 +5488,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:646 lxc/remote.go:647
+#: lxc/remote.go:647 lxc/remote.go:648
 msgid "Show the default remote"
 msgstr ""
 
@@ -5701,7 +5700,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:899 lxc/remote.go:900
+#: lxc/remote.go:900 lxc/remote.go:901
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:214
+#: lxc/console.go:215
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6011,7 +6010,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:570
+#: lxc/remote.go:571
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6054,7 +6053,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:749
 msgid "URL"
 msgstr ""
 
@@ -6082,7 +6081,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:214 lxc/remote.go:248
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6102,7 +6101,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:163
+#: lxc/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6405,7 +6404,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:481
 #: lxc/project.go:486 lxc/project.go:491 lxc/project.go:496 lxc/project.go:501
-#: lxc/project.go:506 lxc/remote.go:709 lxc/remote.go:714 lxc/remote.go:719
+#: lxc/project.go:506 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7062,7 +7061,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:511 lxc/remote.go:738
+#: lxc/project.go:511 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7448,7 +7447,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:463
 msgid "n"
 msgstr ""
 
@@ -7460,7 +7459,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:456
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7497,7 +7496,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:465
 msgid "y"
 msgstr ""
 

--- a/shared/api/error.go
+++ b/shared/api/error.go
@@ -6,6 +6,26 @@ import (
 	"net/http"
 )
 
+// NewGenericStatusError returns a new StatusError with the given status code.
+// The generic http.StatusText will be used for the error message.
+func NewGenericStatusError(status int) StatusError {
+	return StatusError{
+		status: status,
+	}
+}
+
+// NewStatusError returns a new StatusError with the given message and status code.
+func NewStatusError(status int, msg string) StatusError {
+	if msg == "" {
+		return NewGenericStatusError(status)
+	}
+
+	return StatusError{
+		status: status,
+		err:    errors.New(msg),
+	}
+}
+
 // StatusErrorf returns a new StatusError containing the specified status and message.
 func StatusErrorf(status int, format string, a ...any) StatusError {
 	return StatusError{

--- a/shared/api/error.go
+++ b/shared/api/error.go
@@ -26,7 +26,12 @@ func (e StatusError) Error() string {
 		return e.err.Error()
 	}
 
-	return http.StatusText(e.status)
+	statusText := http.StatusText(e.status)
+	if statusText == "" {
+		return "Undefined error"
+	}
+
+	return statusText
 }
 
 // Unwrap implements the xerrors.Wrapper interface for StatusError.


### PR DESCRIPTION
Adds two new methods to instantiate an `api.StatusError`:
- `NewStatusError(status int, msg string)`.
- `NewGenericStatusError(status int)`.

These can be used in the following contexts:
1. When there is an error to wrap but we want to add a status code to it, use `api.StatusErrorf`.
2. When there is no error to wrap but we want to return an error with a status code, use `api.NewStatusError`.
3. When we want to mask an error message to prevent any information leakage (e.g. for auth), use `api.NewGenericStatusError`.