### PR TITLE
Makefile: pin gorilla/websocket version (stable-5.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ endif
 	go get github.com/mdlayher/socket@v0.4.1
 	go get github.com/digitalocean/go-libvirt@v0.0.0-20221205150000-2939327a8519
 	go get github.com/jaypipes/pcidb@v1.0.0
+	go get github.com/gorilla/websocket@v1.5.1 # Due to riscv64 crashes in LP
 	go mod tidy -go=$(GOMIN)
 	go get toolchain@none
 


### PR DESCRIPTION
This avoids crashes in LP on riscv64