### PR TITLE
AppArmor: Allow procfs for unprivileged containers

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -505,6 +505,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   pivot_root,
 
   mount fstype=devpts,
+  mount fstype=proc,
 
   # Allow unlimited modification of mount propagation
   mount options=(rw,slave) -> /{,**},


### PR DESCRIPTION
A new AppArmor includes security fixes and our ruleset become stricter, while the source code remains unchanged.

procfs was always available for unprivileged containers because of AppArmor bugs like [1]. Let's now allow it back by explicit rule.

[1] https://bugs.launchpad.net/apparmor/+bug/1597017