### PR TITLE
lxd/device/cdi: add no-op `defaultNvidiaTegraCSVFiles` for `armhf` build

### DIFF
--- a/lxd/device/cdi/spec_unsupported.go
+++ b/lxd/device/cdi/spec_unsupported.go
@@ -9,6 +9,10 @@ import (
 	"tags.cncf.io/container-device-interface/specs-go"
 )
 
+func defaultNvidiaTegraCSVFiles(rootPath string) []string {
+	return []string{}
+}
+
 func generateSpec(cdiID ID, inst instance.Instance) (*specs.Spec, error) {
 	return nil, fmt.Errorf("NVIDIA CDI operations not supported on this platform")
 }


### PR DESCRIPTION
Fix `armhf` build

https://launchpadlibrarian.net/746378162/buildlog_snap_ubuntu_noble_armhf_lxd-latest-edge_BUILDING.txt.gz