### PR TITLE
test/lint/godeps: don't abort on first error

### DIFF
--- a/test/lint/godeps.sh
+++ b/test/lint/godeps.sh
@@ -5,13 +5,17 @@ set -o pipefail
 # Ensure predictable sorting
 export LC_ALL=C.UTF-8
 
+rc=0
 for pkg in client lxc/config lxd-agent shared/api; do
+  echo ""
   echo "==> Checking for imports/deps that have been added to ${pkg}..."
   DEP_FILE="test/godeps/$(echo "${pkg}" | sed 's/\//-/g').list"
   OUT="$(go list -f '{{ join .Deps "\n" }}' ./${pkg} | grep -F . | sort -u | diff --new-file -u "${DEP_FILE}" - || true)"
   if [ -n "${OUT}" ]; then
     echo "ERROR: you added a new dependency to ${pkg}; please make sure this is what you want"
     echo "${OUT}"
-    exit 1
+    rc=1
   fi
 done
+
+exit "${rc}"


### PR DESCRIPTION
Check all godeps list files rather than abort on the first error:

```
$ test/lint/godeps.sh 

==> Checking for imports/deps that have been added to client...
ERROR: you added a new dependency to client; please make sure this is what you want
--- test/godeps/client.list	2024-08-30 12:07:58.629873467 -0400
+++ -	2024-08-30 13:14:25.140400058 -0400
@@ -75,6 +75,7 @@
 vendor/golang.org/x/crypto/hkdf
 vendor/golang.org/x/crypto/internal/alias
 vendor/golang.org/x/crypto/internal/poly1305
+vendor/golang.org/x/crypto/sha3
 vendor/golang.org/x/net/dns/dnsmessage
 vendor/golang.org/x/net/http/httpguts
 vendor/golang.org/x/net/http/httpproxy

==> Checking for imports/deps that have been added to lxc/config...
ERROR: you added a new dependency to lxc/config; please make sure this is what you want
--- test/godeps/lxc-config.list	2024-08-30 12:07:58.629873467 -0400
+++ -	2024-08-30 13:14:25.237410313 -0400
@@ -77,6 +77,7 @@
 vendor/golang.org/x/crypto/hkdf
 vendor/golang.org/x/crypto/internal/alias
 vendor/golang.org/x/crypto/internal/poly1305
+vendor/golang.org/x/crypto/sha3
 vendor/golang.org/x/net/dns/dnsmessage
 vendor/golang.org/x/net/http/httpguts
 vendor/golang.org/x/net/http/httpproxy

==> Checking for imports/deps that have been added to lxd-agent...
ERROR: you added a new dependency to lxd-agent; please make sure this is what you want
--- test/godeps/lxd-agent.list	2024-08-30 12:08:56.112190552 -0400
+++ -	2024-08-30 13:14:25.328327930 -0400
@@ -333,6 +333,7 @@
 vendor/golang.org/x/crypto/hkdf
 vendor/golang.org/x/crypto/internal/alias
 vendor/golang.org/x/crypto/internal/poly1305
+vendor/golang.org/x/crypto/sha3
 vendor/golang.org/x/net/dns/dnsmessage
 vendor/golang.org/x/net/http/httpguts
 vendor/golang.org/x/net/http/httpproxy

==> Checking for imports/deps that have been added to shared/api...
ERROR: you added a new dependency to shared/api; please make sure this is what you want
--- test/godeps/shared-api.list	2024-08-30 12:07:58.629873467 -0400
+++ -	2024-08-30 13:14:25.465164808 -0400
@@ -5,6 +5,7 @@
 vendor/golang.org/x/crypto/hkdf
 vendor/golang.org/x/crypto/internal/alias
 vendor/golang.org/x/crypto/internal/poly1305
+vendor/golang.org/x/crypto/sha3
 vendor/golang.org/x/net/dns/dnsmessage
 vendor/golang.org/x/net/http/httpguts
 vendor/golang.org/x/net/http/httpproxy
```

Saves round-trips when fighting to get CI green ;)