### PR TITLE
shared: Fix conversion source disk size JSON and YAML key name

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2378,7 +2378,7 @@ definitions:
                 example: foo/snap0
                 type: string
                 x-go-name: Source
-            sourceDiskSize:
+            source_disk_size:
                 description: |-
                     Source disk size in bytes used to set the instance's volume size to accommodate the transferred root
                     disk. This value is ignored if the root disk device has a size explicitly configured (for conversion).

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -430,7 +430,7 @@ type InstanceSource struct {
 	// Example: 12345
 	//
 	// API extension: instance_import_conversion
-	SourceDiskSize int64 `json:"sourceDiskSize" yaml:"sourceDiskSize"`
+	SourceDiskSize int64 `json:"source_disk_size" yaml:"source_disk_size"`
 
 	// Optional list of options that are used during image conversion (for conversion).
 	// Example: ["format"]


### PR DESCRIPTION
Not sure if this is too late to be fixed, but json and yaml keys for source disk size have incorrect case (`sourceDiskSize` -> `source_disk_size`).