### PR TITLE
Test `LXD_INSECURE_TLS`

### DIFF
--- a/test/includes/net.sh
+++ b/test/includes/net.sh
@@ -29,7 +29,7 @@ EOF
 # Certificate-aware curl wrapper
 my_curl() {
     CERTNAME="${CERTNAME:-"client"}"
-    curl -k -s --cert "${LXD_CONF}/${CERTNAME}.crt" --key "${LXD_CONF}/${CERTNAME}.key" "$@"
+    curl --insecure --silent --cert "${LXD_CONF}/${CERTNAME}.crt" --key "${LXD_CONF}/${CERTNAME}.key" "$@"
 }
 
 # Wait for duplicate address detection to complete.

--- a/test/main.sh
+++ b/test/main.sh
@@ -216,6 +216,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_database_no_disk_space "database out of disk space"
     run_test test_sql "lxd sql"
     run_test test_tls_restrictions "TLS restrictions"
+    run_test test_tls_version "TLS version"
     run_test test_oidc "OpenID Connect"
     run_test test_authorization "Authorization"
     run_test test_certificate_edit "Certificate edit"

--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -395,3 +395,71 @@ test_certificate_edit() {
 
   lxc project delete blah
 }
+
+test_tls_version() {
+  echo "TLS 1.3 just works"
+  my_curl -X GET "https://${LXD_ADDR}"
+  my_curl --tlsv1.3 -X GET "https://${LXD_ADDR}"
+
+  echo "TLS 1.3 with various ciphersuites"
+  for cipher in TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 TLS_AES_128_GCM_SHA256; do
+    echo "Testing TLS 1.3: ${cipher}"
+    my_curl --tlsv1.3 --tls13-ciphers "${cipher}" -X GET "https://${LXD_ADDR}"
+  done
+
+  echo "TLS 1.2 is refused with a protocol version error"
+  ! my_curl --tls-max 1.2 -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" || false
+  my_curl --tls-max 1.2 -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" | grep -F "alert protocol version"
+
+  echo "Enable TLS 1.2 with LXD_INSECURE_TLS=true"
+  shutdown_lxd "${LXD_DIR}"
+  export LXD_INSECURE_TLS=true
+  respawn_lxd "${LXD_DIR}" true
+
+  echo "TLS 1.3 is still working and used by default"
+  my_curl -X GET "https://${LXD_ADDR}"
+  my_curl --tlsv1.3 -X GET "https://${LXD_ADDR}"
+
+  echo "TLS 1.2 is now working"
+  my_curl --tls-max 1.2 -X GET "https://${LXD_ADDR}"
+
+  echo "TLS 1.2 with ciphers known to work"
+  for cipher in ECDHE-ECDSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-ECDSA-CHACHA20-POLY1305; do
+    echo "Testing TLS 1.2: ${cipher}"
+    my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}"
+  done
+
+  echo "TLS 1.2 does not work with RSA auth when the server uses ECDSA cert"
+  for cipher in ECDHE-RSA-AES128-GCM-SHA256 ECDHE-RSA-AES256-GCM-SHA384; do
+    echo "Testing TLS 1.2: ${cipher}"
+    ! my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" || false
+    my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" | grep -F "alert handshake failure"
+  done
+
+  echo "TLS 1.2 with ciphers known to be refused with a handshake failure"
+  for cipher in ECDHE-ECDSA-AES128-SHA256 ECDHE-ECDSA-AES256-SHA384; do
+    echo "Testing TLS 1.2: ${cipher}"
+    ! my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" || false
+    my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" | grep -F "alert handshake failure"
+  done
+
+  echo "TLS 1.2 with ciphers known to be a broken pipe error"
+  for cipher in ECDHE-ECDSA-AES128-SHA ECDHE-ECDSA-AES256-SHA; do
+    echo "Testing TLS 1.2: ${cipher}"
+    ! my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" || false
+    my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" | grep -F "Broken pipe, errno"
+  done
+
+  echo "TLS 1.1 is not working"
+  ! my_curl --tls-max 1.1 -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" || false
+  my_curl --tls-max 1.1 -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" | grep -F "no protocols available"
+
+  echo "Disable TLS 1.2"
+  shutdown_lxd "${LXD_DIR}"
+  unset LXD_INSECURE_TLS
+  respawn_lxd "${LXD_DIR}" true
+
+  echo "TLS 1.2 is refused with a protocol version error"
+  ! my_curl --tls-max 1.2 -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" || false
+  my_curl --tls-max 1.2 -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" | grep -F "alert protocol version"
+}


### PR DESCRIPTION
Make sure LXD accepts only TLS 1.3 in its default configuration. Also verify that `LXD_INSECURE_TLS=true` reduces the security just enough to provide TLS 1.2 for backward compatibility without allowing CBC nor SHA1.

The fine grain cipher checks will likely require changes over time as Go default cipher list evolves.