### PR TITLE
Set OSD pool size when creating `ceph` and `cephfs` storage pools

### DIFF
--- a/.github/actions/setup-microceph/action.yml
+++ b/.github/actions/setup-microceph/action.yml
@@ -53,8 +53,9 @@ runs:
 
           sudo snap install microceph --channel "${{ inputs.microceph-channel }}"
           sudo microceph cluster bootstrap
-          sudo microceph.ceph config set global osd_pool_default_size 1
+          sudo microceph.ceph config set global mon_allow_pool_size_one true
           sudo microceph.ceph config set global mon_allow_pool_delete true
+          sudo microceph.ceph config set global osd_pool_default_size 1
           sudo microceph.ceph config set global osd_memory_target 939524096
           sudo microceph.ceph osd crush rule rm replicated_rule
           sudo microceph.ceph osd crush rule create-replicated replicated default osd

--- a/.github/actions/setup-microceph/action.yml
+++ b/.github/actions/setup-microceph/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: MicroCeph snap channel to install
     default: "latest/edge"
     type: string
+  osd-count:
+    description: Number of OSDs to add to MicroCeph
+    default: 1
+    type: integer
 
 runs:
   using: composite
@@ -51,6 +55,7 @@ runs:
           }
           trap cleanup ERR HUP INT TERM
 
+          ephemeral_disk="${{ steps.free_ephemeral_disk.outputs.ephemeral_disk }}"
           sudo snap install microceph --channel "${{ inputs.microceph-channel }}"
           sudo microceph cluster bootstrap
           sudo microceph.ceph config set global mon_allow_pool_size_one true
@@ -62,7 +67,29 @@ runs:
           for flag in nosnaptrim nobackfill norebalance norecover noscrub nodeep-scrub; do
               sudo microceph.ceph osd set $flag
           done
-          sudo microceph disk add --wipe "${{ steps.free_ephemeral_disk.outputs.ephemeral_disk }}"
+
+          # If there is more than one OSD, set up partitions.
+          if [ ${{ inputs.osd-count }} -gt 1 ]; then
+            sudo blkdiscard "${ephemeral_disk}" --force
+            sudo parted "${ephemeral_disk}" --script mklabel gpt
+
+            for i in $(seq 1 "${{ inputs.osd-count }}"); do
+              # Create equal sized partitions for each OSD.
+              min="$(( (${i}-1) *  100 / ${{ inputs.osd-count }} ))"
+              max="$(( ${i} * 100 / ${{ inputs.osd-count }} ))"
+              sudo parted "${ephemeral_disk}" --align optimal --script mkpart primary "${min}%" "${max}%"
+
+              # MicroCeph does not accept partitions directly.
+              # See: https://github.com/canonical/microceph/issues/251
+              disk="$(losetup -f)"
+              sudo losetup --direct-io=on "${disk}" "${ephemeral_disk}${i}"
+              sudo microceph disk add "${disk}"
+            done
+          else
+              sudo microceph disk add --wipe "${ephemeral_disk}"
+          fi
+
+
           sudo rm -rf /etc/ceph
           sudo ln -s /var/snap/microceph/current/conf/ /etc/ceph
           sudo microceph enable rgw

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -256,6 +256,8 @@ jobs:
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}
         uses: ./.github/actions/setup-microceph
+        with:
+          osd-count: 3
 
       - name: Make GOCOVERDIR
         run: |

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2535,3 +2535,6 @@ Adds a new {config:option}`device-unix-hotplug-device-conf:ownership.inherit` co
 ## `unix_device_hotplug_subsystem_device_option`
 
 Adds a new {config:option}`device-unix-hotplug-device-conf:subsystem` configuration option for `unix-hotplug` devices. This adds support for detecting `unix-hotplug` devices by subsystem, and can be used in conjunction with {config:option}`device-unix-hotplug-device-conf:productid` and {config:option}`device-unix-hotplug-device-conf:vendorid`.
+
+## `storage_ceph_osd_pool_size`
+This introduces the configuration keys {config:option}`storage-ceph-pool-conf:ceph.osd.pool_size`, and {config:option}`storage-cephfs-pool-conf:cephfs.osd_pool_size` to be used when adding or updating a `ceph` or `cephfs` storage pool to instruct LXD to create set the replication size for the underlying OSD pools.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4996,6 +4996,14 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```
 
+```{config:option} ceph.osd.pool_size storage-ceph-pool-conf
+:defaultdesc: "`3`"
+:shortdesc: "Number of RADOS object replicas. Set to 1 for no replication."
+:type: "string"
+This option specifies the name for the file metadata OSD pool that should be used when
+creating a file system automatically.
+```
+
 ```{config:option} ceph.rbd.clone_copy storage-ceph-pool-conf
 :defaultdesc: "`true`"
 :scope: "global"
@@ -5196,6 +5204,14 @@ creating a file system automatically.
 :type: "string"
 This option specifies the number of OSD pool placement groups (`pg_num`) to use
 when creating a missing OSD pool.
+```
+
+```{config:option} cephfs.osd_pool_size storage-cephfs-pool-conf
+:defaultdesc: "`3`"
+:shortdesc: "Number of RADOS object replicas. Set to 1 for no replication."
+:type: "string"
+This option specifies the number of OSD pool replicas to use
+when creating an OSD pool.
 ```
 
 ```{config:option} cephfs.path storage-cephfs-pool-conf

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5627,6 +5627,14 @@
 						}
 					},
 					{
+						"ceph.osd.pool_size": {
+							"defaultdesc": "`3`",
+							"longdesc": "This option specifies the name for the file metadata OSD pool that should be used when\ncreating a file system automatically.",
+							"shortdesc": "Number of RADOS object replicas. Set to 1 for no replication.",
+							"type": "string"
+						}
+					},
+					{
 						"ceph.rbd.clone_copy": {
 							"defaultdesc": "`true`",
 							"longdesc": "Enable this option to use RBD lightweight clones rather than full dataset copies.",
@@ -5836,6 +5844,14 @@
 							"longdesc": "This option specifies the number of OSD pool placement groups (`pg_num`) to use\nwhen creating a missing OSD pool.",
 							"scope": "global",
 							"shortdesc": "Number of placement groups when creating missing OSD pools",
+							"type": "string"
+						}
+					},
+					{
+						"cephfs.osd_pool_size": {
+							"defaultdesc": "`3`",
+							"longdesc": "This option specifies the number of OSD pool replicas to use\nwhen creating an OSD pool.",
+							"shortdesc": "Number of RADOS object replicas. Set to 1 for no replication.",
 							"type": "string"
 						}
 					},

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -406,6 +406,23 @@ func (d *ceph) Validate(config map[string]string) error {
 
 // Update applies any driver changes required from a configuration change.
 func (d *ceph) Update(changedConfig map[string]string) error {
+	newSize, changed := changedConfig["ceph.osd.pool_size"]
+	if changed {
+		_, err := shared.TryRunCommand("ceph",
+			"--name", "client."+d.config["ceph.user.name"],
+			"--cluster", d.config["ceph.cluster_name"],
+			"osd",
+			"pool",
+			"set",
+			d.config["ceph.osd.pool_name"],
+			"size",
+			newSize,
+			"--yes-i-really-mean-it")
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/canonical/lxd/lxd/migration"
@@ -111,6 +112,29 @@ func (d *ceph) FillConfig() error {
 
 	if d.config["ceph.osd.pg_num"] == "" {
 		d.config["ceph.osd.pg_num"] = "32"
+	}
+
+	if d.config["ceph.osd.pool_size"] == "" {
+		size, err := shared.TryRunCommand("ceph",
+			"--name", "client."+d.config["ceph.user.name"],
+			"--cluster", d.config["ceph.cluster_name"],
+			"config",
+			"get",
+			"mon",
+			"osd_pool_default_size",
+			"--format",
+			"json")
+		if err != nil {
+			return err
+		}
+
+		var sizeInt int
+		err = json.Unmarshal([]byte(size), &sizeInt)
+		if err != nil {
+			return err
+		}
+
+		d.config["ceph.osd.pool_size"] = strconv.Itoa(sizeInt)
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -344,6 +344,14 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  shortdesc: Number of placement groups for the OSD storage pool
 		//  scope: global
 		"ceph.osd.pg_num": validate.IsAny,
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.osd.pool_size)
+		// This option specifies the name for the file metadata OSD pool that should be used when
+		// creating a file system automatically.
+		// ---
+		//  type: string
+		//  defaultdesc: `3`
+		//  shortdesc: Number of RADOS object replicas. Set to 1 for no replication.
+		"ceph.osd.pool_size": validate.Optional(validate.IsInRange(1, 255)),
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.osd.pool_name)
 		//
 		// ---

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -196,6 +196,20 @@ func (d *ceph) Create() error {
 
 		revert.Add(func() { _ = d.osdDeletePool() })
 
+		_, err = shared.TryRunCommand("ceph",
+			"--name", "client."+d.config["ceph.user.name"],
+			"--cluster", d.config["ceph.cluster_name"],
+			"osd",
+			"pool",
+			"set",
+			d.config["ceph.osd.pool_name"],
+			"size",
+			d.config["ceph.osd.pool_size"],
+			"--yes-i-really-mean-it")
+		if err != nil {
+			return err
+		}
+
 		// Initialize the pool. This is not necessary but allows the pool to be monitored.
 		_, err = shared.TryRunCommand("rbd",
 			"--id", d.config["ceph.user.name"],

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -159,7 +159,7 @@ func (d *ceph) Create() error {
 	if !poolExists {
 		// Create new osd pool.
 		_, err := shared.TryRunCommand("ceph",
-			"--name", fmt.Sprintf("client.%s", d.config["ceph.user.name"]),
+			"--name", "client."+d.config["ceph.user.name"],
 			"--cluster", d.config["ceph.cluster_name"],
 			"osd",
 			"pool",
@@ -218,7 +218,7 @@ func (d *ceph) Create() error {
 
 		// Use existing OSD pool.
 		msg, err := shared.RunCommand("ceph",
-			"--name", fmt.Sprintf("client.%s", d.config["ceph.user.name"]),
+			"--name", "client."+d.config["ceph.user.name"],
 			"--cluster", d.config["ceph.cluster_name"],
 			"osd",
 			"pool",
@@ -398,7 +398,7 @@ func (d *ceph) GetResources() (*api.ResourcesStoragePool, error) {
 
 	err := shared.RunCommandWithFds(context.TODO(), nil, &stdout,
 		"ceph",
-		"--name", fmt.Sprintf("client.%s", d.config["ceph.user.name"]),
+		"--name", "client."+d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
 		"df",
 		"-f", "json")

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -950,16 +950,16 @@ func (d *ceph) parseParent(parent string) (Volume, string, error) {
 // <osd-pool-name>/<lxd-specific-prefix>_<rbd-storage-volume>
 // will be split into
 // <osd-pool-name>, <lxd-specific-prefix>, <rbd-storage-volume>.
-func (d *ceph) parseClone(clone string) (string, string, string, error) {
+func (d *ceph) parseClone(clone string) (poolName string, volumeType string, volumeName string, err error) {
 	idx := strings.Index(clone, "/")
 	if idx == -1 {
 		return "", "", "", fmt.Errorf("Unexpected parsing error")
 	}
 
 	slider := clone[(idx + 1):]
-	poolName := clone[:idx]
+	poolName = clone[:idx]
 
-	volumeType := slider
+	volumeType = slider
 	idx = strings.Index(slider, "zombie_")
 	if idx == 0 {
 		idx += len("zombie_")
@@ -983,7 +983,7 @@ func (d *ceph) parseClone(clone string) (string, string, string, error) {
 		return "", "", "", fmt.Errorf("Unexpected parsing error")
 	}
 
-	volumeName := slider
+	volumeName = slider
 	idx = strings.Index(volumeName, "_")
 	if idx == -1 {
 		return "", "", "", fmt.Errorf("Unexpected parsing error")

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -49,7 +49,7 @@ var cephVolTypePrefixes = map[VolumeType]string{
 func (d *ceph) osdPoolExists() (bool, error) {
 	_, err := shared.RunCommand(
 		"ceph",
-		"--name", fmt.Sprintf("client.%s", d.config["ceph.user.name"]),
+		"--name", "client."+d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
 		"osd",
 		"pool",
@@ -83,7 +83,7 @@ func (d *ceph) osdPoolExists() (bool, error) {
 func (d *ceph) osdDeletePool() error {
 	_, err := shared.RunCommand(
 		"ceph",
-		"--name", fmt.Sprintf("client.%s", d.config["ceph.user.name"]),
+		"--name", "client."+d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
 		"osd",
 		"pool",

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -226,6 +226,20 @@ func (d *cephfs) Create() error {
 						"--yes-i-really-really-mean-it",
 					)
 				})
+
+				_, err = shared.TryRunCommand("ceph",
+					"--name", "client."+d.config["cephfs.user.name"],
+					"--cluster", d.config["cephfs.cluster_name"],
+					"osd",
+					"pool",
+					"set",
+					pool,
+					"size",
+					d.config["cephfs.osd_pool_size"],
+					"--yes-i-really-mean-it")
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -453,6 +453,14 @@ func (d *cephfs) Validate(config map[string]string) error {
 		//  shortdesc: Number of placement groups when creating missing OSD pools
 		//  scope: global
 		"cephfs.osd_pg_num": validate.Optional(validate.IsInt64),
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.osd_pool_size)
+		// This option specifies the number of OSD pool replicas to use
+		// when creating an OSD pool.
+		// ---
+		//  type: string
+		//  defaultdesc: `3`
+		//  shortdesc: Number of RADOS object replicas. Set to 1 for no replication.
+		"cephfs.osd_pool_size": validate.Optional(validate.IsInRange(1, 255)),
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.meta_pool)
 		// This option specifies the name for the file metadata OSD pool that should be used when
 		// creating a file system automatically.

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -1,10 +1,12 @@
 package drivers
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/canonical/lxd/lxd/migration"
@@ -100,6 +102,29 @@ func (d *cephfs) FillConfig() error {
 
 	if d.config["cephfs.user.name"] == "" {
 		d.config["cephfs.user.name"] = CephDefaultUser
+	}
+
+	if d.config["cephfs.osd_pool_size"] == "" {
+		size, err := shared.TryRunCommand("ceph",
+			"--name", "client."+d.config["cephfs.user.name"],
+			"--cluster", d.config["cephfs.cluster_name"],
+			"config",
+			"get",
+			"mon",
+			"osd_pool_default_size",
+			"--format",
+			"json")
+		if err != nil {
+			return err
+		}
+
+		var sizeInt int
+		err = json.Unmarshal([]byte(size), &sizeInt)
+		if err != nil {
+			return err
+		}
+
+		d.config["cephfs.osd_pool_size"] = strconv.Itoa(sizeInt)
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -176,7 +176,7 @@ func (d *cephfs) Create() error {
 			if !osdPoolExists {
 				// Create new osd pool.
 				_, err := shared.RunCommand("ceph",
-					"--name", fmt.Sprintf("client.%s", d.config["cephfs.user.name"]),
+					"--name", "client."+d.config["cephfs.user.name"],
 					"--cluster", d.config["cephfs.cluster_name"],
 					"osd",
 					"pool",
@@ -191,7 +191,7 @@ func (d *cephfs) Create() error {
 				revert.Add(func() {
 					// Delete the OSD pool.
 					_, _ = shared.RunCommand("ceph",
-						"--name", fmt.Sprintf("client.%s", d.config["cephfs.user.name"]),
+						"--name", "client."+d.config["cephfs.user.name"],
 						"--cluster", d.config["cephfs.cluster_name"],
 						"osd",
 						"pool",
@@ -206,7 +206,7 @@ func (d *cephfs) Create() error {
 
 		// Create the filesystem.
 		_, err := shared.RunCommand("ceph",
-			"--name", fmt.Sprintf("client.%s", d.config["cephfs.user.name"]),
+			"--name", "client."+d.config["cephfs.user.name"],
 			"--cluster", d.config["cephfs.cluster_name"],
 			"fs",
 			"new",
@@ -221,7 +221,7 @@ func (d *cephfs) Create() error {
 		revert.Add(func() {
 			// Set the FS to fail so that we can remove it.
 			_, _ = shared.RunCommand("ceph",
-				"--name", fmt.Sprintf("client.%s", d.config["cephfs.user.name"]),
+				"--name", "client."+d.config["cephfs.user.name"],
 				"--cluster", d.config["cephfs.cluster_name"],
 				"fs",
 				"fail",
@@ -230,7 +230,7 @@ func (d *cephfs) Create() error {
 
 			// Delete the FS.
 			_, _ = shared.RunCommand("ceph",
-				"--name", fmt.Sprintf("client.%s", d.config["cephfs.user.name"]),
+				"--name", "client."+d.config["cephfs.user.name"],
 				"--cluster", d.config["cephfs.cluster_name"],
 				"fs",
 				"rm",

--- a/lxd/storage/drivers/driver_cephfs_utils.go
+++ b/lxd/storage/drivers/driver_cephfs_utils.go
@@ -1,14 +1,12 @@
 package drivers
 
 import (
-	"fmt"
-
 	"github.com/canonical/lxd/shared"
 )
 
 // fsExists checks that the Ceph FS instance indeed exists.
 func (d *cephfs) fsExists(clusterName string, userName string, fsName string) (bool, error) {
-	_, err := shared.RunCommand("ceph", "--name", fmt.Sprintf("client.%s", userName), "--cluster", clusterName, "fs", "get", fsName)
+	_, err := shared.RunCommand("ceph", "--name", "client."+userName, "--cluster", clusterName, "fs", "get", fsName)
 	if err != nil {
 		status, _ := shared.ExitStatus(err)
 		// If the error status code is 2, the fs definitely doesn't exist.
@@ -27,7 +25,7 @@ func (d *cephfs) fsExists(clusterName string, userName string, fsName string) (b
 
 // osdPoolExists checks that the Ceph OSD Pool indeed exists.
 func (d *cephfs) osdPoolExists(clusterName string, userName string, osdPoolName string) (bool, error) {
-	_, err := shared.RunCommand("ceph", "--name", fmt.Sprintf("client.%s", userName), "--cluster", clusterName, "osd", "pool", "get", osdPoolName, "size")
+	_, err := shared.RunCommand("ceph", "--name", "client."+userName, "--cluster", clusterName, "osd", "pool", "get", osdPoolName, "size")
 	if err != nil {
 		status, _ := shared.ExitStatus(err)
 		// If the error status code is 2, the pool definitely doesn't exist.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -427,6 +427,7 @@ var APIExtensions = []string{
 	"metadata_configuration_scope",
 	"unix_device_hotplug_ownership_inherit",
 	"unix_device_hotplug_subsystem_device_option",
+	"storage_ceph_osd_pool_size",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/storage_driver_ceph.sh
+++ b/test/suites/storage_driver_ceph.sh
@@ -129,7 +129,7 @@ test_storage_driver_ceph() {
     lxc profile device remove default root
     lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool1"
     lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool2"
-    ceph --cluster "${LXD_CEPH_CLUSTER}" osd pool rm "lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool" "lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool"  --yes-i-really-really-mean-it
+    ! ceph --cluster "${LXD_CEPH_CLUSTER}" osd pool ls | grep -q "lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool" || false
 
 
     # Test that pre-existing OSD pools are not affected by the config option in LXD. Only the associated pool should be affected.


### PR DESCRIPTION
Closes #14006

Adds the keys `ceph.osd.pool_size` and `cephfs.osd_pool_size` (in keeping with the other naming schemes).

By default, if no value is supplied, the pool size will be pulled from the global default pool size. It can be set to any value larger than 0. 

On update, we will try to re-apply the OSD pool size value, if it has changed.