### PR TITLE
lxd/apparmor: allow signals receiving

### DIFF
--- a/lxd/apparmor/instance_forkproxy.go
+++ b/lxd/apparmor/instance_forkproxy.go
@@ -24,6 +24,9 @@ var forkproxyProfileTpl = template.Must(template.New("forkproxyProfile").Parse(`
 profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
+  # Allow processes to send us signals by default
+  signal (receive),
+
   # Capabilities
   capability chown,
   capability dac_read_search,

--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -10,6 +10,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/consoles>
   #include <abstractions/nameservice>
 
+  # Allow processes to send us signals by default
+  signal (receive),
+
   capability dac_override,
   capability dac_read_search,
   capability ipc_lock,

--- a/lxd/apparmor/network_dnsmasq.go
+++ b/lxd/apparmor/network_dnsmasq.go
@@ -14,6 +14,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/dbus>
   #include <abstractions/nameservice>
 
+  # Allow processes to send us signals by default
+  signal (receive),
+
   # Capabilities
   capability chown,
   capability net_bind_service,

--- a/lxd/apparmor/network_forkdns.go
+++ b/lxd/apparmor/network_forkdns.go
@@ -15,6 +15,9 @@ var forkdnsProfileTpl = template.Must(template.New("forkdnsProfile").Parse(`#inc
 profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
+  # Allow processes to send us signals by default
+  signal (receive),
+
   # Network access
   network inet dgram,
   network inet6 dgram,

--- a/lxd/apparmor/pyuefivars.go
+++ b/lxd/apparmor/pyuefivars.go
@@ -19,6 +19,9 @@ var pythonUEFIVarsProfileTpl = template.Must(template.New("pythonUEFIVarsProfile
 profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
+  # Allow processes to send us signals by default
+  signal (receive),
+
   # Python locations
   /usr/bin/python* mixr,
   /bin**/*.py r,

--- a/lxd/apparmor/qemuimg.go
+++ b/lxd/apparmor/qemuimg.go
@@ -22,6 +22,9 @@ var qemuImgProfileTpl = template.Must(template.New("qemuImgProfile").Parse(`#inc
 profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
+  # Allow processes to send us signals by default
+  signal (receive),
+
   capability dac_override,
   capability dac_read_search,
   capability ipc_lock,

--- a/lxd/apparmor/rsync.go
+++ b/lxd/apparmor/rsync.go
@@ -19,6 +19,9 @@ var rsyncProfileTpl = template.Must(template.New("rsyncProfile").Parse(`#include
 profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
+  # Allow processes to send us signals by default
+  signal (receive),
+
   capability chown,
   capability dac_override,
   capability dac_read_search,


### PR DESCRIPTION
This is a workaround for AppArmor 4.0+ and new
unconfined profile feature. It was found [1]
that the new unconfined profile mode is not fully
permissive. Some things are forbidden for no reason.

We need this change to prevent breakage of LXD
when we eventually enable a new unconfined mode for lxd-support plug in snapd.

This change is absolutely safe in general and there is no reason to put it under "if" condition. [2]

[1] https://bugs.launchpad.net/apparmor/+bug/2077413
[2] https://gitlab.com/apparmor/apparmor/-/merge_requests/1310