### PR TITLE
doc/reference: Add warning about volatile keys

### DIFF
--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -369,6 +369,11 @@ The following instance options control the creation and expiry of {ref}`instance
 
 The following volatile keys are currently used internally by LXD to store internal data specific to an instance:
 
+```{important}
+Setting these `volatile.*` keys might break LXD in non-obvious ways.
+Therefore, you should avoid setting any of these keys.
+```
+
 % Include content from [../metadata.txt](../metadata.txt)
 ```{include} ../metadata.txt
     :start-after: <!-- config group instance-volatile start -->


### PR DESCRIPTION
Adds a short warning about volatile keys in the reference page. I wasn't sure how explicit to be about this warning so recommendations welcome.

Edit: I've just seen that a similar warning exists for `raw.*` config keys so I've copied that instead.