### PR TITLE
lxd/instances: Don't bypass instance limit check (from Incus)

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1238,8 +1238,6 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			if err != nil {
 				return err
 			}
-
-			return nil
 		}
 
 		if !clusterNotification {


### PR DESCRIPTION
User reported in https://github.com/lxc/incus/issues/463 that project limits were not being enforced on the cluster member in direct communication with the client during instance creation.

~I also noticed that the limit checks were being skipped based on the value of the [`User-Agent` header](https://github.com/canonical/lxd/commit/d6871e49e4ae7c1ee173c49ca08e350e11f45b73), which is spoofable. This pushes the limits check back to the target cluster member.~

Contains cherry-picks from https://github.com/lxc/incus/pull/505