### PR TITLE
Entity: Rename TypeNode to TypeClusterMember

### DIFF
--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -178,7 +178,7 @@ func (hbState *APIHeartbeat) Send(ctx context.Context, networkCert *shared.CertI
 			heartbeatData.Unlock()
 			logger.Debug("Successful heartbeat", logger.Ctx{"remote": address})
 
-			err = warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(hbState.cluster, "", warningtype.OfflineClusterMember, entity.TypeNode, int(nodeID))
+			err = warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(hbState.cluster, "", warningtype.OfflineClusterMember, entity.TypeClusterMember, int(nodeID))
 			if err != nil {
 				logger.Warn("Failed to resolve warning", logger.Ctx{"err": err})
 			}
@@ -187,7 +187,7 @@ func (hbState *APIHeartbeat) Send(ctx context.Context, networkCert *shared.CertI
 
 			if ctx.Err() == nil {
 				err = hbState.cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-					return tx.UpsertWarningLocalNode(ctx, "", entity.TypeNode, int(nodeID), warningtype.OfflineClusterMember, err.Error())
+					return tx.UpsertWarningLocalNode(ctx, "", entity.TypeClusterMember, int(nodeID), warningtype.OfflineClusterMember, err.Error())
 				})
 				if err != nil {
 					logger.Warn("Failed to create warning", logger.Ctx{"err": err})

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -557,7 +557,7 @@ func HeartbeatNode(taskCtx context.Context, address string, networkCert *shared.
 	defer func() { _ = response.Body.Close() }()
 
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("Heartbeat request failed with status: %w", api.StatusErrorf(response.StatusCode, response.Status))
+		return fmt.Errorf("Heartbeat request failed with status: %w", api.NewStatusError(response.StatusCode, response.Status))
 	}
 
 	return nil

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -82,7 +82,7 @@ var entityTypes = map[entity.Type]entityTypeDBInfo{
 	entity.TypeInstanceSnapshot:      entityTypeInstanceSnapshot{},
 	entity.TypeNetwork:               entityTypeNetwork{},
 	entity.TypeNetworkACL:            entityTypeNetworkACL{},
-	entity.TypeNode:                  entityTypeClusterMember{},
+	entity.TypeClusterMember:         entityTypeClusterMember{},
 	entity.TypeOperation:             entityTypeOperation{},
 	entity.TypeStoragePool:           entityTypeStoragePool{},
 	entity.TypeStorageVolume:         entityTypeStorageVolume{},

--- a/shared/entity/type.go
+++ b/shared/entity/type.go
@@ -51,8 +51,8 @@ const (
 	// TypeNetworkACL represents network acl resources.
 	TypeNetworkACL Type = "network_acl"
 
-	// TypeNode represents node resources.
-	TypeNode Type = "node"
+	// TypeClusterMember represents node resources.
+	TypeClusterMember Type = "cluster_member"
 
 	// TypeOperation represents operation resources.
 	TypeOperation Type = "operation"

--- a/shared/entity/type.go
+++ b/shared/entity/type.go
@@ -141,7 +141,7 @@ var entityTypes = map[Type]typeInfo{
 	TypeInstanceSnapshot:      instanceSnapshot{},
 	TypeNetwork:               network{},
 	TypeNetworkACL:            networkACL{},
-	TypeNode:                  clusterMember{},
+	TypeClusterMember:         clusterMember{},
 	TypeOperation:             operation{},
 	TypeStoragePool:           storagePool{},
 	TypeStorageVolume:         storageVolume{},

--- a/shared/entity/type_test.go
+++ b/shared/entity/type_test.go
@@ -121,7 +121,7 @@ func TestURL(t *testing.T) {
 			name:                  "cluster members",
 			rawURL:                "/1.0/cluster/members/node01",
 			expectedNormalisedURL: "/1.0/cluster/members/node01",
-			expectedEntityType:    TypeNode,
+			expectedEntityType:    TypeClusterMember,
 			expectedProject:       "",
 			expectedPathArgs:      []string{"node01"},
 			expectedErr:           nil,


### PR DESCRIPTION
Updates `TypeNode` to `TypeClusterMember` and its value from `node` to `cluster_member`.
This is done because the term node is inappropriate to be exposed to users, and it will be when the API metrics are introduced.
As of now this type is not exposed to users so an API extension is not needed.