### PR TITLE
lxd/project: Allow managed volumes under "allow" (from Incus)

### DIFF
--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -642,10 +642,11 @@ func checkRestrictions(project api.Project, instances []api.Instance, profiles [
 					}
 
 				case "allow":
-					var allowed bool
-					allowed, _ = CheckRestrictedDevicesDiskPaths(project.Config, device["source"])
-					if !allowed {
-						return fmt.Errorf("Disk source path %q not allowed", device["source"])
+					if device["pool"] == "" {
+						allowed, _ := CheckRestrictedDevicesDiskPaths(project.Config, device["source"])
+						if !allowed {
+							return fmt.Errorf("Disk source path %q not allowed", device["source"])
+						}
 					}
 				}
 

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -972,6 +972,28 @@ test_projects_restrictions() {
   lxc project set p1 restricted.devices.disk=block
   ! lxc profile device add default data disk pool="${pool}" path=/mnt source="v-proj$$" || false
 
+  restrictedDir="/opt/projects_restricted"
+  mkdir "${restrictedDir}"
+  tmpDir=$(mktemp -d)
+  optDir=$(mktemp -d --tmpdir="${restrictedDir}")
+
+  # Block unmanaged disk devices
+  lxc project set p1 restricted.devices.disk=managed
+  ! lxc profile device add default data disk path=/mnt source="${tmpDir}" || false
+
+  # Allow unmanaged disk devices
+  lxc project set p1 restricted.devices.disk=allow
+  lxc profile device add default data disk path=/mnt source="${tmpDir}"
+  lxc profile device remove default data
+
+  # Path restrictions
+  lxc project set p1 restricted.devices.disk.paths="${restrictedDir}"
+  ! lxc profile device add default data disk path=/mnt source="${tmpDir}" || false
+  lxc profile device add default data disk path=/mnt source="${optDir}"
+  lxc profile device remove default data
+
+  rm -r "${tmpDir}" "${optDir}" "${restrictedDir}"
+
   # Setting restricted.containers.nesting to 'allow' makes it possible to create
   # nested containers.
   lxc project set p1 restricted.containers.nesting=allow


### PR DESCRIPTION
See [the docs](https://documentation.ubuntu.com/lxd/en/latest/reference/projects/#project-restricted:restricted.devices.disk) for disk device restrictions. This PR prevents checking the `restricted.devices.disk.paths` for managed devices when `restricted.devices.disk: allow`.

Contains cherry-picks from https://github.com/lxc/incus/pull/708