### PR TITLE
lxd/device/cdi: Disable NVIDIA CDI for `armhf` platforms

### DIFF
--- a/doc/reference/devices_gpu.md
+++ b/doc/reference/devices_gpu.md
@@ -55,6 +55,10 @@ See {ref}`instances-configure-devices` for more information.
 
 #### CDI mode
 
+```{note}
+The CDI mode is currently not supported on `armhf` architectures.
+```
+
 Add a specific GPU from the host system as a `physical` GPU device to an instance using the [Container Device Interface](https://github.com/cncf-tags/container-device-interface) (CDI) notation through a fully-qualified CDI name:
 
     lxc config device add <instance_name> <device_name> gpu gputype=physical id=<fully_qualified_CDI_name>

--- a/lxd/device/cdi/spec.go
+++ b/lxd/device/cdi/spec.go
@@ -1,3 +1,5 @@
+//go:build !armhf && !arm && !arm32
+
 package cdi
 
 import (

--- a/lxd/device/cdi/spec_unsupported.go
+++ b/lxd/device/cdi/spec_unsupported.go
@@ -1,0 +1,14 @@
+//go:build armhf || arm || arm32
+
+package cdi
+
+import (
+	"fmt"
+
+	"github.com/canonical/lxd/lxd/instance"
+	"tags.cncf.io/container-device-interface/specs-go"
+)
+
+func generateSpec(cdiID ID, inst instance.Instance) (*specs.Spec, error) {
+	return nil, fmt.Errorf("NVIDIA CDI operations not supported on this platform")
+}


### PR DESCRIPTION
Related issue: https://launchpadlibrarian.net/746341085/buildlog_snap_ubuntu_noble_armhf_lxd-latest-edge_BUILDING.txt.gz