### PR TITLE
Storage: Fix unnecessary dir project quota updates (from Incus)

### DIFF
--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -120,14 +120,15 @@ func (d *dir) setQuota(path string, volID int64, sizeBytes int64) error {
 
 	// Clear and create new project if desired project ID is different.
 	if currentProjectID != d.quotaProjectID(volID) {
-		err = quota.DeleteProject(path, currentProjectID)
-		if err != nil {
-			return err
-		}
-
 		err = quota.SetProject(path, projectID)
 		if err != nil {
 			return fmt.Errorf("Failed setting project: %w", err)
+		}
+
+		// Unset the quota on the current project.
+		err = quota.SetProjectQuota(path, currentProjectID, 0)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -118,18 +118,17 @@ func (d *dir) setQuota(path string, volID int64, sizeBytes int64) error {
 		return err
 	}
 
-	// Remove current project if desired project ID is different.
+	// Clear and create new project if desired project ID is different.
 	if currentProjectID != d.quotaProjectID(volID) {
 		err = quota.DeleteProject(path, currentProjectID)
 		if err != nil {
 			return err
 		}
-	}
 
-	// Initialise the project.
-	err = quota.SetProject(path, projectID)
-	if err != nil {
-		return fmt.Errorf("Failed setting project: %w", err)
+		err = quota.SetProject(path, projectID)
+		if err != nil {
+			return fmt.Errorf("Failed setting project: %w", err)
+		}
 	}
 
 	// Set the project quota size.

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -119,7 +119,7 @@ func (d *dir) setQuota(path string, volID int64, sizeBytes int64) error {
 	}
 
 	// Clear and create new project if desired project ID is different.
-	if currentProjectID != d.quotaProjectID(volID) {
+	if currentProjectID != projectID {
 		err = quota.SetProject(path, projectID)
 		if err != nil {
 			return fmt.Errorf("Failed setting project: %w", err)


### PR DESCRIPTION
Fixes #13115

This avoids setting project quotas when the project does not change ([from Incus](https://github.com/lxc/incus/pull/1163)), and also avoids unnecessary project setting on `DeleteProject`.

Reported-by: Marius Klocke [mklocke@maxcluster.de](mailto:mklocke@maxcluster.de)

Closes https://github.com/canonical/lxd/pull/13813