### PR TITLE
Storage: Don't use d.state.ShutdownCtx in ZFS GetVolumeDiskPath

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1377,7 +1377,7 @@ func (d *Daemon) init() error {
 			return fmt.Errorf("Failed loading containers to restart: %w", err)
 		}
 
-		instancesShutdown(s, instances)
+		instancesShutdown(instances)
 		instancesStart(s, instances)
 	}
 
@@ -1941,7 +1941,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 
 		// Full shutdown requested.
 		if sig == unix.SIGPWR {
-			instancesShutdown(s, instances)
+			instancesShutdown(instances)
 
 			logger.Info("Stopping networks")
 			networkShutdown(s)

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -438,7 +438,7 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 	return instances, nil
 }
 
-func instancesShutdown(s *state.State, instances []instance.Instance) {
+func instancesShutdown(instances []instance.Instance) {
 	sort.Sort(instanceStopList(instances))
 
 	// Limit shutdown concurrency to number of instances or number of CPU cores (which ever is less).

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1974,7 +1974,9 @@ func (d *zfs) getVolumeDiskPathFromDataset(dataset string) (string, error) {
 // GetVolumeDiskPath returns the location of a root disk block device.
 func (d *zfs) GetVolumeDiskPath(vol Volume) (string, error) {
 	// Wait up to 30 seconds for the device to appear.
-	ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 30*time.Second)
+	// Don't use d.state.ShutdownCtx here as this is used during instance stop during LXD shutdown after it is
+	// canceled.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	return d.tryGetVolumeDiskPathFromDataset(ctx, d.dataset(vol, false))


### PR DESCRIPTION
Because otherwise ZFS volumes aren't deactivated during instance shutdown during LXD shutdown
because `d.state.ShutdownCtx` is canceled already.