### PR TITLE
lxd/apparmor/instance_lxc: allow sysfs for unprivileged containers

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -504,8 +504,13 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   ### Configuration: unprivileged containers
   pivot_root,
 
+  # We need to allow all these filesystems because they were allowed
+  # for years as a result of a https://bugs.launchpad.net/apparmor/+bug/1597017
+  # Now, when AppArmor is fixed, we start to get complaints that things which
+  # were working before stopped to work now.
   mount fstype=devpts,
   mount fstype=proc,
+  mount fstype=sysfs,
 
   # Allow unlimited modification of mount propagation
   mount options=(rw,slave) -> /{,**},


### PR DESCRIPTION
A new AppArmor includes security fixes and our ruleset become stricter, while the source code remains unchanged.

sysfs was always available for unprivileged containers because of AppArmor bugs like [1]. Let's now allow it back by explicit rule.

[1] https://bugs.launchpad.net/apparmor/+bug/1597017

Fixes:
https://discourse.ubuntu.com/t/mount-root-sysfs-cannot-mount-sysfs-read-only-with-lxd-5-21-2-22f93f4-from-snap/47563