### PR TITLE
Add lxd-migrate flags for non-interactive usage

### DIFF
--- a/doc/.sphinx/.markdownlint/exceptions.txt
+++ b/doc/.sphinx/.markdownlint/exceptions.txt
@@ -1,6 +1,6 @@
 .tmp/doc/howto/access_ui.md:31: MD029 Ordered list item prefix
-.tmp/doc/howto/import_machines_to_instances.md:114: MD034 Bare URL used
-.tmp/doc/howto/import_machines_to_instances.md:218: MD034 Bare URL used
+.tmp/doc/howto/import_machines_to_instances.md:116: MD034 Bare URL used
+.tmp/doc/howto/import_machines_to_instances.md:220: MD034 Bare URL used
 .tmp/doc/howto/network_forwards.md:66: MD004 Unordered list style
 .tmp/doc/howto/network_forwards.md:71: MD004 Unordered list style
 .tmp/doc/howto/network_forwards.md:67: MD005 Inconsistent indentation for list items at the same level

--- a/doc/howto/import_machines_to_instances.md
+++ b/doc/howto/import_machines_to_instances.md
@@ -67,6 +67,8 @@ The tool can also inject the required VIRTIO drivers into the image:
    </details>
    ````
 
+## Interactive instance import
+
 Complete the following steps to migrate an existing machine to a LXD instance:
 
 1. Download the `bin.linux.lxd-migrate` tool ([`bin.linux.lxd-migrate.aarch64`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxd-migrate.aarch64) or [`bin.linux.lxd-migrate.x86_64`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxd-migrate.x86_64)) from the **Assets** section of the latest [LXD release](https://github.com/canonical/lxd/releases).
@@ -320,3 +322,77 @@ Complete the following steps to migrate an existing machine to a LXD instance:
    </details>
 1. When the migration is complete, check the new instance and update its configuration to the new environment.
    Typically, you must update at least the storage configuration (`/etc/fstab`) and the network configuration.
+
+## Non-interactive instance import
+
+Alternatively, the entire instance import configuration can be provided using `lxd-migrate` flags.
+If any required flag is missing, `lxd-migrate` will interactively prompt for the missing value.
+However, when the `--non-interactive` flag is used, an error is returned instead.
+
+Note that if any flag contains an invalid value, an error is returned regardless of the mode (interactive or non-interactive).
+
+The `lxd-migrate` command supports the following flags that can be used in non-interactive migration:
+
+```
+Instance configuration:
+  -c, --config               Config key/value to apply to the new instance
+      --mount-path           Additional container mount paths
+      --name                 Name of the new instance
+      --network              Network name
+      --no-profiles          Create the instance with no profiles applied
+      --profiles             Profiles to apply on the new instance (default [default])
+      --project              Project name
+      --source               Path to the root filesystem for containers, or to the block device or disk image file for virtual machines
+      --storage              Storage pool name
+      --storage-size         Size of the instance's storage volume
+      --type                 Type of the instance to create (container or vm)
+
+Target server:
+      --server               Unix or HTTPS URL of the target server
+      --token                Authentication token for HTTPS remote
+      --cert-path            Trusted certificate path
+      --key-path             Trusted certificate path
+
+Other:
+      --conversion strings   Comma-separated list of conversion options to apply. Allowed values are: [format, virtio] (default [format])
+      --non-interactive      Prevent further interaction if migration questions are incomplete
+      --rsync-args           Extra arguments to pass to rsync
+```
+
+Example VM import to local LXD server:
+
+```sh
+lxd-migrate \
+  --name v1 \
+  --type vm \
+  --source "${sourcePath}" \
+  --non-interactive
+```
+
+Example VM import to remote HTTPS server:
+
+```sh
+# Token from remote server.
+token=$(lxc config trust add --name lxd-migrate --quiet)
+
+lxd-migrate \
+  --server https://example.com:8443 \
+  --token "$token" \
+  --name v1 \
+  --type vm \
+  --source "${sourcePath}" \
+  --non-interactive
+```
+
+Example VM import with secure boot disabled and custom resource limits:
+
+```sh
+lxd-migrate \
+  --name v1 \
+  --type vm \
+  --source "${sourcePath}" \
+  --config security.secureboot=false \
+  --config limits.cpu=4 \
+  --config limits.memory=4GiB \
+  --non-interactive
+```

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -160,7 +160,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 	}
 
 	if len(line) < 1 || line[0] != 'y' && line[0] != 'Y' {
-		return nil, "", fmt.Errorf("Server certificate rejected by user")
+		return nil, "", errors.New("Server certificate rejected by user")
 	}
 
 	server, err := lxd.ConnectLXD(serverURL, &args)
@@ -355,7 +355,7 @@ func (c *cmdMigrate) runInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 			}
 
 			if !isImageTypeRaw {
-				return fmt.Errorf(`Source disk format cannot be converted by server. Source disk should be in raw format`)
+				return errors.New("Source disk format cannot be converted by server. Source disk should be in raw format")
 			}
 		}
 
@@ -369,7 +369,7 @@ func (c *cmdMigrate) runInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 		// Ensure the source file is not a tarball.
 		_, err = tar.NewReader(file).Next()
 		if err == nil {
-			return fmt.Errorf("Source cannot be a tar archive or OVA file")
+			return errors.New("Source cannot be a tar archive or OVA file")
 		}
 
 		return nil
@@ -475,7 +475,7 @@ Additional overrides can be applied at this stage:
 func (c *cmdMigrate) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	if os.Geteuid() != 0 {
-		return fmt.Errorf("This tool must be run as root")
+		return errors.New("This tool must be run as root")
 	}
 
 	// Check conversion options.
@@ -747,7 +747,7 @@ func (c *cmdMigrate) askStorage(server lxd.InstanceServer, config *cmdMigrateDat
 	}
 
 	if len(storagePools) == 0 {
-		return fmt.Errorf("No storage pools available")
+		return errors.New("No storage pools available")
 	}
 
 	storagePool, err := c.global.asker.AskChoice("Please provide the storage pool to use: ", storagePools, "")

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -116,8 +116,7 @@ func (c *cmdMigrateData) render() string {
 }
 
 func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
-	// Detect local server.
-	local, err := c.connectLocal()
+	local, err := c.connectLocal("")
 	if err == nil {
 		useLocal, err := c.global.asker.AskBool("The local LXD server is the target [default=yes]: ", "yes")
 		if err != nil {

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -713,6 +713,36 @@ func (c *cmdMigrate) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Check the required flags in non-interactive mode.
+	if c.flagNonInteractive {
+		if c.flagInstanceType == "" {
+			return errors.New("Instance type is required in non-interactive mode")
+		}
+
+		if c.flagSource == "" {
+			return errors.New("Source path is required in non-interactive mode")
+		}
+	}
+
+	// Precheck instance type.
+	if c.flagInstanceType != "" && !slices.Contains([]string{"container", "vm"}, c.flagInstanceType) {
+		return fmt.Errorf("Invalid instance type %q: Valid values are [%s]", c.flagInstanceType, strings.Join([]string{"container", "vm"}, ", "))
+	}
+
+	// Check source path. This is only precheck, as we cannot know the whether
+	// conversion is supported until the connection with the server is established.
+	if c.flagSource != "" {
+		err := c.checkSource(c.flagSource, "", "")
+		if err != nil {
+			return fmt.Errorf("Invalid source path %q: %w", c.flagSource, err)
+		}
+	}
+
+	// Ensure no-profiles and profiles flags are not used together.
+	if c.flagNoProfiles && len(c.flagProfiles) > 0 {
+		return errors.New("Flags --no-profiles and --profiles are mutually exclusive")
+	}
+
 	_, err := exec.LookPath("rsync")
 	if err != nil {
 		return err

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -587,7 +587,9 @@ func (c *cmdMigrate) runInteractive(config *cmdMigrateData, server lxd.InstanceS
 		}
 	}
 
-	if config.InstanceArgs.Type == api.InstanceTypeVM {
+	// Ask VM supports the secureboot. In non-interactive mode, security.secureboot can be
+	// configured using --config flag.
+	if !c.flagNonInteractive && config.InstanceArgs.Type == api.InstanceTypeVM {
 		architectureName, _ := osarch.ArchitectureGetLocal()
 
 		if shared.ValueInSlice(architectureName, []string{"x86_64", "aarch64"}) {

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -737,9 +737,20 @@ func (c *cmdMigrate) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = c.runInteractive(config, server)
-	if err != nil {
-		return err
+	if c.flagNonInteractive {
+		// In non-interactive mode, print the instance to be created and continue with the migration.
+		fmt.Println("\nInstance to be created:")
+		scanner := bufio.NewScanner(strings.NewReader(config.render()))
+		for scanner.Scan() {
+			fmt.Printf("  %s\n", scanner.Text())
+		}
+	} else {
+		// Otherwise, run in interactive mode where user is asked for missing information
+		// and given the opportunity to review and modify the instance configuration.
+		err = c.runInteractive(config, server)
+		if err != nil {
+			return err
+		}
 	}
 
 	if config.Project != "" {

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -288,7 +288,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 
 		i := 1
 
-		if shared.ValueInSlice(api.AuthenticationMethodTLS, apiServer.AuthMethods) {
+		if slices.Contains(apiServer.AuthMethods, api.AuthenticationMethodTLS) {
 			fmt.Printf("%d) Use a certificate token\n", i)
 			availableAuthMethods = append(availableAuthMethods, authMethodTLSCertificateToken)
 			i++
@@ -299,7 +299,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 			availableAuthMethods = append(availableAuthMethods, authMethodTLSTemporaryCertificate)
 		}
 
-		if len(apiServer.AuthMethods) > 1 || shared.ValueInSlice(api.AuthenticationMethodTLS, apiServer.AuthMethods) {
+		if len(apiServer.AuthMethods) > 1 || slices.Contains(apiServer.AuthMethods, api.AuthenticationMethodTLS) {
 			authMethodInt, err := c.global.asker.AskInt("Please pick an authentication mechanism above: ", 1, int64(i), "", nil)
 			if err != nil {
 				return nil, "", err
@@ -393,7 +393,7 @@ func (c *cmdMigrate) newMigrateData(server lxd.InstanceServer) (*cmdMigrateData,
 			return nil, err
 		}
 
-		if !shared.ValueInSlice(c.flagProject, projectNames) {
+		if !slices.Contains(projectNames, c.flagProject) {
 			return nil, fmt.Errorf("Project %q does not exist", c.flagProject)
 		}
 
@@ -408,7 +408,7 @@ func (c *cmdMigrate) newMigrateData(server lxd.InstanceServer) (*cmdMigrateData,
 			return nil, err
 		}
 
-		if shared.ValueInSlice(c.flagInstanceName, instanceNames) {
+		if slices.Contains(instanceNames, c.flagInstanceName) {
 			return nil, fmt.Errorf("Instance %q already exists", c.flagInstanceName)
 		}
 
@@ -435,7 +435,7 @@ func (c *cmdMigrate) newMigrateData(server lxd.InstanceServer) (*cmdMigrateData,
 		}
 
 		for _, profile := range c.flagProfiles {
-			if !shared.ValueInSlice(profile, profileNames) {
+			if !slices.Contains(profileNames, profile) {
 				return nil, fmt.Errorf("Profile %q not found", profile)
 			}
 		}
@@ -468,7 +468,7 @@ func (c *cmdMigrate) newMigrateData(server lxd.InstanceServer) (*cmdMigrateData,
 			return nil, errors.New("No storage pools available")
 		}
 
-		if !shared.ValueInSlice(c.flagStorage, storagePools) {
+		if !slices.Contains(storagePools, c.flagStorage) {
 			return nil, fmt.Errorf("Storage pool %q not found", c.flagStorage)
 		}
 
@@ -495,7 +495,7 @@ func (c *cmdMigrate) newMigrateData(server lxd.InstanceServer) (*cmdMigrateData,
 			return nil, err
 		}
 
-		if !shared.ValueInSlice(c.flagNetwork, networks) {
+		if !slices.Contains(networks, c.flagNetwork) {
 			return nil, fmt.Errorf("Network %q not found", c.flagNetwork)
 		}
 
@@ -583,7 +583,7 @@ func (c *cmdMigrate) runInteractive(config *cmdMigrateData, server lxd.InstanceS
 				return err
 			}
 
-			if shared.ValueInSlice(instanceName, instanceNames) {
+			if slices.Contains(instanceNames, instanceName) {
 				fmt.Printf("Instance %q already exists\n", instanceName)
 				continue
 			}
@@ -612,7 +612,7 @@ func (c *cmdMigrate) runInteractive(config *cmdMigrateData, server lxd.InstanceS
 	if !c.flagNonInteractive && config.InstanceArgs.Type == api.InstanceTypeVM {
 		architectureName, _ := osarch.ArchitectureGetLocal()
 
-		if shared.ValueInSlice(architectureName, []string{"x86_64", "aarch64"}) {
+		if slices.Contains([]string{"x86_64", "aarch64"}, architectureName) {
 			hasSecureBoot, err := c.global.asker.AskBool("Does the VM support UEFI Secure Boot? [default=no]: ", "no")
 			if err != nil {
 				return err
@@ -969,7 +969,7 @@ func (c *cmdMigrate) askProfiles(server lxd.InstanceServer, config *cmdMigrateDa
 		profiles := strings.Split(s, " ")
 
 		for _, profile := range profiles {
-			if !shared.ValueInSlice(profile, profileNames) {
+			if !slices.Contains(profileNames, profile) {
 				return fmt.Errorf("Unknown profile %q", profile)
 			}
 		}

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -69,8 +69,6 @@ func (c *cmdMigrate) command() *cobra.Command {
   It will setup a clean mount tree made of the root filesystem and any
   additional mount you list, then transfer this through LXD's migration
   API to create a new instance from it.
-
-  The same set of options as ` + "`lxc launch`" + ` are also supported.
 `
 	cmd.RunE = c.run
 

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -116,7 +117,7 @@ func transferRootDiskForMigration(ctx context.Context, op lxd.Operation, rootfs 
 	}
 
 	if !msg.GetSuccess() {
-		return fmt.Errorf(msg.GetMessage())
+		return errors.New(msg.GetMessage())
 	}
 
 	return nil
@@ -315,7 +316,7 @@ func (c *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 	}
 
 	if srv.Auth == "untrusted" {
-		return nil, "", fmt.Errorf("Server doesn't trust us after authentication")
+		return nil, "", errors.New("Server doesn't trust us after authentication")
 	}
 
 	fmt.Printf("\nRemote LXD server:\n  Hostname: %s\n  Version: %s\n\n", srv.Environment.ServerName, srv.Environment.ServerVersion)

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -254,6 +254,14 @@ func (c *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 			if err != nil {
 				return nil, "", fmt.Errorf("Failed to create certificate: %w", err)
 			}
+		} else if c.flagNonInteractive {
+			// In non-interactive mode stop at this point, as we know that the server
+			// does not trust us, but we should not make any further interaction with the caller.
+			if certPath != "" || keyPath != "" {
+				return nil, "", fmt.Errorf("Provided certificate is not trusted by the server")
+			}
+
+			return nil, "", errors.New("Failed to authenticate with the server: Please, either provide a trust token or an already trusted certificate")
 		} else if instanceServer.HasExtension("explicit_trust_token") {
 			fmt.Println("A temporary client certificate was generated, use `lxc config trust add` on the target server.")
 			fmt.Println("")

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -149,11 +149,11 @@ func transferRootDiskForConversion(ctx context.Context, op lxd.Operation, rootfs
 	return op.Wait()
 }
 
-func (c *cmdMigrate) connectLocal() (lxd.InstanceServer, error) {
+func (c *cmdMigrate) connectLocal(path string) (lxd.InstanceServer, error) {
 	args := lxd.ConnectionArgs{}
 	args.UserAgent = fmt.Sprintf("LXD-MIGRATE %s", version.Version)
 
-	return lxd.ConnectLXDUnix("", &args)
+	return lxd.ConnectLXDUnix(path, &args)
 }
 
 func (c *cmdMigrate) connectTarget(url string, certPath string, keyPath string, authType string, token string) (lxd.InstanceServer, string, error) {


### PR DESCRIPTION
Added flags for `lxd-migrate` to allow non-interactive usage.

List of added flags:
```
      --cert-path            Trusted certificate path
  -c, --config               Config key/value to apply to the new instance
      --key-path             Trusted certificate key path
      --mount-path           Additional container mount paths
      --name                 Name of the new instance
      --network              Network name
      --no-profiles          Create the instance with no profiles applied
      --non-interactive      Prevent further interaction if migration questions are incomplete
      --profiles             Profiles to apply on the new instance (default [default])
      --project              Project name
      --server               Unix or HTTPS URL of the target server
      --source               Path to the root filesystem for containers, or to the block device or disk image file for virtual machines
      --storage              Storage pool name
      --storage-size         Size of the instance's storage volume
      --token                Authentication token for HTTPS remote
      --type                 Type of the instance to create (container or vm)
```

Some flag names that should be renamed if necessary:
- `storage-size` - Used for setting storage volume size of a new instance.
- `server` - Server URL (unix/https)
- `type` - While the name is fine, allowed values for instance-type are `container` and `vm`, which differs from the interactive mode, where `1` is used for container and `2` for virtual machine.

TODO:
- [x] Docs
- [x] Tests in https://github.com/canonical/lxd-ci/pull/283